### PR TITLE
FIX bug: exit code in the metadata dan tidy up tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ build-ts:
 # Phase 2: Functional Testing
 test:
 	@echo "Running Semantic Core Verification Suite..."
-	@node test-semantic.mjs || { echo "✗ Semantic testing failed"; exit 1; }
+	@node tests/test-semantic.mjs || { echo "✗ Semantic testing failed"; exit 1; }
 	@echo "✓ Semantic routing logic verified."
 
 # Phase 3: System monitoring

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",
-    "dev": "ts-node-dev --respawn src/index.ts"
+    "dev": "ts-node-dev --respawn src/index.ts",
+    "test": "node tests/test-semantic.mjs",
+    "test:semantic": "node tests/test-semantic.mjs"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -417,16 +417,21 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const args = request.params.arguments as any;
         const opts = args.cwd ? { cwd: args.cwd } : {};
         let resultOutput = "";
+        let exitCode = 0;
         
         try {
           const { stdout, stderr } = await execAsync(args.command, opts);
           resultOutput = String(stdout) + (stderr ? "\nSTDERR:\n" + String(stderr) : "");
         } catch (e: any) {
           resultOutput = String(e.stdout || "") + (e.stderr ? "\nSTDERR:\n" + String(e.stderr) : "") + `\nExit code: ${e.code}`;
+          exitCode = e.code || 1;
         }
         
         const distilled = await distillText(resultOutput);
-        return { content: [{ type: "text", text: distilled }] };
+        return { 
+          content: [{ type: "text", text: distilled }],
+          metadata: { exitCode }
+        };
       }
 
       case "omni_read_file": {
@@ -507,14 +512,23 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             let resultOutput = String(stdout);
             if (!resultOutput.trim()) resultOutput = "No matches found.";
             
-            // Grep output can be huge, definitely distill
             const distilled = await distillText(resultOutput);
-            return { content: [{ type: "text", text: distilled }] };
+            return { 
+              content: [{ type: "text", text: distilled }],
+              metadata: { exitCode: 0 }
+            };
          } catch (e: any) {
              if (e.code === 1) {
-                 return { content: [{ type: "text", text: "No matches found." }] }; // grep exits with 1 if no matches
+                 return { 
+                   content: [{ type: "text", text: "No matches found." }],
+                   metadata: { exitCode: 1 }
+                 };
              }
-             return { content: [{ type: "text", text: `Grep error: ${e.message}` }], isError: true };
+             return { 
+               content: [{ type: "text", text: `Grep error: ${e.message}` }], 
+               isError: true,
+               metadata: { exitCode: e.code || 1 }
+             };
          }
       }
 
@@ -529,9 +543,16 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
              const files = String(stdout).split("\n").filter(Boolean);
              const resultOutput = files.join(", ");
              const distilled = await distillText(resultOutput || "No files found.");
-             return { content: [{ type: "text", text: distilled }] };
+             return { 
+               content: [{ type: "text", text: distilled }],
+               metadata: { exitCode: 0 }
+             };
          } catch (e: any) {
-             return { content: [{ type: "text", text: `Find error: ${e.message}` }], isError: true };
+             return { 
+               content: [{ type: "text", text: `Find error: ${e.message}` }], 
+               isError: true,
+               metadata: { exitCode: e.code || 1 }
+             };
          }
       }
 
@@ -612,14 +633,19 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       case "Bash": {
         const command = (request.params.arguments as any).command;
         let resultOutput = "";
+        let exitCode = 0;
         try {
           const { stdout, stderr } = await execAsync(command);
           resultOutput = String(stdout) + (stderr ? "\nSTDERR:\n" + String(stderr) : "");
         } catch (e: any) {
           resultOutput = String(e.stdout || "") + (e.stderr ? "\nSTDERR:\n" + String(e.stderr) : "") + `\nExit code: ${e.code}`;
+          exitCode = e.code || 1;
         }
         const distilled = await distillText(resultOutput);
-        return { content: [{ type: "text", text: distilled }] };
+        return { 
+          content: [{ type: "text", text: distilled }],
+          metadata: { exitCode }
+        };
       }
 
       case "ReadFile": {
@@ -639,14 +665,19 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const command = args.CommandLine;
         const opts = args.Cwd ? { cwd: args.Cwd } : {};
         let resultOutput = "";
+        let exitCode = 0;
         try {
           const { stdout, stderr } = await execAsync(command, opts);
           resultOutput = String(stdout) + (stderr ? "\nSTDERR:\n" + String(stderr) : "");
         } catch (e: any) {
           resultOutput = String(e.stdout || "") + (e.stderr ? "\nSTDERR:\n" + String(e.stderr) : "") + `\nExit code: ${e.code}`;
+          exitCode = e.code || 1;
         }
         const distilled = await distillText(resultOutput);
-        return { content: [{ type: "text", text: distilled }] };
+        return { 
+          content: [{ type: "text", text: distilled }],
+          metadata: { exitCode }
+        };
       }
 
       case "view_file": {

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,30 @@
+# OMNI Test Suite 🧪
+
+This directory contains the verification and testing tools for OMNI.
+
+## Available Tests
+
+### 1. Semantic Verification Suite (`test-semantic.mjs`)
+Validates that the OMNI engine correctly routes and distills text based on signal density thresholds (HIGH, GREY, NOISE). This test uses the Wasm core via Node.js WASI.
+
+## Running Tests
+
+You can run individual tests or the full suite using the following commands:
+
+### Via npm:
+```bash
+# Run all tests
+npm test
+
+# Run only semantic tests
+npm run test:semantic
+```
+
+### Via Makefile:
+```bash
+# Run official verification suite
+make test
+```
+
+## Future Tests
+New unit tests for specific filter logic (Zig) or MCP server functionality (TypeScript) should be added to this directory.

--- a/tests/test-semantic.mjs
+++ b/tests/test-semantic.mjs
@@ -5,7 +5,7 @@ import { WASI } from 'wasi';
 import { argv, env } from 'process';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const wasmPath = join(__dirname, 'core/zig-out/bin/omni-wasm.wasm');
+const wasmPath = join(__dirname, '../core/zig-out/bin/omni-wasm.wasm');
 const wasmBuffer = fs.readFileSync(wasmPath);
 
 async function runTest() {


### PR DESCRIPTION
## Checklist
* [x] **Build**
  * Version sync `make check-version`, Zig/Wasm build `make build-wasm`, TS build `make build-ts` OK
* [x] **Test**
  * All tests pass `make test` + `omni report` verified 
* [x] **Release Ready**
  * No telemetry, data local, docs updated, `make verify` passed



## PR Auto Describe
This pull request restructures project test infrastructure, adds standard test running workflows, enhances MCP server tool response data, and documents the project's test suite.

1. **Type**: Refactor
   **Description**: Restructured test file layout by relocating the root `test-semantic.mjs` to a new dedicated `tests/` directory, updating all dependent file paths in the Makefile and test script itself to maintain full functionality.
2. **Type**: New Feature
   **Description**: Added standard Node.js npm test scripts (`npm test` and `npm run test:semantic`) to run the semantic verification suite, aligning with common JavaScript project conventions and enabling cross-environment test execution.
3. **Type**: New Feature
   **Description**: Enhanced all command-executing MCP server tools (Bash, grep, find, and generic command execution tools) to return process exit codes in a new `metadata` field, improving error and execution context for tool consumers.
4. **Type**: Documentation
   **Description**: Added a `tests/README.md` file that documents the purpose of the OMNI test suite, lists available test assets, and provides clear instructions for running tests via both npm and Make.