### PR TITLE
feat: Implement hook integrity verification using SHA256 hashes with an `omni_trust` command and automatic startup checks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,10 +263,34 @@ You can manually edit these files to define `rules` (exact matching) or `dsl_fil
 
 OMNI provides a **Trust Boundary** by ensuring that any hook scripts executed through the system remain untampered.
 
-1.  **Add Hooks**: Place your custom scripts in the `~/.omni/hooks/` directory.
-2.  **Verify & Trust**: Use the `omni_trust` MCP tool to manually inspect and approve the scripts. This generates SHA-256 signatures in `~/.omni/hooks.sha256`.
-3.  **Startup Protection**: Every time the OMNI MCP server starts, it re-calculates hashes and compares them to the trusted signatures.
-4.  **Automatic Lockdown**: If any file is modified or an untrusted file is added, OMNI will log a security alert and **immediately exit** to prevent execution of tampered logic.
+### Why use Custom Hooks?
+Hooks are best used when OMNI's built-in filters aren't enough for your specific needs:
+- **AI DevSecOps**: Run a script like `scan-vulnerabilities.sh` that filters 1000 lines of security output into a 5-line summary for the AI.
+- **Infrastructure Polishing**: A script to clean up `terraform plan` or `kubectl` output to show only the "Intent-Critical" changes.
+- **Data Distillation**: Use a Python script to parse large JSON/XML responses from internal APIs and return only the relevant fields.
+
+### Workflow:
+1. **Add Hooks**: Create the directory if it doesn't exist (`mkdir -p ~/.omni/hooks`) and place your custom scripts there.
+2. **Verify & Trust**: Use the `omni_trust` MCP tool to manually inspect and approve the scripts. This generates SHA-256 signatures in `~/.omni/hooks.sha256`.
+3. **Startup Protection**: Every time the OMNI MCP server starts, it re-calculates hashes and compares them to the trusted signatures.
+4. **Automatic Lockdown**: If any file is modified or an untrusted file is added, OMNI will log a security alert and **immediately exit** to prevent execution of tampered logic.
+
+> [!IMPORTANT]
+> **Modifying Hook Scripts?**
+> If you edit the content of your hook scripts, OMNI will block startup due to the fingerprint mismatch. You **must** run the `omni_trust` MCP tool again to re-authorize the updated scripts and generate new SHA-256 signatures.
+
+### Best Practices: Custom Hooks
+To extend OMNI's capabilities safely using your own scripts, follow this workflow:
+
+1.  **Create**: Store your custom script (e.g., `git-summary.sh`) in `~/.omni/hooks/`.
+2.  **Test**: Verify the script works manually in your terminal.
+3.  **Authorize**: Run the `omni_trust` tool to sign the script's current state.
+4.  **Execute**: Your AI Agent can now safely run the script via `omni_execute`:
+    ```json
+    {
+      "command": "~/.omni/hooks/git-summary.sh"
+    }
+    ```
 
 To manually audit your hook integrity, you can run:
 ```bash

--- a/README.md
+++ b/README.md
@@ -259,6 +259,24 @@ You can manually edit these files to define `rules` (exact matching) or `dsl_fil
 
 ---
 
+## Security: Hook Integrity Workflow
+
+OMNI provides a **Trust Boundary** by ensuring that any hook scripts executed through the system remain untampered.
+
+1.  **Add Hooks**: Place your custom scripts in the `~/.omni/hooks/` directory.
+2.  **Verify & Trust**: Use the `omni_trust` MCP tool to manually inspect and approve the scripts. This generates SHA-256 signatures in `~/.omni/hooks.sha256`.
+3.  **Startup Protection**: Every time the OMNI MCP server starts, it re-calculates hashes and compares them to the trusted signatures.
+4.  **Automatic Lockdown**: If any file is modified or an untrusted file is added, OMNI will log a security alert and **immediately exit** to prevent execution of tampered logic.
+
+To manually audit your hook integrity, you can run:
+```bash
+node dist/index.js --test-integrity
+```
+
+[SEE SECURITY.md](SECURITY.md) FOR MORE DETAILS
+
+---
+
 ## Performance Monitoring & Metrics
 
 OMNI is obsessed with efficiency. Use these tools to see how much you're saving:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,8 @@ Security updates are applied to the latest release on the `main` branch.
 
 | Version | Supported          |
 | ------- | ------------------ |
-| v0.3.x  | :white_check_mark: |
+| v0.4.x  | :white_check_mark: |
+| v0.3.x  | :x:                |
 | v0.2.x  | :x:                |
 | v0.1.x  | :x:                |
 
@@ -14,7 +15,7 @@ Security updates are applied to the latest release on the `main` branch.
 
 We take the security of OMNI seriously. If you discover a vulnerability, please do not report it publicly. Instead, follow these steps:
 
-1. **Email us**: Send a detailed report to [security@fajarhide.dev](mailto:security@fajarhide.dev).
+1. **Email us**: Send a detailed report to [security@weekndlabs.com](mailto:security@weekndlabs.com).
 2. **Details**: Include a description of the issue, steps to reproduce, and potential impact.
 3. **Response**: We will acknowledge your report within 48 hours and provide a timeline for a fix.
 
@@ -24,5 +25,39 @@ We take the security of OMNI seriously. If you discover a vulnerability, please 
 - **Local Metrics data**: Usage stats stored in `~/.omni/metrics.csv` contain only aggregate metrics (timestamps, byte counts, latency), never the actual content. **No data ever leaves your machine.**
 - **MCP Server**: The MCP server runs locally via `stdio` transport and does not expose any network ports.
 - **`omni update`**: Only reads the public GitHub Releases API (no authentication required). No data is uploaded.
+- **Hook Integrity Check**: OMNI provides a security mechanism to verify the integrity of hook scripts located in `~/.omni/hooks/`.
+
+### How it Works:
+1. **User Approval**: You manually inspect your scripts and run the `omni_trust` tool.
+2. **Digital Fingerprint**: OMNI records a unique "fingerprint" (SHA-256) for each approved script.
+3. **Auto-Verification**: Every time OMNI starts, it compares the current scripts' fingerprints with the trusted records.
+4. **Lockdown**: If any script is modified without approval or a new suspicious script is detected, OMNI will refuse to start to protect your system.
+
+```mermaid
+sequenceDiagram
+    participant U as User/Admin
+    participant H as Hook Scripts (~/.omni/hooks)
+    participant T as Trust Store (~/.omni/hooks.sha256)
+    participant S as OMNI Server
+
+    Note over U,T: Phase 1: Establish Trust
+    U->>H: Manual Review of Scripts
+    U->>S: Run omni_trust
+    S->>H: Read scripts
+    S->>S: Generate SHA-256 Hashes
+    S->>T: Save trusted fingerprints
+
+    Note over H,S: Phase 2: Runtime Verification (Startup)
+    S->>H: Scan current hooks
+    S->>T: Load trusted fingerprints
+    alt Integrity Match
+        S->>S: Hashes match
+        S-->>U: Server starts normally
+    else Tampering Detected (Scenario 2)
+        H->>H: ⚠️ Malicious Modification
+        S->>S: Hash Mismatch / Unknown File
+        S-->>U: ❌ Security Alert & Shutdown
+    end
+```
 
 Thank you for helping keep OMNI secure!

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,6 +33,9 @@ We take the security of OMNI seriously. If you discover a vulnerability, please 
 3. **Auto-Verification**: Every time OMNI starts, it compares the current scripts' fingerprints with the trusted records.
 4. **Lockdown**: If any script is modified without approval or a new suspicious script is detected, OMNI will refuse to start to protect your system.
 
+> [!IMPORTANT]
+> **Updating Trusted Scripts**: Any modification to a hook script's content changes its SHA-256 hash. If you update your hooks, you must re-run the `omni_trust` tool to update the `hooks.sha256` file with the new fingerprints.
+
 ```mermaid
 sequenceDiagram
     participant U as User/Admin

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -82,6 +82,12 @@ omni generate claude-code
 ### `omni setup`
 An interactive configuration guide that walks you through optimal OMNI usage, setting shell aliases (e.g., alias `npm`="omni -- npm"), and installing MCP plugins.
 
+### `omni_trust` (MCP Tool)
+An MCP instrumented tool to verify and store SHA-256 hashes of hook scripts in `~/.omni/hooks/`. Run this after you manually inspect and approve new or modified hooks.
+
+### `--test-integrity` (Flag)
+A startup flag for the MCP server (`node dist/index.js --test-integrity`) that performs a one-time verification of hook scripts and exits with 0 on success, or 1 on mismatch.
+
 ### `omni update`
 Connects to GitHub releases to fetch binary updates. Replaces your local binary with the requested version.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { fileURLToPath } from "url";
 import { WASI } from "wasi";
 import { LRUCache } from "./cache.js";
 import os from "os";
+import crypto from "crypto";
 
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
@@ -65,6 +66,58 @@ const WASM_PATH = path.join(__dirname, "..", "core", "omni-wasm.wasm");
 const GLOBAL_CONFIG_DIR = path.join(os.homedir(), ".omni");
 const GLOBAL_CONFIG_PATH = path.join(GLOBAL_CONFIG_DIR, "omni_config.json");
 const LOCAL_CONFIG_PATH = path.join(process.cwd(), "omni_config.json");
+
+// Security: Hook Integrity Check
+const HOOKS_DIR = path.join(os.homedir(), ".omni", "hooks");
+const HOOKS_SHA_FILE = path.join(os.homedir(), ".omni", "hooks.sha256");
+
+async function verifyHookIntegrity() {
+  if (!fs.existsSync(HOOKS_SHA_FILE)) return;
+
+  try {
+    const storedHashesRaw = fs.readFileSync(HOOKS_SHA_FILE, "utf-8");
+    const storedHashes: Record<string, string> = JSON.parse(storedHashesRaw);
+    
+    if (!fs.existsSync(HOOKS_DIR)) {
+      if (Object.keys(storedHashes).length > 0) {
+        console.error(`Security Alert: Hooks directory ${HOOKS_DIR} missing but hashes exist.`);
+        process.exit(1);
+      }
+      return;
+    }
+
+    const files = fs.readdirSync(HOOKS_DIR);
+    const currentHashes: Record<string, string> = {};
+
+    for (const file of files) {
+      const filePath = path.join(HOOKS_DIR, file);
+      if (fs.statSync(filePath).isDirectory()) continue;
+      
+      const content = fs.readFileSync(filePath);
+      const hash = crypto.createHash('sha256').update(content).digest('hex');
+      currentHashes[file] = hash;
+    }
+
+    // Check for mismatches or missing files
+    for (const [file, hash] of Object.entries(storedHashes)) {
+      if (currentHashes[file] !== hash) {
+        console.error(`Security Alert: Hook integrity mismatch for file: ${file}`);
+        process.exit(1);
+      }
+    }
+
+    // Check for new untrusted files
+    for (const file of Object.keys(currentHashes)) {
+      if (!storedHashes[file]) {
+        console.error(`Security Alert: New untrusted hook file detected: ${file}`);
+        process.exit(1);
+      }
+    }
+  } catch (e: any) {
+    console.error(`Error verifying hook integrity: ${e.message}`);
+    process.exit(1);
+  }
+}
 
 function getMergedConfig(): any {
   let config: any = { rules: [], dsl_filters: [] };
@@ -398,6 +451,15 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           },
           required: ["AbsolutePath"],
         },
+      },
+      {
+        name: "omni_trust",
+        description: "Verify and store SHA-256 hashes of hook scripts in ~/.omni/hooks. Run this after you manually inspect and approve new or modified hooks.",
+        inputSchema: {
+          type: "object",
+          properties: {},
+          required: [],
+        },
       }
     ],
   };
@@ -701,6 +763,34 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         }
       }
 
+      case "omni_trust": {
+        try {
+          if (!fs.existsSync(HOOKS_DIR)) {
+            return { content: [{ type: "text", text: `No hooks directory found at ${HOOKS_DIR}. Nothing to trust.` }] };
+          }
+
+          const files = fs.readdirSync(HOOKS_DIR);
+          const hashes: Record<string, string> = {};
+
+          for (const file of files) {
+            const filePath = path.join(HOOKS_DIR, file);
+            if (fs.statSync(filePath).isDirectory()) continue;
+            
+            const content = fs.readFileSync(filePath);
+            const hash = crypto.createHash('sha256').update(content).digest('hex');
+            hashes[file] = hash;
+          }
+
+          const dir = path.dirname(HOOKS_SHA_FILE);
+          if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+          
+          fs.writeFileSync(HOOKS_SHA_FILE, JSON.stringify(hashes, null, 2));
+          return { content: [{ type: "text", text: `Successfully trusted ${Object.keys(hashes).length} hooks. Hashes saved to ${HOOKS_SHA_FILE}.` }] };
+        } catch (e: any) {
+          return { content: [{ type: "text", text: `Error updating trusted hashes: ${e.message}` }], isError: true };
+        }
+      }
+
       default:
         throw new Error(`Tool not found: ${request.params.name}`);
     }
@@ -713,6 +803,14 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 });
 
 async function main() {
+  // Check for --test-integrity flag
+  if (process.argv.includes("--test-integrity")) {
+    await verifyHookIntegrity();
+    console.log("Hook integrity check passed.");
+    process.exit(0);
+  }
+
+  await verifyHookIntegrity();
   const transport = new StdioServerTransport();
   await server.connect(transport);
 }

--- a/tests/mcp/integrity.test.js
+++ b/tests/mcp/integrity.test.js
@@ -1,0 +1,69 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { spawnSync } from 'child_process';
+import path from 'path';
+import fs from 'fs';
+import os from 'os';
+import crypto from 'crypto';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const serverPath = path.join(__dirname, '../../dist/index.js');
+const HOOKS_DIR = path.join(os.homedir(), ".omni", "hooks");
+const HOOKS_SHA_FILE = path.join(os.homedir(), ".omni", "hooks.sha256");
+
+test('MCP Server - Hook Integrity Check', async (t) => {
+    // Backup existing hooks if any (unlikely in test env but safe)
+    const backupDir = HOOKS_DIR + ".bak";
+    const backupFile = HOOKS_SHA_FILE + ".bak";
+    if (fs.existsSync(HOOKS_DIR)) fs.renameSync(HOOKS_DIR, backupDir);
+    if (fs.existsSync(HOOKS_SHA_FILE)) fs.renameSync(HOOKS_SHA_FILE, backupFile);
+
+    try {
+        await t.test('Passes with no hooks', () => {
+            const result = spawnSync('node', [serverPath, '--test-integrity']);
+            assert.strictEqual(result.status, 0, 'Should pass when no hooks exist');
+        });
+
+        await t.test('Detects mismatch', () => {
+            if (!fs.existsSync(path.dirname(HOOKS_DIR))) fs.mkdirSync(path.dirname(HOOKS_DIR), { recursive: true });
+            fs.mkdirSync(HOOKS_DIR, { recursive: true });
+            
+            const hookFile = path.join(HOOKS_DIR, 'test.sh');
+            fs.writeFileSync(hookFile, 'echo "secure"');
+            
+            const hashes = { "test.sh": "wrong-hash" };
+            fs.writeFileSync(HOOKS_SHA_FILE, JSON.stringify(hashes));
+
+            const result = spawnSync('node', [serverPath, '--test-integrity']);
+            assert.strictEqual(result.status, 1, 'Should fail on hash mismatch');
+            assert.ok(result.stderr.toString().includes('Security Alert: Hook integrity mismatch'), 'Should log security alert');
+        });
+
+        await t.test('Detects untrusted file', () => {
+            const hookFile = path.join(HOOKS_DIR, 'test.sh');
+            const content = 'echo "secure"';
+            fs.writeFileSync(hookFile, content);
+            const hash = crypto.createHash('sha256').update(content).digest('hex');
+            
+            const hashes = { "test.sh": hash };
+            fs.writeFileSync(HOOKS_SHA_FILE, JSON.stringify(hashes));
+
+            // Add an untrusted file
+            fs.writeFileSync(path.join(HOOKS_DIR, 'untrusted.sh'), 'echo "evil"');
+
+            const result = spawnSync('node', [serverPath, '--test-integrity']);
+            assert.strictEqual(result.status, 1, 'Should fail on untrusted file');
+            assert.ok(result.stderr.toString().includes('Security Alert: New untrusted hook file detected'), 'Should log untrusted file alert');
+        });
+
+    } finally {
+        // Cleanup
+        if (fs.existsSync(HOOKS_DIR)) fs.rmSync(HOOKS_DIR, { recursive: true, force: true });
+        if (fs.existsSync(HOOKS_SHA_FILE)) fs.unlinkSync(HOOKS_SHA_FILE);
+
+        // Restore backups
+        if (fs.existsSync(backupDir)) fs.renameSync(backupDir, HOOKS_DIR);
+        if (fs.existsSync(backupFile)) fs.renameSync(backupFile, HOOKS_SHA_FILE);
+    }
+});


### PR DESCRIPTION
## Checklist
* [x] **Build**
  * Version sync `make check-version`, Zig/Wasm build `make build-wasm`, TS build `make build-ts` OK
* [x] **Test**
  * All tests pass `make test` + `omni monitor` verified 
* [x] **Release Ready**
  * No telemetry, data local, docs updated, `make verify` passed

## Output / Proof
<img width="528" height="540" alt="Screenshot 2026-03-20 at 00 37 42" src="https://github.com/user-attachments/assets/87e96442-68e3-4cae-a123-ec55ff7a3a7b" />

### Test Case
<img width="732" height="393" alt="Screenshot 2026-03-20 at 00 35 22" src="https://github.com/user-attachments/assets/c9cd3fc1-018c-4d11-8065-14409db3d052" />



## PR Auto Describe
This pull request implements a new hook integrity security workflow for the OMNI project, which blocks execution of tampered or untrusted custom hook scripts, alongside version policy updates, documentation expansions, and test coverage for the new security system.

1. **Type**: New Feature
   **Description**: Added core hook integrity security logic to the OMNI server, including automatic SHA-256 hash verification of custom hooks on every startup, the `omni_trust` MCP tool to generate and store trusted hashes for user-inspected scripts, and the `--test-integrity` CLI flag for manual one-off integrity checks. The server exits immediately if tampering or unapproved files are detected.
2. **Type**: Documentation
   **Description**: Added a full "Security: Hook Integrity Workflow" section to README.md, outlining the step-by-step process for adding, trusting, and auditing custom hooks, with a link to expanded details in SECURITY.md.
3. **Type**: Documentation
   **Description**: Updated the CLI reference guide (CLI_REFERENCE.md) to add official documentation for the new `omni_trust` MCP tool and `--test-integrity` server flag.
4. **Type**: Security Update
   **Description**: Updated SECURITY.md to reflect current version support (v0.4.x marked as supported, all older versions unsupported), updated the official vulnerability reporting email to security@weeknd