### PR TITLE
feat: Introduce `node_modules` target for dependency installation and integrate it into `build-ts` and `test` targets.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,11 @@
 # Default target: Verify everything
 all: verify
 
+node_modules: package.json
+	@echo "Installing dependencies (npm install)..."
+	@npm install
+	@touch node_modules
+
 help:
 	@echo "OMNI Command Interface"
 	@echo "----------------------"
@@ -42,7 +47,7 @@ build-wasm:
 		echo "✗ Failed to generate Wasm binary"; exit 1; \
 	fi
 
-build-ts:
+build-ts: node_modules
 	@echo "Building OMNI MCP Server (dist/index.js)..."
 	@npm run build > /dev/null
 	@if [ -f dist/index.js ]; then \
@@ -52,7 +57,7 @@ build-ts:
 	fi
 
 # Phase 2: Functional Testing
-test:
+test: node_modules
 	@echo "Running Filter Unit Tests..."
 	@npm test || { echo "✗ Filter testing failed"; exit 1; }
 	@echo "Running Learning Discovery Tests..."


### PR DESCRIPTION
## Checklist
* [x] **Build**
  * Version sync `make check-version`, Zig/Wasm build `make build-wasm`, TS build `make build-ts` OK
* [x] **Test**
  * All tests pass `make test` + `omni monitor` verified 
* [x] **Release Ready**
  * No telemetry, data local, docs updated, `make verify` passed

## PR Auto Describe
Updates to the project's Makefile to add automatic npm dependency installation, which runs automatically before TypeScript builds and test suites to eliminate manual dependency setup steps for users.

1. **Type**: New Feature
   **Description**: Added a new `node_modules` target that triggers `npm install` to install project dependencies, including a status log and timestamp to track dependency installation state.
2. **Type**: Usability Improvement
   **Description**: Updated the `build-ts` TypeScript build target to add `node_modules` as a prerequisite, ensuring dependencies are always installed before building the project's TypeScript code.
3. **Type**: Usability Improvement
   **Description**: Updated the `test` target to add `node_modules` as a prerequisite, so dependencies are automatically installed prior to running the project's full test suite.