### PR TITLE
feat: implement environment variable sanitization for child processes and introduce project trust for local configurations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,8 @@ OMNI exposes high-density tools that replace standard agent context commands:
 | **`omni_execute`** | Run ANY command and distill its output. | Massive (30-90%) |
 | **`omni_read_file`** | Full file distillation (great for logs/SQL/json). | Massive |
 | **`omni_density`** | Measure gain and reduction metrics. | N/A |
+| **`omni_trust`** | Trust a project's local `omni_config.json` before loading. | N/A |
+| **`omni_trust_hooks`** | Verify SHA-256 hashes of hook scripts. | N/A |
 
 ---
 
@@ -259,32 +261,39 @@ You can manually edit these files to define `rules` (exact matching) or `dsl_fil
 
 ---
 
-## Security: Hook Integrity Workflow
+## Security: Trust Boundary
 
-OMNI provides a **Trust Boundary** by ensuring that any hook scripts executed through the system remain untampered.
+OMNI includes **three layers** of security to protect your AI agent from malicious inputs:
 
-### Why use Custom Hooks?
-Hooks are best used when OMNI's built-in filters aren't enough for your specific needs:
-- **AI DevSecOps**: Run a script like `scan-vulnerabilities.sh` that filters 1000 lines of security output into a 5-line summary for the AI.
-- **Infrastructure Polishing**: A script to clean up `terraform plan` or `kubectl` output to show only the "Intent-Critical" changes.
-- **Data Distillation**: Use a Python script to parse large JSON/XML responses from internal APIs and return only the relevant fields.
+### 1. Project Trust Boundary
+OMNI will **not** load project-local `omni_config.json` until you explicitly trust it. This prevents a cloned repository from injecting malicious filter rules.
 
-### Workflow:
-1. **Add Hooks**: Create the directory if it doesn't exist (`mkdir -p ~/.omni/hooks`) and place your custom scripts there.
-2. **Verify & Trust**: Use the `omni_trust` MCP tool to manually inspect and approve the scripts. This generates SHA-256 signatures in `~/.omni/hooks.sha256`.
-3. **Startup Protection**: Every time the OMNI MCP server starts, it re-calculates hashes and compares them to the trusted signatures.
-4. **Automatic Lockdown**: If any file is modified or an untrusted file is added, OMNI will log a security alert and **immediately exit** to prevent execution of tampered logic.
+**How to use:**
+1. Clone or open a project that has `omni_config.json`.
+2. OMNI will log: `⚠ Local config not trusted. Run omni_trust to review and trust.`
+3. Call the `omni_trust` MCP tool — it shows the config contents and SHA-256 hash.
+4. The project is now trusted. If you later edit the config, run `omni_trust` again.
+
+### 2. Sandbox Environment Denylist
+OMNI automatically strips **50+ dangerous environment variables** (`BASH_ENV`, `NODE_OPTIONS`, `LD_PRELOAD`, `DYLD_INSERT_LIBRARIES`, etc.) from all child processes. No configuration needed — this is always active.
+
+### 3. Hook Integrity Verification
+Custom hook scripts in `~/.omni/hooks/` are protected by SHA-256 fingerprinting.
+
+**How to use:**
+1. **Add Hooks**: Place your custom scripts in `~/.omni/hooks/`.
+2. **Verify & Trust**: Use the `omni_trust_hooks` MCP tool to inspect and approve the scripts. This generates SHA-256 signatures in `~/.omni/hooks.sha256`.
+3. **Startup Protection**: Every time OMNI starts, it re-calculates hashes and compares them to the trusted signatures.
+4. **Automatic Lockdown**: If any file is modified or an untrusted file is added, OMNI will **immediately exit**.
 
 > [!IMPORTANT]
 > **Modifying Hook Scripts?**
-> If you edit the content of your hook scripts, OMNI will block startup due to the fingerprint mismatch. You **must** run the `omni_trust` MCP tool again to re-authorize the updated scripts and generate new SHA-256 signatures.
+> If you edit the content of your hook scripts, OMNI will block startup due to the fingerprint mismatch. You **must** run the `omni_trust_hooks` MCP tool again to re-authorize the updated scripts.
 
 ### Best Practices: Custom Hooks
-To extend OMNI's capabilities safely using your own scripts, follow this workflow:
-
 1.  **Create**: Store your custom script (e.g., `git-summary.sh`) in `~/.omni/hooks/`.
 2.  **Test**: Verify the script works manually in your terminal.
-3.  **Authorize**: Run the `omni_trust` tool to sign the script's current state.
+3.  **Authorize**: Run the `omni_trust_hooks` tool to sign the script's current state.
 4.  **Execute**: Your AI Agent can now safely run the script via `omni_execute`:
     ```json
     {

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,16 +25,134 @@ We take the security of OMNI seriously. If you discover a vulnerability, please 
 - **Local Metrics data**: Usage stats stored in `~/.omni/metrics.csv` contain only aggregate metrics (timestamps, byte counts, latency), never the actual content. **No data ever leaves your machine.**
 - **MCP Server**: The MCP server runs locally via `stdio` transport and does not expose any network ports.
 - **`omni update`**: Only reads the public GitHub Releases API (no authentication required). No data is uploaded.
-- **Hook Integrity Check**: OMNI provides a security mechanism to verify the integrity of hook scripts located in `~/.omni/hooks/`.
+
+---
+
+## 1. Project Trust Boundary
+
+OMNI will **not** load project-local `omni_config.json` files until you explicitly trust them. This prevents a malicious repository from injecting custom filter rules that could hide important output from your AI agent.
+
+### How it Works
+
+```
+ Your Project/
+ ├── omni_config.json   ← OMNI sees this but WON'T load it
+ └── ...
+
+ ~/.omni/
+ └── trusted-projects.json  ← Trust registry (path + SHA-256 hash)
+```
+
+1. OMNI detects `omni_config.json` in the project directory.
+2. It checks `~/.omni/trusted-projects.json` for the project path **and** a matching SHA-256 hash.
+3. If not found or hash doesn't match → **config is skipped**, OMNI logs a warning.
+4. If trusted and hash matches → config is loaded normally.
+
+### Quick Start
+
+**Trust a project for the first time:**
+```
+Call the `omni_trust` MCP tool (or ask your AI agent to run it).
+```
+
+The tool will:
+- Display the full config contents for your review
+- Show the SHA-256 fingerprint
+- Add the project to `~/.omni/trusted-projects.json`
+
+**After editing your local config:**
+```
+Run `omni_trust` again to re-verify and update the hash.
+```
+
+> [!IMPORTANT]
+> If you modify `omni_config.json` after trusting, OMNI will **stop loading it** until you re-trust. This protects against silent config tampering.
+
+### What Happens When Config is Untrusted?
+
+| Scenario | OMNI Behavior |
+| :--- | :--- |
+| No local config exists | Global config only (normal) |
+| Local config exists, **not trusted** | Skipped. Logs: `⚠ Local config not trusted. Run omni_trust to review and trust.` |
+| Local config exists, **trusted** | Loaded and merged with global config |
+| Local config **modified** after trust | Skipped. Logs: `⚠ Local config modified since last trust. Run omni_trust to re-verify.` |
+
+### Trust Flow Diagram
+
+```mermaid
+sequenceDiagram
+    participant U as User/Agent
+    participant O as OMNI Server
+    participant C as omni_config.json
+    participant T as trusted-projects.json
+
+    Note over U,T: Scenario A: First Use (Untrusted)
+    O->>C: Detects local config
+    O->>T: Check trusted-projects.json
+    T-->>O: ❌ Not found
+    O-->>U: ⚠ "Local config not trusted"
+
+    Note over U,T: Scenario B: Trust the Project
+    U->>O: Call omni_trust
+    O->>C: Read config, compute SHA-256
+    O-->>U: Show contents + hash for review
+    O->>T: Save {path, hash, timestamp}
+    O-->>U: ✅ "Project trusted"
+
+    Note over U,T: Scenario C: Normal Startup (Trusted)
+    O->>C: Detects local config
+    O->>T: Check trusted-projects.json
+    T-->>O: ✅ Found + hash matches
+    O->>O: Load and merge config
+```
+
+---
+
+## 2. Sandbox Environment Denylist
+
+OMNI **strips 50+ dangerous environment variables** from all child processes it spawns. This prevents environment-based attacks where malicious env vars could hijack command execution.
+
+### Why This Matters
+
+Some environment variables can inject code into any process that reads them:
+
+| Variable | Risk |
+| :--- | :--- |
+| `BASH_ENV` | Shell runs this file **before** executing any command |
+| `NODE_OPTIONS` | Injects flags/code into every Node.js process |
+| `LD_PRELOAD` | Loads a shared library into **every** process (Linux) |
+| `DYLD_INSERT_LIBRARIES` | Same as `LD_PRELOAD` (macOS) |
+| `PYTHONSTARTUP` | Python executes this file on startup |
+| `JAVA_TOOL_OPTIONS` | Injects JVM arguments into every Java process |
+
+### What OMNI Blocks
+
+All child processes spawned by OMNI tools (`omni_execute`, `Bash`, `run_command`, `omni_grep_search`, `omni_find_by_name`) receive a **sanitized** copy of `process.env` with these categories removed:
+
+- **Shell injection**: `BASH_ENV`, `ENV`, `ZDOTDIR`, `BASH_PROFILE`, `PROMPT_COMMAND`, `IFS`, etc.
+- **Runtime hijacking**: `NODE_OPTIONS`, `PYTHONSTARTUP`, `RUBYOPT`, `PERL5OPT`, `JAVA_TOOL_OPTIONS`
+- **Dynamic linker**: `LD_PRELOAD`, `LD_LIBRARY_PATH`, `DYLD_INSERT_LIBRARIES`, `DYLD_FRAMEWORK_PATH`
+- **Path manipulation**: `PYTHONPATH`, `RUBYLIB`, `GEM_PATH`, `NODE_PATH`, `CLASSPATH`
+- **Proxy/TLS hijacking**: `HTTP_PROXY`, `HTTPS_PROXY`, `SSL_CERT_FILE`, `CURL_CA_BUNDLE`
+- **Git injection**: `GIT_ASKPASS`, `GIT_SSH_COMMAND`, `GIT_CONFIG_GLOBAL`
+
+> [!NOTE]
+> This is transparent — you don't need to configure anything. OMNI automatically sanitizes the environment for every command it runs.
+
+---
+
+## 3. Hook Integrity Check
+
+OMNI provides a security mechanism to verify the integrity of custom hook scripts located in `~/.omni/hooks/`.
 
 ### How it Works:
-1. **User Approval**: You manually inspect your scripts and run the `omni_trust` tool.
+1. **User Approval**: You manually inspect your scripts and run the `omni_trust_hooks` tool.
 2. **Digital Fingerprint**: OMNI records a unique "fingerprint" (SHA-256) for each approved script.
 3. **Auto-Verification**: Every time OMNI starts, it compares the current scripts' fingerprints with the trusted records.
 4. **Lockdown**: If any script is modified without approval or a new suspicious script is detected, OMNI will refuse to start to protect your system.
 
 > [!IMPORTANT]
-> **Updating Trusted Scripts**: Any modification to a hook script's content changes its SHA-256 hash. If you update your hooks, you must re-run the `omni_trust` tool to update the `hooks.sha256` file with the new fingerprints.
+> **Updating Trusted Scripts**: Any modification to a hook script's content changes its SHA-256 hash. If you update your hooks, you must re-run the `omni_trust_hooks` tool to update the `hooks.sha256` file with the new fingerprints.
 
 ```mermaid
 sequenceDiagram
@@ -45,7 +163,7 @@ sequenceDiagram
 
     Note over U,T: Phase 1: Establish Trust
     U->>H: Manual Review of Scripts
-    U->>S: Run omni_trust
+    U->>S: Run omni_trust_hooks
     S->>H: Read scripts
     S->>S: Generate SHA-256 Hashes
     S->>T: Save trusted fingerprints
@@ -62,5 +180,17 @@ sequenceDiagram
         S-->>U: ❌ Security Alert & Shutdown
     end
 ```
+
+---
+
+## Security Tools Summary
+
+| Tool | Purpose | When to Use |
+| :--- | :--- | :--- |
+| `omni_trust` | Trust a project's local `omni_config.json` | After cloning a repo with config, or after editing config |
+| `omni_trust_hooks` | Trust hook scripts in `~/.omni/hooks/` | After adding or modifying hook scripts |
+| `--test-integrity` | One-time hook integrity check (CLI flag) | CI/CD pipelines or manual audit |
+
+---
 
 Thank you for helping keep OMNI secure!

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -83,7 +83,10 @@ omni generate claude-code
 An interactive configuration guide that walks you through optimal OMNI usage, setting shell aliases (e.g., alias `npm`="omni -- npm"), and installing MCP plugins.
 
 ### `omni_trust` (MCP Tool)
-An MCP instrumented tool to verify and store SHA-256 hashes of hook scripts in `~/.omni/hooks/`. Run this after you manually inspect and approve new or modified hooks.
+An MCP tool to review and trust a project's local `omni_config.json`. OMNI will not load project-local configs until explicitly trusted. The tool displays the config contents and SHA-256 hash, then registers the project in `~/.omni/trusted-projects.json`. Re-run after modifying the local config for changes to take effect.
+
+### `omni_trust_hooks` (MCP Tool)
+An MCP tool to verify and store SHA-256 hashes of hook scripts in `~/.omni/hooks/`. Run this after you manually inspect and approve new or modified hooks.
 
 ### `--test-integrity` (Flag)
 A startup flag for the MCP server (`node dist/index.js --test-integrity`) that performs a one-time verification of hook scripts and exits with 0 on success, or 1 on mismatch.

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,49 @@ import crypto from "crypto";
 
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
+
+// Sandbox Env Denylist: block dangerous env vars from child processes
+const ENV_DENYLIST = new Set([
+  // Shell injection vectors
+  'BASH_ENV', 'ENV', 'ZDOTDIR', 'BASH_PROFILE', 'BASH_LOGIN',
+  'BASH_LOGOUT', 'PROFILE', 'INPUTRC', 'HISTFILE',
+  // Node.js
+  'NODE_OPTIONS', 'NODE_EXTRA_CA_CERTS', 'NODE_PATH',
+  'NODE_REDIRECT_WARNINGS', 'NODE_REPL_HISTORY',
+  // Python
+  'PYTHONSTARTUP', 'PYTHONPATH', 'PYTHONHOME', 'PYTHONWARNINGS',
+  'PYTHONDONTWRITEBYTECODE', 'PYTHONHASHSEED',
+  // Ruby
+  'RUBYOPT', 'RUBYLIB', 'GEM_PATH', 'GEM_HOME', 'BUNDLE_GEMFILE',
+  // Perl
+  'PERL5OPT', 'PERL5LIB', 'PERLLIB',
+  // Java
+  'JAVA_TOOL_OPTIONS', '_JAVA_OPTIONS', 'JDK_JAVA_OPTIONS',
+  'JAVA_HOME', 'CLASSPATH',
+  // Dynamic linker hijacking (Linux)
+  'LD_PRELOAD', 'LD_LIBRARY_PATH', 'LD_AUDIT',
+  'LD_PROFILE', 'LD_SHOW_AUXV', 'LD_DEBUG',
+  // Dynamic linker hijacking (macOS)
+  'DYLD_INSERT_LIBRARIES', 'DYLD_FORCE_FLAT_NAMESPACE',
+  'DYLD_LIBRARY_PATH', 'DYLD_FRAMEWORK_PATH', 'DYLD_FALLBACK_LIBRARY_PATH',
+  // Curl / HTTP
+  'CURL_CA_BUNDLE', 'SSL_CERT_FILE', 'SSL_CERT_DIR',
+  'REQUESTS_CA_BUNDLE', 'HTTP_PROXY', 'HTTPS_PROXY', 'ALL_PROXY',
+  'NO_PROXY', 'http_proxy', 'https_proxy',
+  // Git
+  'GIT_EXEC_PATH', 'GIT_TEMPLATE_DIR', 'GIT_CONFIG_GLOBAL',
+  'GIT_ASKPASS', 'GIT_SSH_COMMAND',
+  // Misc
+  'EDITOR', 'VISUAL', 'BROWSER', 'PAGER',
+  'PROMPT_COMMAND', 'PS1', 'PS2', 'PS4',
+  'IFS', 'CDPATH', 'GLOBIGNORE', 'MAIL', 'MAILPATH',
+]);
+
+function sanitizeEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const clean = { ...env };
+  for (const key of ENV_DENYLIST) delete clean[key];
+  return clean;
+}
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // Parse Agent Argument (--agent=claude-code)
@@ -72,6 +115,58 @@ const LOCAL_CONFIG_PATH = path.join(process.cwd(), "omni_config.json");
 // Security: Hook Integrity Check
 const HOOKS_DIR = path.join(os.homedir(), ".omni", "hooks");
 const HOOKS_SHA_FILE = path.join(os.homedir(), ".omni", "hooks.sha256");
+
+// Security: Project Trust Boundary
+const TRUSTED_PROJECTS_PATH = path.join(os.homedir(), ".omni", "trusted-projects.json");
+
+interface TrustedProject {
+  path: string;
+  configHash: string;
+  trustedAt: string;
+}
+
+function loadTrustedProjects(): TrustedProject[] {
+  try {
+    if (fs.existsSync(TRUSTED_PROJECTS_PATH)) {
+      return JSON.parse(fs.readFileSync(TRUSTED_PROJECTS_PATH, "utf-8"));
+    }
+  } catch (e) {
+    console.error("Error reading trusted-projects.json:", e);
+  }
+  return [];
+}
+
+function saveTrustedProjects(projects: TrustedProject[]): void {
+  const dir = path.dirname(TRUSTED_PROJECTS_PATH);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(TRUSTED_PROJECTS_PATH, JSON.stringify(projects, null, 2));
+}
+
+function hashFileContent(filePath: string): string {
+  const content = fs.readFileSync(filePath);
+  return crypto.createHash('sha256').update(content).digest('hex');
+}
+
+function isProjectTrusted(projectPath: string): { trusted: boolean; reason?: string } {
+  const configPath = path.join(projectPath, "omni_config.json");
+  if (!fs.existsSync(configPath)) return { trusted: false, reason: "no_config" };
+
+  const projects = loadTrustedProjects();
+  const normalizedPath = path.resolve(projectPath);
+  const entry = projects.find(p => path.resolve(p.path) === normalizedPath);
+
+  if (!entry) {
+    return { trusted: false, reason: "not_trusted" };
+  }
+
+  // Verify config hasn't been tampered with since trust was granted
+  const currentHash = hashFileContent(configPath);
+  if (currentHash !== entry.configHash) {
+    return { trusted: false, reason: "config_modified" };
+  }
+
+  return { trusted: true };
+}
 
 async function verifyHookIntegrity() {
   if (!fs.existsSync(HOOKS_SHA_FILE)) return;
@@ -136,16 +231,25 @@ function getMergedConfig(): any {
     }
   }
 
-  // 2. Merge Local Config (Overrides/Augments)
+  // 2. Merge Local Config (requires explicit trust)
   if (fs.existsSync(LOCAL_CONFIG_PATH)) {
-    try {
-      const localRaw = fs.readFileSync(LOCAL_CONFIG_PATH, "utf-8");
-      const localConfig = JSON.parse(localRaw);
-      // For now, just append rules/filters. Specific name-matching overrides can be added later.
-      if (localConfig.rules) config.rules.push(...localConfig.rules);
-      if (localConfig.dsl_filters) config.dsl_filters.push(...localConfig.dsl_filters);
-    } catch (e) {
-      console.error("Error parsing local config:", e);
+    const trustCheck = isProjectTrusted(process.cwd());
+    if (!trustCheck.trusted) {
+      const reasons: Record<string, string> = {
+        not_trusted: "Local config not trusted. Run omni_trust to review and trust.",
+        config_modified: "Local config modified since last trust. Run omni_trust to re-verify.",
+        no_config: "No local config found."
+      };
+      console.error(`⚠ ${reasons[trustCheck.reason || "not_trusted"]} Skipping local config.`);
+    } else {
+      try {
+        const localRaw = fs.readFileSync(LOCAL_CONFIG_PATH, "utf-8");
+        const localConfig = JSON.parse(localRaw);
+        if (localConfig.rules) config.rules.push(...localConfig.rules);
+        if (localConfig.dsl_filters) config.dsl_filters.push(...localConfig.dsl_filters);
+      } catch (e) {
+        console.error("Error parsing local config:", e);
+      }
     }
   }
 
@@ -500,11 +604,22 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         },
       },
       {
-        name: "omni_trust",
+        name: "omni_trust_hooks",
         description: "Verify and store SHA-256 hashes of hook scripts in ~/.omni/hooks. Run this after you manually inspect and approve new or modified hooks.",
         inputSchema: {
           type: "object",
           properties: {},
+          required: [],
+        },
+      },
+      {
+        name: "omni_trust",
+        description: "Review and trust a project's local omni_config.json. OMNI will not load local configs until explicitly trusted. Shows config contents and SHA-256 hash before trusting. Re-run after modifying the config.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            projectPath: { type: "string", description: "Path to the project directory (defaults to current working directory)" }
+          },
           required: [],
         },
       },
@@ -536,7 +651,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
       case "omni_execute": {
         const args = request.params.arguments as any;
-        const opts = args.cwd ? { cwd: args.cwd } : {};
+        const opts: any = { env: sanitizeEnv(process.env) };
+        if (args.cwd) opts.cwd = args.cwd;
         let resultOutput = "";
         let exitCode = 0;
         
@@ -629,7 +745,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
          if (isRegex) flags.push("-E");
 
          try {
-            const { stdout, stderr } = await execFileAsync('grep', [...flags, query, targetPath]);
+            const { stdout, stderr } = await execFileAsync('grep', [...flags, query, targetPath], { env: sanitizeEnv(process.env) });
             let resultOutput = String(stdout);
             if (!resultOutput.trim()) resultOutput = "No matches found.";
             
@@ -660,7 +776,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
          
          try {
              // Basic find command
-             const { stdout } = await execFileAsync('find', [dir, '-name', pattern]);
+             const { stdout } = await execFileAsync('find', [dir, '-name', pattern], { env: sanitizeEnv(process.env) });
              const files = String(stdout).split("\n").filter(Boolean);
              const resultOutput = files.join(", ");
              const distilled = await distillText(resultOutput || "No files found.");
@@ -756,7 +872,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         let resultOutput = "";
         let exitCode = 0;
         try {
-          const { stdout, stderr } = await execAsync(command);
+          const { stdout, stderr } = await execAsync(command, { env: sanitizeEnv(process.env) });
           resultOutput = String(stdout) + (stderr ? "\nSTDERR:\n" + String(stderr) : "");
         } catch (e: any) {
           resultOutput = String(e.stdout || "") + (e.stderr ? "\nSTDERR:\n" + String(e.stderr) : "") + `\nExit code: ${e.code}`;
@@ -784,7 +900,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       case "run_command": {
         const args = request.params.arguments as any;
         const command = args.CommandLine;
-        const opts = args.Cwd ? { cwd: args.Cwd } : {};
+        const opts: any = { env: sanitizeEnv(process.env) };
+        if (args.Cwd) opts.cwd = args.Cwd;
         let resultOutput = "";
         let exitCode = 0;
         try {
@@ -822,7 +939,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         }
       }
 
-      case "omni_trust": {
+      case "omni_trust_hooks": {
         try {
           if (!fs.existsSync(HOOKS_DIR)) {
             return { content: [{ type: "text", text: `No hooks directory found at ${HOOKS_DIR}. Nothing to trust.` }] };
@@ -847,6 +964,65 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           return { content: [{ type: "text", text: `Successfully trusted ${Object.keys(hashes).length} hooks. Hashes saved to ${HOOKS_SHA_FILE}.` }] };
         } catch (e: any) {
           return { content: [{ type: "text", text: `Error updating trusted hashes: ${e.message}` }], isError: true };
+        }
+      }
+
+      case "omni_trust": {
+        const args = request.params.arguments as any;
+        const projectDir = path.resolve(args.projectPath || process.cwd());
+        const configPath = path.join(projectDir, "omni_config.json");
+
+        try {
+          if (!fs.existsSync(configPath)) {
+            return { content: [{ type: "text", text: `No omni_config.json found in ${projectDir}. Nothing to trust.` }] };
+          }
+
+          // Read and display the config for review
+          const rawConfig = fs.readFileSync(configPath, "utf-8");
+          const configHash = hashFileContent(configPath);
+          let parsedConfig: any;
+          try {
+            parsedConfig = JSON.parse(rawConfig);
+          } catch {
+            return { content: [{ type: "text", text: `Error: ${configPath} is not valid JSON.` }], isError: true };
+          }
+
+          const ruleCount = (parsedConfig.rules?.length || 0) + (parsedConfig.dsl_filters?.length || 0);
+
+          // Check existing trust status
+          const projects = loadTrustedProjects();
+          const existingIdx = projects.findIndex(p => path.resolve(p.path) === projectDir);
+          const wasAlreadyTrusted = existingIdx !== -1;
+
+          // Update or add trust entry
+          const entry: TrustedProject = {
+            path: projectDir,
+            configHash,
+            trustedAt: new Date().toISOString()
+          };
+
+          if (existingIdx !== -1) {
+            projects[existingIdx] = entry;
+          } else {
+            projects.push(entry);
+          }
+
+          saveTrustedProjects(projects);
+
+          // Force Wasm engine reload to pick up newly trusted config
+          wasmInstance = null;
+
+          const status = wasAlreadyTrusted ? "🔄 Re-trusted" : "✅ Trusted";
+          const report =
+            `${status} project: ${projectDir}\n` +
+            `Config: ${configPath}\n` +
+            `SHA-256: ${configHash}\n` +
+            `Rules: ${ruleCount} (${parsedConfig.rules?.length || 0} rules, ${parsedConfig.dsl_filters?.length || 0} DSL filters)\n` +
+            `\n--- Config Contents ---\n${JSON.stringify(parsedConfig, null, 2)}`;
+
+          return { content: [{ type: "text", text: report }] };
+        } catch (e: any) {
+          return { content: [{ type: "text", text: `Error trusting project: ${e.message}` }], isError: true };
         }
       }
 


### PR DESCRIPTION
## Checklist
* [x] **Build**
  * Version sync `make check-version`, Zig/Wasm build `make build-wasm`, TS build `make build-ts` OK
* [x] **Test**
  * All tests pass `make test` + `omni monitor` verified 
* [x] **Release Ready**
  * No telemetry, data local, docs updated, `make verify` passed

## Output / Proof

### Trust Flow 

<img width="615" height="582" alt="Screenshot 2026-03-20 at 13 47 25" src="https://github.com/user-attachments/assets/bbf9b5f0-770d-4c96-9c65-6036cafea2fc" />



## PR Auto Describe
This PR delivers a major 3-layer security upgrade for OMNI, adding protections against malicious config and code injection, splitting the legacy trust tool into two dedicated tools, and updating all core documentation and source code to support the new security model.

1. **Type**: New Feature
   **Description**: Added Project Trust Boundary, which blocks loading untrusted local `omni_config.json` files until users explicitly approve them via the new `omni_trust` MCP tool, which stores verified SHA-256 hashes of trusted configs in a central trust registry.
2. **Type**: New Feature
   **Description**: Implemented a sandbox environment denylist that automatically strips 50+ dangerous environment variables (including `LD_PRELOAD`, `NODE_OPTIONS`, `BASH_ENV`) from all child processes spawned by OMNI to block code injection attacks.
3. **Type**: New Feature
   **Description**: Added config tamper detection that disables loading of a project's local config if it is modified after being trusted, requiring users to re-run `omni_trust` to re-approve the updated file.
4. **Type**: Refactor
   **Description**: Split the legacy single `omni_trust` hook verification tool into two dedicated tools: `omni_trust` (for project config management) and `omni_trust_hooks` (for maintaining SHA-256 integrity