### PR TITLE
Fix setup mcp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,6 +1010,7 @@ dependencies = [
  "regex",
  "rmcp",
  "rusqlite",
+ "rust-embed",
  "serde",
  "serde_json",
  "sha2",
@@ -1263,6 +1264,40 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
+]
+
+[[package]]
+name = "rust-embed"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
+dependencies = [
+ "sha2",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ is-terminal = "0.4"
 # Misc
 tempfile = "3"
 ureq = { version = "2", features = ["json"] }
+rust-embed = "8"
 
 [dev-dependencies]
 insta = "1"  # snapshot testing

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ $ omni stats
 | `omni init --hook` | Setup Claude Code hooks |
 | `omni stats` | Token savings analytics |
 | `omni session` | Session state inspection |
-| `omni learn` | Auto-generate filters from passthrough |
+| `omni learn` | Auto-generate filters from noise | [docs/LEARN.md](docs/LEARN.md) |
 | `omni doctor` | Diagnose installation |
 | `omni version` | Print version |
 | `omni help` | Show help |

--- a/docs/FILTERS.md
+++ b/docs/FILTERS.md
@@ -2,15 +2,19 @@
 
 OMNI supports user-defined TOML filters for distilling output from any command — including internal company tools, custom deploy scripts, and CI pipelines.
 
-## Filter Location
-
 | Directory | Priority | Description |
 |---|---|---|
-| Built-in (compiled) | Lowest | Ships with OMNI |
-| `~/.omni/filters/` | Medium | User-global filters |
-| `.omni/filters/` | Highest | Project-local (requires `omni trust`) |
+| **Built-in (embedded)** | Lowest | Compiled into the OMNI binary |
+| **User** (`~/.omni/filters/`) | Medium | Personal/User-global filters |
+| **Project** (`.omni/filters/`) | Highest | Project-specific (requires `omni trust`) |
 
-Project-local filters override user filters which override built-in filters.
+### Hierarchy Logic
+1. **Project-local filters** override User filters.
+2. **User filters** override Built-in filters.
+3. **Built-in filters** are the fallback for standard commands.
+
+> [!NOTE]
+> **Built-in** filters are not visible in the filesystem because they are compiled into the binary (`embedded`). If you want to modify them, create a file with the same name in `~/.omni/filters/` to override their behavior.
 
 ## Basic Structure
 
@@ -274,11 +278,40 @@ omni learn --dry-run < output.log
 omni learn --apply < output.log
 ```
 
+## Project-local Filters (.omni/filters/)
+
+This filter level is extremely useful for teams or repositories that have specific internal tooling. By placing filters inside the project folder, you ensure that the entire team (and their AI agents) gets consistent signal distillation.
+
+### Usage Guide (Step-by-Step)
+
+1. **Create Directory**: In your project root, create the `.omni/filters/` directory.
+   ```bash
+   mkdir -p .omni/filters
+   ```
+
+2. **Add Filter**: Create a TOML file, for example `.omni/filters/setup-backend.toml`.
+   ```toml
+   schema_version = 1
+   [filters.setup-backend]
+   match_command = "^./scripts/setup-db"
+   strip_lines_matching = ["^Connecting", "^Checking versions"]
+   on_empty = "db: setup complete"
+   ```
+
+3. **Verify & Trust**: Run `omni doctor`. You will see the status **[WARNING] NOT TRUSTED**. Run the following command to enable it:
+   ```bash
+   omni trust
+   ```
+
+### Benefits of Project Filters
+- **Checked into Git**: These filters can be added to the repository (`git add .omni/filters`), ensuring anyone who clones the repo immediately gets the same token savings.
+- **Custom Signalling**: Perfect for internal scripts that produce noisy output but only contain small bits of information relevant to the AI.
+
 ## Trust for Project Filters
 
-Project-local filters (`.omni/filters/`) are not loaded until trusted:
+Project-local filters (`.omni/filters/`) will not be loaded until you explicitly "trust" the project. This is a security feature to prevent malicious filters from untrusted repositories.
 
 ```bash
-omni trust    # Review and trust current project's filters
-omni doctor   # Shows trust status
+omni trust    # Review and approve filters in the current project
+omni doctor   # Check trust status and number of loaded filters
 ```

--- a/docs/LEARN.md
+++ b/docs/LEARN.md
@@ -1,0 +1,54 @@
+# OMNI Learn — Automatic Pattern Discovery
+
+OMNI can automatically generate TOML filters by analyzing repetitive noise in your terminal output. This is the fastest way to shrink your token usage without writing regex manually.
+
+## How it works
+
+The `omni learn` engine uses a "Word Prefix Frequency" algorithm:
+1. It splits incoming text into lines.
+2. It extracts the **first 3 words** of every line as a signature.
+3. If a signature appears **3 or more times**, OMNI identifies it as a "Repetitive Noise Candidate".
+4. It then generates a TOML filter that can either **Strip** (remove the line) or **Count** (replace with a summary count).
+
+## 1. Passive Background Learning
+
+Whenever OMNI runs as a hook (e.g., inside Claude Code), it silently monitors for patterns. If it finds noise that isn't already covered by a filter, it records it in a local queue:
+
+`~/.omni/learn_queue.jsonl`
+
+You can process this queue at any time:
+```bash
+omni learn --from-queue --dry-run
+```
+
+## 2. Manual Learning (Pipe Mode)
+
+If you have a log file or a command output that is very noisy, you can pipe it directly into OMNI to generate a filter:
+
+```bash
+cat build.log | omni learn --dry-run
+```
+
+## 3. Applying Learned Filters
+
+Once you are happy with the dry-run output, apply it:
+
+```bash
+cat build.log | omni learn --apply
+```
+
+This will:
+- Create (or append to) `~/.omni/filters/learned.toml`.
+- Assign a unique ID to the filter (e.g., `learned_1711234567`).
+- Include **inline tests** based on the actual log data to ensure the filter works as expected.
+
+## Best Practices
+
+- **Validate First**: Always use `--dry-run` before `--apply`.
+- **Review `learned.toml`**: Since it's a standard TOML file, you can manually edit descriptions or refine regex patterns later.
+- **Run Diagnostics**: After applying, run `omni doctor` to ensure the new filters are loaded correctly.
+- **Verify Tests**: Run `omni learn --verify` to execute all inline tests in your filter library.
+
+---
+> [!TIP]
+> OMNI Learn is designed to be conservative. It only suggests filters for patterns it is very confident in.

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -101,27 +101,35 @@ pub fn run() -> anyhow::Result<()> {
         path => {
             if path.exists() {
                 if let Ok(content) = fs::read_to_string(&path) {
-                    if content.contains("omni --hook --post-tool") {
-                        println!("   PostToolUse:  [OK] installed");
-                    } else {
-                        println!("   PostToolUse:  [WARNING] missing");
-                        warnings.push("PostToolUse hook is not installed. Run `omni init`.");
-                        all_ok = false;
-                    }
+                    if content.contains("--hook") {
+                        if content.contains("PostToolUse") {
+                            println!("   PostToolUse:  [OK] installed");
+                        } else {
+                            println!("   PostToolUse:  [WARNING] missing");
+                            warnings.push("PostToolUse hook is not installed. Run `omni init`.");
+                            all_ok = false;
+                        }
 
-                    if content.contains("omni --hook --session-start") {
-                        println!("   SessionStart: [OK] installed");
-                    } else {
-                        println!("   SessionStart: [WARNING] missing");
-                        warnings.push("SessionStart hook is not installed.");
-                        all_ok = false;
-                    }
+                        if content.contains("SessionStart") {
+                            println!("   SessionStart: [OK] installed");
+                        } else {
+                            println!("   SessionStart: [WARNING] missing");
+                            warnings.push("SessionStart hook is not installed.");
+                            all_ok = false;
+                        }
 
-                    if content.contains("omni --hook --pre-compact") {
-                        println!("   PreCompact:   [OK] installed");
+                        if content.contains("PreCompact") {
+                            println!("   PreCompact:   [OK] installed");
+                        } else {
+                            println!("   PreCompact:   [WARNING] missing");
+                            warnings.push("PreCompact hook is not installed.");
+                            all_ok = false;
+                        }
                     } else {
-                        println!("   PreCompact:   [WARNING] missing");
-                        warnings.push("PreCompact hook is not installed.");
+                        println!(
+                            "   Hooks:        [WARNING] omni --hook not found in settings.json"
+                        );
+                        warnings.push("OMNI hooks are not configured. Run `omni init`.");
                         all_ok = false;
                     }
                 }
@@ -161,34 +169,36 @@ pub fn run() -> anyhow::Result<()> {
 
     // 6. Config Filters
     println!(" Filters:");
-    let all_filters = crate::pipeline::toml_filter::load_all_filters();
-    let mut built_in = 0;
-    let mut user: usize = 0;
-    let _local = 0;
+    let (built_in, user_filters, local_filters) =
+        crate::pipeline::toml_filter::get_filters_by_source();
 
-    for f in &all_filters {
-        if f.name.starts_with("sys_") {
-            built_in += 1;
-        } else {
-            user += 1;
-        } // Simplify: assume all non sys_ are user/local
-    }
-
-    println!("   Built-in:    {} filters loaded", built_in);
+    println!(
+        "   Built-in:    {} filters loaded (embedded)",
+        built_in.len()
+    );
 
     let user_dir = conf_dir.join("filters");
     if user_dir.exists() {
-        println!("   User:        ~/.omni/filters/ ({} filters)", user);
+        println!(
+            "   User:        ~/.omni/filters/ ({} filters)",
+            user_filters.len()
+        );
     } else {
-        println!("   User:        ~/.omni/filters/ (missing) [WARNING]");
+        println!("   User:        ~/.omni/filters/ (none)");
     }
 
     let project_dir = PathBuf::from(".omni/filters");
     if project_dir.exists() {
         if crate::guard::trust::is_trusted(std::env::current_dir().unwrap_or_default().as_path()) {
-            println!("   Project:     .omni/filters/ (TRUSTED) [OK]");
+            println!(
+                "   Project:     .omni/filters/ ({} filters, TRUSTED) [OK]",
+                local_filters.len()
+            );
         } else {
-            println!("   Project:     .omni/filters/ (NOT TRUSTED — run: omni trust) [WARNING]");
+            println!(
+                "   Project:     .omni/filters/ ({} filters, NOT TRUSTED — run: omni trust) [WARNING]",
+                local_filters.len()
+            );
             warnings.push("Project filters found but not trusted.");
             all_ok = false;
         }

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -3,6 +3,12 @@ use std::env;
 use std::fs;
 use std::path::PathBuf;
 
+pub fn get_claude_json_path() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".claude.json")
+}
+
 pub fn get_settings_path() -> PathBuf {
     dirs::home_dir()
         .unwrap_or_else(|| PathBuf::from("."))
@@ -37,6 +43,7 @@ fn backup_settings(path: &PathBuf) -> anyhow::Result<PathBuf> {
 
 pub fn run_init(args: &[String]) -> anyhow::Result<()> {
     let is_hook = args.iter().any(|a| a == "--hook");
+    let is_mcp = args.iter().any(|a| a == "--mcp");
     let is_status = args.iter().any(|a| a == "--status");
     let is_uninstall = args.iter().any(|a| a == "--uninstall");
 
@@ -68,28 +75,43 @@ pub fn run_init(args: &[String]) -> anyhow::Result<()> {
 
         remove_omni_hooks(&mut val);
 
+        // Also remove MCP from .claude.json
+        let mcp_path = get_claude_json_path();
+        if mcp_path.exists()
+            && let Ok(content) = fs::read_to_string(&mcp_path)
+            && let Ok(mut mcp_val) = serde_json::from_str::<Value>(&content)
+        {
+            if let Some(obj) = mcp_val.as_object_mut()
+                && let Some(servers) = obj.get_mut("mcpServers").and_then(|v| v.as_object_mut())
+            {
+                servers.remove("omni");
+            }
+            let _ = fs::write(&mcp_path, serde_json::to_string_pretty(&mcp_val)?);
+        }
+
         let new_content = serde_json::to_string_pretty(&val)?;
         fs::write(&path, new_content)?;
-        println!("✓ OMNI hooks uninstalled from settings.json");
+        println!("✓ OMNI hooks and MCP server uninstalled");
         return Ok(());
     }
 
-    if is_hook {
+    if is_hook || is_mcp {
         let (path, mut val) = initialize_settings()?;
-        let backup_path = backup_settings(&path)?;
+        let _ = backup_settings(&path);
 
-        install_omni_hooks(&mut val, &exe_path);
+        if is_hook {
+            install_omni_hooks(&mut val, &exe_path);
+            let new_content = serde_json::to_string_pretty(&val)?;
+            fs::write(&path, new_content)?;
+            println!("✓ OMNI hooks installed in Claude settings");
+        }
 
-        let new_content = serde_json::to_string_pretty(&val)?;
-        fs::write(&path, new_content)?;
+        if is_mcp {
+            install_mcp_server(&exe_path)?;
+            println!("✓ OMNI MCP server registered in .claude.json");
+        }
 
-        println!("✓ OMNI hooks installed");
-        println!("      PostToolUse (Bash) → distil output transparently");
-        println!("      SessionStart       → inject session context");
-        println!("      PreCompact         → snapshot before compaction\n");
-        println!("   Binary: {}", exe_path);
-        println!("   Config: {}", path.display());
-        println!("   Backup: {}\n", backup_path.display());
+        println!("\n   Binary: {}", exe_path);
         println!("   Restart Claude Code to activate.");
     }
 
@@ -195,6 +217,59 @@ pub fn remove_omni_hooks(val: &mut Value) {
             }
         }
     }
+}
+
+pub fn install_mcp_server(exe_path: &str) -> anyhow::Result<()> {
+    let path = get_claude_json_path();
+    let mut val = if path.exists() {
+        let content = fs::read_to_string(&path)?;
+        serde_json::from_str(&content).unwrap_or_else(|_| json!({}))
+    } else {
+        json!({})
+    };
+
+    let obj = val
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("Invalid .claude.json format"))?;
+
+    // 1. Ensure top-level mcpServers exists
+    let servers = obj
+        .entry("mcpServers")
+        .or_insert_with(|| json!({}))
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("mcpServers is not an object"))?;
+
+    // 2. Add/Update OMNI
+    servers.insert(
+        "omni".to_string(),
+        json!({
+            "type": "stdio",
+            "command": exe_path,
+            "args": ["--mcp"]
+        }),
+    );
+
+    // 3. Also update any project entries that might have an old OMNI reference
+    if let Some(projects) = obj.get_mut("projects").and_then(|p| p.as_object_mut()) {
+        for (_path, p_val) in projects.iter_mut() {
+            if let Some(ps) = p_val.get_mut("mcpServers").and_then(|s| s.as_object_mut())
+                && ps.contains_key("omni")
+            {
+                ps.insert(
+                    "omni".to_string(),
+                    serde_json::json!({
+                        "command": "omni",
+                        "args": ["--mcp"],
+                        "env": {}
+                    }),
+                );
+            }
+        }
+    }
+
+    let new_content = serde_json::to_string_pretty(&val)?;
+    fs::write(&path, new_content)?;
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/cli/learn.rs
+++ b/src/cli/learn.rs
@@ -1,5 +1,6 @@
-use crate::session::learn::{apply_to_config, detect_patterns, generate_toml};
+use crate::session::learn::{apply_to_config, detect_patterns};
 use anyhow::Result;
+use chrono::Utc;
 use std::fs;
 use std::io::{self, Read};
 use std::path::PathBuf;
@@ -69,9 +70,10 @@ pub fn run_learn(args: &[String]) -> Result<()> {
         );
     }
 
-    let generated = generate_toml(&candidates, "auto_learned");
+    let filter_name = format!("learned_{}", Utc::now().timestamp());
 
     if dry_run {
+        let generated = crate::session::learn::generate_toml(&candidates, &filter_name);
         println!("\n[Dry Run] Generated TOML configuration:\n{}", generated);
     } else if apply {
         let path = dirs::home_dir()
@@ -79,7 +81,7 @@ pub fn run_learn(args: &[String]) -> Result<()> {
             .join(".omni")
             .join("filters")
             .join("learned.toml");
-        apply_to_config(&candidates, "auto_learned", &path)?;
+        apply_to_config(&candidates, &filter_name, &path)?;
         println!(
             "\nSuccessfully appended {} triggers to {:?}",
             candidates.len(),

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -71,43 +71,36 @@ pub fn run_session(args: &[String], store: Arc<Store>) -> anyhow::Result<()> {
     }
 
     if is_inject {
-        let task = state
-            .inferred_task
-            .as_deref()
-            .unwrap_or("general development");
+        let task = state.inferred_task.as_deref().unwrap_or("none");
+
+        let mut hot_vec: Vec<(&String, &u32)> = state.hot_files.iter().collect();
+        hot_vec.sort_by(|a, b| b.1.cmp(a.1));
+        let hot_str = if hot_vec.is_empty() {
+            "none".to_string()
+        } else {
+            hot_vec
+                .iter()
+                .take(2)
+                .map(|(f, _)| f.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+
         let err = state
             .active_errors
             .first()
-            .map(|e| e.as_str())
-            .unwrap_or("none");
-        let mut hot_vec: Vec<(&String, &u32)> = state.hot_files.iter().collect();
-        hot_vec.sort_by(|a, b| b.1.cmp(a.1));
+            .map(|e| e.replace('\n', " "))
+            .unwrap_or_else(|| "none".to_string());
 
-        let hot_str = hot_vec
-            .iter()
-            .take(2)
-            .map(|(k, v)| format!("{} ({}x)", k, v))
-            .collect::<Vec<_>>()
-            .join(", ");
-
-        // Format yang bisa langsung di-inject ke Claude
-        let mut ctx = format!("[OMNI Context] Task: {}.", task);
-        if !hot_str.is_empty() {
-            ctx.push_str(&format!(" Hot: {}.", hot_str));
+        let mut msg = format!(
+            "[OMNI Context] Task: {}. Hot: {}. Error: {}",
+            task, hot_str, err
+        );
+        if msg.len() > 200 {
+            msg.truncate(197);
+            msg.push_str("...");
         }
-        if err != "none" {
-            let err_clean = err.replace('\n', " ");
-            ctx.push_str(&format!(
-                " Error: {}",
-                &err_clean[..err_clean.len().min(80)]
-            ));
-        }
-        // Trim ke max 200 chars
-        if ctx.len() > 200 {
-            ctx.truncate(197);
-            ctx.push_str("...");
-        }
-        println!("{}", ctx);
+        println!("{}", msg);
         return Ok(());
     }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -167,76 +167,65 @@ impl OmniServer {
         match action.as_str() {
             "status" => {
                 let s = self.session.lock().unwrap();
-                let task = s.inferred_task.as_deref().unwrap_or("not detected");
-                let domain = s.inferred_domain.as_deref().unwrap_or("not detected");
+                let task = s.inferred_task.as_deref().unwrap_or("none");
+                let domain = s.inferred_domain.as_deref().unwrap_or("none");
 
-                // Hot files: top 3 dengan count
-                let mut hot: Vec<_> = s.hot_files.iter().collect();
-                hot.sort_by(|a, b| b.1.cmp(a.1));
-                let hot_str = hot
-                    .iter()
-                    .take(3)
-                    .map(|(f, c)| format!("{} ({}x)", f, c))
-                    .collect::<Vec<_>>()
-                    .join(", ");
+                let mut hot_vec: Vec<(&String, &u32)> = s.hot_files.iter().collect();
+                hot_vec.sort_by(|a, b| b.1.cmp(a.1));
+                let hot_str = if hot_vec.is_empty() {
+                    "none".to_string()
+                } else {
+                    hot_vec
+                        .iter()
+                        .take(3)
+                        .map(|(f, c)| format!("{} ({}x)", f, c))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                };
 
-                // Last error
-                let last_err = s
+                let err = s
                     .active_errors
                     .first()
-                    .map(|e| &e[..e.len().min(100)])
-                    .unwrap_or("none");
+                    .map(|e| e.replace('\n', " "))
+                    .unwrap_or_else(|| "none".to_string());
 
                 format!(
-                    "OMNI Session: {}\n\
-                     Commands run: {}\n\
-                     Inferred task: {}\n\
-                     Inferred domain: {}\n\
-                     Hot files: {}\n\
-                     Last error: {}",
-                    &s.session_id[..s.session_id.len().min(12)],
-                    s.command_count,
-                    task,
-                    domain,
-                    if hot_str.is_empty() {
-                        "none yet"
-                    } else {
-                        &hot_str
-                    },
-                    last_err
+                    "OMNI Session: {}\nCommands: {}\nTask: {}\nDomain: {}\nHot Files: {}\nLast Error: {}",
+                    s.session_id, s.command_count, task, domain, hot_str, err
                 )
             }
             "context" => {
                 let s = self.session.lock().unwrap();
-                let task = s.inferred_task.as_deref().unwrap_or("general development");
+                let task = s.inferred_task.as_deref().unwrap_or("none");
+
+                let mut hot_vec: Vec<(&String, &u32)> = s.hot_files.iter().collect();
+                hot_vec.sort_by(|a, b| b.1.cmp(a.1));
+                let hot_str = if hot_vec.is_empty() {
+                    "none".to_string()
+                } else {
+                    hot_vec
+                        .iter()
+                        .take(2)
+                        .map(|(f, _)| f.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                };
+
                 let err = s
                     .active_errors
                     .first()
-                    .map(|e| e.as_str())
-                    .unwrap_or("none");
-                let mut hot: Vec<_> = s.hot_files.iter().collect();
-                hot.sort_by(|a, b| b.1.cmp(a.1));
-                let hot_str = hot
-                    .iter()
-                    .take(2)
-                    .map(|(f, c)| format!("{} ({}x)", f, c))
-                    .collect::<Vec<_>>()
-                    .join(", ");
+                    .map(|e| e.replace('\n', " "))
+                    .unwrap_or_else(|| "none".to_string());
 
-                // Format yang bisa langsung di-inject ke Claude
-                let mut ctx = format!("[OMNI Context] Task: {}.", task);
-                if !hot_str.is_empty() {
-                    ctx.push_str(&format!(" Hot: {}.", hot_str));
+                let mut msg = format!(
+                    "[OMNI Context] Task: {}. Hot: {}. Error: {}",
+                    task, hot_str, err
+                );
+                if msg.len() > 200 {
+                    msg.truncate(197);
+                    msg.push_str("...");
                 }
-                if err != "none" {
-                    ctx.push_str(&format!(" Error: {}", &err[..err.len().min(80)]));
-                }
-                // Trim ke max 200 chars
-                if ctx.len() > 200 {
-                    ctx.truncate(197);
-                    ctx.push_str("...");
-                }
-                ctx
+                msg
             }
             "clear" => {
                 {
@@ -245,7 +234,7 @@ impl OmniServer {
                 }
                 "Session state cleared.".to_string()
             }
-            _ => "Unknown action defined for bindings.".to_string(),
+            _ => "Unknown action. Use status, context, or clear.".to_string(),
         }
     }
 }

--- a/src/pipeline/toml_filter.rs
+++ b/src/pipeline/toml_filter.rs
@@ -1,9 +1,14 @@
 use anyhow::{Context, Result};
 use regex::Regex;
+use rust_embed::RustEmbed;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+
+#[derive(RustEmbed)]
+#[folder = "filters/"]
+struct Asset;
 
 #[derive(Debug, Deserialize)]
 struct TomlDocument {
@@ -304,6 +309,95 @@ pub fn load_from_dir(dir: &Path) -> Vec<TomlFilter> {
     all_filters
 }
 
+pub fn load_embedded_filters() -> Vec<TomlFilter> {
+    let mut all_filters = Vec::new();
+    for file in Asset::iter() {
+        if file.ends_with(".toml")
+            && let Some(content) = Asset::get(&file)
+        {
+            let s = String::from_utf8_lossy(&content.data);
+            match toml::from_str::<TomlDocument>(&s) {
+                Ok(doc) => {
+                    if let Some(filters) = doc.filters {
+                        let mut tests_map = doc.tests.unwrap_or_default();
+                        for (name, config) in filters {
+                            // Add sys_ prefix to built-in filters
+                            let sys_name = format!("sys_{}", name);
+                            if let Ok(filter) =
+                                create_filter_from_config(sys_name, config, &mut tests_map)
+                            {
+                                all_filters.push(filter);
+                            }
+                        }
+                    }
+                }
+                Err(e) => eprintln!("[omni] failed to parse embedded filter {}: {}", file, e),
+            }
+        }
+    }
+    all_filters
+}
+
+fn create_filter_from_config(
+    name: String,
+    config: FilterConfig,
+    tests_map: &mut HashMap<String, Vec<TestConfig>>,
+) -> Result<TomlFilter> {
+    let match_regex = Regex::new(&config.match_command)?;
+    let mut replace_rules = Vec::new();
+    for rr in config.replace_rules {
+        replace_rules.push((Regex::new(&rr.pattern)?, rr.replacement));
+    }
+
+    let mut match_output = Vec::new();
+    for mo in config.match_output {
+        let pattern = Regex::new(&mo.pattern)?;
+        let unless = match mo.unless {
+            Some(u) => Some(Regex::new(&u)?),
+            None => None,
+        };
+        match_output.push(MatchOutputRule {
+            pattern,
+            message: mo.message,
+            unless,
+        });
+    }
+
+    let line_filter = if let Some(strips) = config.strip_lines_matching {
+        let mut rules = Vec::new();
+        for s in strips {
+            rules.push(Regex::new(&s)?);
+        }
+        LineFilter::Strip(rules)
+    } else if let Some(keeps) = config.keep_lines_matching {
+        let mut rules = Vec::new();
+        for k in keeps {
+            rules.push(Regex::new(&k)?);
+        }
+        LineFilter::Keep(rules)
+    } else {
+        LineFilter::None
+    };
+
+    let inline_tests = tests_map
+        .remove(&name.replace("sys_", ""))
+        .unwrap_or_default();
+
+    Ok(TomlFilter {
+        name,
+        description: config.description,
+        match_regex,
+        strip_ansi: config.strip_ansi,
+        replace_rules,
+        match_output,
+        line_filter,
+        max_lines: config.max_lines,
+        on_empty: config.on_empty,
+        confidence: config.confidence,
+        inline_tests,
+    })
+}
+
 pub fn run_inline_tests(filters: &[TomlFilter]) -> TestReport {
     let mut passes = 0;
     let mut failures = Vec::new();
@@ -327,16 +421,21 @@ pub fn run_inline_tests(filters: &[TomlFilter]) -> TestReport {
 
 pub fn load_all_filters() -> Vec<TomlFilter> {
     let mut all = Vec::new();
+    let mut seen = std::collections::HashSet::new();
 
     // 1. .omni/filters/*.toml (project-local, if trusted)
     if let Ok(cwd) = std::env::current_dir() {
-        let omni_config_path = cwd.join("omni_config.json");
-        // We evaluate project trust over omni_config.json conceptually
-        // since `trust.rs` specifically hashes `omni_config.json`.
-        // Alternatively, if the project is trusted, we load its filters directory.
-        if crate::guard::trust::is_trusted(&omni_config_path) {
-            let local_filters_dir = cwd.join(".omni").join("filters");
-            all.append(&mut load_from_dir(&local_filters_dir));
+        let local_filters_dir = cwd.join(".omni").join("filters");
+        if local_filters_dir.exists() {
+            let config_path = cwd.join("omni_config.json");
+            if crate::guard::trust::is_trusted(&config_path) {
+                for f in load_from_dir(&local_filters_dir) {
+                    if !seen.contains(&f.name) {
+                        seen.insert(f.name.clone());
+                        all.push(f);
+                    }
+                }
+            }
         }
     }
 
@@ -344,28 +443,68 @@ pub fn load_all_filters() -> Vec<TomlFilter> {
     if let Some(mut home) = dirs::home_dir() {
         home.push(".omni");
         home.push("filters");
-        all.append(&mut load_from_dir(&home));
-    }
-
-    // 3. Built-in filters (for now loaded straight from standard `filters/` dir relative to project,
-    // though in production we might `include_str!` or `include_dir!`. We use `filters/` path dynamically).
-    if let Ok(cwd) = std::env::current_dir() {
-        let default_filters = cwd.join("filters");
-        all.append(&mut load_from_dir(&default_filters));
-    }
-
-    // Remove duplicates based on name, honoring priority order (first loaded wins)
-    let mut unique = Vec::new();
-    let mut seen = std::collections::HashSet::new();
-
-    for filter in all {
-        if !seen.contains(&filter.name) {
-            seen.insert(filter.name.clone());
-            unique.push(filter);
+        for f in load_from_dir(&home) {
+            if !seen.contains(&f.name) {
+                seen.insert(f.name.clone());
+                all.push(f);
+            }
         }
     }
 
-    unique
+    // 3. Built-in filters (embedded)
+    for f in load_embedded_filters() {
+        if !seen.contains(&f.name) {
+            seen.insert(f.name.clone());
+            all.push(f);
+        }
+    }
+
+    all
+}
+
+pub fn get_filters_by_source() -> (Vec<TomlFilter>, Vec<TomlFilter>, Vec<TomlFilter>) {
+    let mut built_in = Vec::new();
+    let mut user = Vec::new();
+    let mut local = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+
+    // 1. Local
+    if let Ok(cwd) = std::env::current_dir() {
+        let local_filters_dir = cwd.join(".omni").join("filters");
+        if local_filters_dir.exists() {
+            let config_path = cwd.join("omni_config.json");
+            if crate::guard::trust::is_trusted(&config_path) {
+                for f in load_from_dir(&local_filters_dir) {
+                    if !seen.contains(&f.name) {
+                        seen.insert(f.name.clone());
+                        local.push(f);
+                    }
+                }
+            }
+        }
+    }
+
+    // 2. User
+    if let Some(mut home) = dirs::home_dir() {
+        home.push(".omni");
+        home.push("filters");
+        for f in load_from_dir(&home) {
+            if !seen.contains(&f.name) {
+                seen.insert(f.name.clone());
+                user.push(f);
+            }
+        }
+    }
+
+    // 3. Built-in
+    for f in load_embedded_filters() {
+        if !seen.contains(&f.name) {
+            seen.insert(f.name.clone());
+            built_in.push(f);
+        }
+    }
+
+    (built_in, user, local)
 }
 
 #[cfg(test)]

--- a/src/session/learn.rs
+++ b/src/session/learn.rs
@@ -207,7 +207,7 @@ mod tests {
             suggested_action: LearnAction::Strip,
         }];
         let toml = generate_toml(&c, "gen_test");
-        assert!(toml.contains("schema_version = 1"));
+        // schema_version is now handled by apply_to_config, not generation
         assert!(toml.contains("[filters.gen_test]"));
         assert!(toml.contains("\"^Test Prefix Gen\""));
     }

--- a/src/session/learn.rs
+++ b/src/session/learn.rs
@@ -76,7 +76,7 @@ pub fn detect_patterns(input: &str) -> Vec<PatternCandidate> {
 }
 
 pub fn generate_toml(candidates: &[PatternCandidate], filter_name: &str) -> String {
-    let mut toml = format!("schema_version = 1\n\n[filters.{}]\n", filter_name);
+    let mut toml = format!("\n[filters.{}]\n", filter_name);
     toml.push_str("description = \"Auto-learned filter\"\n");
     toml.push_str(&format!("match_command = \"{}.*\"\n", filter_name));
     toml.push_str("strip_ansi = true\n");
@@ -84,7 +84,7 @@ pub fn generate_toml(candidates: &[PatternCandidate], filter_name: &str) -> Stri
 
     let mut strips = Vec::new();
     let mut tests = format!(
-        "\n[[tests.{}]\nname = \"auto_learned_strip\"\n",
+        "\n[[tests.{}]]\nname = \"auto_learned_strip\"\n",
         filter_name
     );
     let mut sample_lines = String::new();
@@ -136,15 +136,15 @@ pub fn apply_to_config(
 
     let generated = generate_toml(candidates, filter_name);
 
-    if config_path.exists() {
-        let mut file = OpenOptions::new().append(true).open(config_path)?;
-        writeln!(file, "\n{}", generated)?;
-    } else {
+    if !config_path.exists() {
         if let Some(p) = config_path.parent() {
             fs::create_dir_all(p)?;
         }
-        fs::write(config_path, generated)?;
+        fs::write(config_path, "schema_version = 1\n")?;
     }
+
+    let mut file = OpenOptions::new().append(true).open(config_path)?;
+    file.write_all(generated.as_bytes())?;
 
     Ok(candidates.len())
 }


### PR DESCRIPTION
## Pull Request

### Checklist

* [x] `cargo fmt` — code is formatted
* [x] `cargo clippy -- -D warnings` — no lint warnings
* [x] `cargo test` — all tests pass (147+)
* [x] `cargo insta review` — all snapshots approved
* [ ] New functionality has tests 

### Type of Change

- [x] Bug fix
- [x] New feature
- [x] Documentation
- [ ] Refactoring
- [ ] Performance improvement

### Description / Screenshot / Proof



## PR Auto Describe
This PR adds embedded built-in filter support, MCP server integration for Claude Code, expands the `omni learn` auto-filter generator, improves OMNI's CLI diagnostics and filter documentation, and standardizes session context logic across all commands.

1. **Type**: New Feature
   **Description**: Added embedded built-in filter support via the `rust-embed` crate, compiling default filters directly into the OMNI binary instead of loading them from the filesystem. Filters follow the priority hierarchy (project-local > user-global > built-in) to prevent lower-priority filters from overriding higher ones.
2. **Type**: New Feature
   **Description**: Added MCP server support for Claude Code, including a new `--mcp` flag for `omni init` to register the OMNI MCP server, MCP uninstall logic, and updated MCP session output to align with CLI formatting standards.
3. **Type**: New Feature
   **Description**: Expanded the `omni learn` auto-filter generator, added a full dedicated `docs/LEARN.md` documentation file, updated the command to generate unique timestamped filter IDs, and fixed logic to avoid corrupting existing user filter configs when appending new learned filters. Updated the README to link to the new docs and correct the feature's description.
4. **Type**: Documentation
   **Description**: Overhauled `docs/FILTERS.md` to explain the new embedded filter hierarchy,