### PR TITLE
feat: Add confirmation prompt to `omni reset`, enhance `omni doctor` with comprehensive hook and MCP server checks, and update `omni init` instructions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.3] - 2026-03-25
+
+### Added
+- `omni update` command: Easily upgrade OMNI to the latest version via Homebrew with a confirmation prompt.
+- Automated Version Check: OMNI now checks for updates from GitHub (24h cached) and notifies you in `help` and `doctor` screens.
+- Safety Confirmations: Added `[y/N]` interactive prompts to `omni reset` and `omni update` to prevent accidental uninstalls or upgrades.
+- Full Hook Diagnostics: `omni doctor` now explicitly checks and displays status for all 4 OMNI hooks, including `PreToolUse`.
+
+### Fixed
+- Hook Cleanup: `omni reset` and `omni init --uninstall` now correctly remove `PreToolUse` (Bash) hooks from Claude settings.
+- Hook Detection: Fixed `omni doctor` logic to correctly identify OMNI hooks using any valid flag variant.
+- Clippy Compliance: Resolved `collapsible-if` and other minor lints in the new update module.
+
+### Improved
+- CLI Diagnostics: Refined `omni doctor` output with clearer labels ("OMNI Hooks", "OMNI MCP Server") for better readability.
+
 ## [0.5.2] - 2026-03-25
 
 ### Added

--- a/omni.rb
+++ b/omni.rb
@@ -33,9 +33,9 @@ class Omni < Formula
   def caveats
     <<~EOS
       Quick start:
-        omni init          # Initialize OMNI setup
-        omni doctor        # Verify installation
-        omni stats         # View token savings
+        omni init --all        # Initialize OMNI setup
+        omni doctor            # Verify installation
+        omni stats             # View token savings
 
       OMNI works automatically — no configuration needed.
       Hooks intercept Claude Code tool outputs and distill them in real-time.

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -21,6 +21,10 @@ fn print_help() {
     println!("  • MCP server registration");
     println!("  • Filter trust and loading status");
     println!();
+
+    if let Some(latest) = crate::guard::update::check() {
+        crate::guard::update::print_notification(&latest);
+    }
 }
 
 fn format_time_ago(ts: u64) -> String {
@@ -169,11 +173,16 @@ pub fn run(args: &[String]) -> anyhow::Result<()> {
     }
 
     // 4. Hook entries in ~/.claude/settings.json
-    println!("\n {}", "Hooks (Claude Code):".bold().bright_white());
+    println!("\n {}", "OMNI Hooks:".bold().bright_white());
     let path = get_settings_path();
     if path.exists() {
         if let Ok(content) = fs::read_to_string(&path) {
-            if content.contains("--hook") {
+            if content.contains("--hook")
+                || content.contains("--post-hook")
+                || content.contains("--pre-hook")
+                || content.contains("--session-start")
+                || content.contains("--pre-compact")
+            {
                 let fmt_hook = |name: &str, tag: &str| {
                     if content.contains(tag) {
                         println!(
@@ -192,6 +201,9 @@ pub fn run(args: &[String]) -> anyhow::Result<()> {
                     }
                 };
 
+                if !fmt_hook("PreToolUse", "PreToolUse") {
+                    all_ok = false;
+                }
                 if !fmt_hook("PostToolUse", "PostToolUse") {
                     all_ok = false;
                     warnings.push("PostToolUse hook is not installed. Run `omni init`.");
@@ -206,7 +218,7 @@ pub fn run(args: &[String]) -> anyhow::Result<()> {
                 println!(
                     "   {:<15} {}",
                     "Hooks:".bright_black(),
-                    "[WARNING] omni not found".yellow()
+                    "[WARNING] no hooks found".yellow().bold()
                 );
                 warnings.push("OMNI hooks are not configured. Run `omni init`.");
                 all_ok = false;
@@ -221,9 +233,9 @@ pub fn run(args: &[String]) -> anyhow::Result<()> {
         warnings.push("Claude settings not found. Have you installed Claude Code?");
         all_ok = false;
     }
-    println!();
 
     // 5. MCP Server registration
+    println!("\n {}", "OMNI MCP Server:".bold().bright_white());
     let mcp_path = dirs::home_dir()
         .unwrap_or_else(|| PathBuf::from("."))
         .join("Library/Application Support/Claude/claude_desktop_config.json");
@@ -251,7 +263,7 @@ pub fn run(args: &[String]) -> anyhow::Result<()> {
         println!(
             "   {:<15} {}",
             "Registered:".bright_black(),
-            "[WARNING] not found".yellow().bold()
+            "[WARNING] no MCP server found".yellow().bold()
         );
         warnings.push("MCP Server is not configured. Run `omni init`.");
         all_ok = false;
@@ -299,6 +311,10 @@ pub fn run(args: &[String]) -> anyhow::Result<()> {
         }
     } else {
         println!("   {:<15} none", "Project:".bright_black());
+    }
+
+    if let Some(latest) = crate::guard::update::check() {
+        crate::guard::update::print_notification(&latest);
     }
 
     // Status Footer

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -332,6 +332,7 @@ pub fn remove_omni_hooks(val: &mut Value) {
                                 c.contains("omni")
                                     && (c.contains("--hook")
                                         || c.contains("--post-hook")
+                                        || c.contains("--pre-hook")
                                         || c.contains("--session-start")
                                         || c.contains("--pre-compact"))
                             })

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -6,3 +6,4 @@ pub mod reset;
 pub mod rewrite;
 pub mod session;
 pub mod stats;
+pub mod update;

--- a/src/cli/reset.rs
+++ b/src/cli/reset.rs
@@ -9,7 +9,7 @@ fn print_help() {
         "reset".bold().yellow()
     );
     println!("\n{}", "USAGE:".bold().bright_white());
-    println!("  omni {}", "reset".cyan());
+    println!("  omni {} [--yes]", "reset".cyan());
 
     println!("\n{}", "DESCRIPTION:".bold().bright_white());
     println!("  Performs a clean uninstall of OMNI by:");
@@ -26,6 +26,27 @@ pub fn run(args: &[String]) -> Result<(), String> {
     {
         print_help();
         return Ok(());
+    }
+
+    if args.iter().any(|a| a == "--yes" || a == "-y") {
+        // Skip prompt
+    } else {
+        use std::io::{self, Write};
+        print!(
+            "{} Are you sure you want to uninstall OMNI? [y/N]: ",
+            "⚠".yellow().bold()
+        );
+        io::stdout().flush().unwrap();
+
+        let mut input = String::new();
+        if io::stdin().read_line(&mut input).is_err() {
+            return Err("Failed to read input".to_string());
+        }
+        let input = input.trim().to_lowercase();
+        if input != "y" && input != "yes" {
+            println!("Reset aborted.");
+            return Ok(());
+        }
     }
 
     let home_dir = dirs::home_dir().ok_or("Could not determine home directory")?;

--- a/src/cli/update.rs
+++ b/src/cli/update.rs
@@ -1,0 +1,89 @@
+use colored::*;
+use std::io::{self, Write};
+use std::process::Command;
+
+pub fn print_help() {
+    println!(
+        "\n{} {} — Upgrade OMNI to latest version",
+        "omni".bold().cyan(),
+        "update".bold().yellow()
+    );
+    println!("\n{}", "USAGE:".bold().bright_white());
+    println!("  omni {}", "update".cyan());
+
+    println!("\n{}", "DESCRIPTION:".bold().bright_white());
+    println!("  Fetches the latest version from GitHub and upgrades OMNI.");
+    println!("  Currently supports Homebrew-based installations.");
+    println!();
+}
+
+pub fn run(args: &[String]) -> Result<(), String> {
+    if args
+        .iter()
+        .any(|a| a == "--help" || a == "-h" || a == "help")
+    {
+        print_help();
+        return Ok(());
+    }
+
+    let latest = crate::guard::update::check();
+
+    if let Some(latest_ver) = latest {
+        println!(
+            "\n{} A new version is available: {} → {}",
+            "✨".yellow(),
+            env!("CARGO_PKG_VERSION").bright_black(),
+            latest_ver.green().bold()
+        );
+
+        print!(
+            "   Confirm update to version {}? [y/N]: ",
+            latest_ver.green().bold()
+        );
+        io::stdout().flush().unwrap();
+
+        let mut input = String::new();
+        if io::stdin().read_line(&mut input).is_err() {
+            return Err("Failed to read input".to_string());
+        }
+
+        let input = input.trim().to_lowercase();
+        if input != "y" && input != "yes" {
+            println!("Update aborted.");
+            return Ok(());
+        }
+
+        println!("{} Updating OMNI via Homebrew...", "🚀".cyan());
+
+        // Run brew upgrade
+        let status = Command::new("brew")
+            .args(["upgrade", "fajarhide/tap/omni"])
+            .status();
+
+        match status {
+            Ok(s) if s.success() => {
+                println!("\n{} OMNI updated successfully!", "✓".green());
+            }
+            Ok(s) => {
+                return Err(format!(
+                    "Brew upgrade failed with exit code: {}. You may need to run 'brew update' first.",
+                    s.code().unwrap_or(1)
+                ));
+            }
+            Err(e) => {
+                return Err(format!(
+                    "Failed to execute 'brew': {}. Please run 'brew upgrade fajarhide/tap/omni' manually.",
+                    e
+                ));
+            }
+        }
+    } else {
+        println!(
+            "\n{} OMNI is already up to date (v{}).",
+            "✓".green(),
+            env!("CARGO_PKG_VERSION")
+        );
+    }
+
+    Ok(())
+}

--- a/src/guard/mod.rs
+++ b/src/guard/mod.rs
@@ -1,3 +1,4 @@
 pub mod env;
 pub mod limits;
 pub mod trust;
+pub mod update;

--- a/src/guard/update.rs
+++ b/src/guard/update.rs
@@ -1,0 +1,123 @@
+use colored::*;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[derive(Serialize, Deserialize, Debug)]
+struct UpdateCache {
+    latest_version: String,
+    last_checked: u64,
+}
+
+fn get_cache_path() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".omni")
+        .join("update_cache.json")
+}
+
+pub fn check() -> Option<String> {
+    let current_version = env!("CARGO_PKG_VERSION");
+    let cache_path = get_cache_path();
+
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+
+    // 1. Try to load from cache
+    if let Ok(content) = fs::read_to_string(&cache_path)
+        && let Ok(cache) = serde_json::from_str::<UpdateCache>(&content)
+        && now < cache.last_checked + 86400
+    {
+        if is_newer(&cache.latest_version, current_version) {
+            return Some(cache.latest_version);
+        }
+        return None;
+    }
+
+    // 2. Not in cache or cache expired: Fetch from GitHub
+    // We do this synchronously but with a very short timeout (2s)
+    let url = "https://api.github.com/repos/fajarhide/omni/releases/latest";
+    let agent = ureq::AgentBuilder::new()
+        .timeout_read(std::time::Duration::from_secs(2))
+        .timeout_connect(std::time::Duration::from_secs(2))
+        .build();
+
+    let resp = agent.get(url).set("User-Agent", "omni-cli").call();
+
+    match resp {
+        Ok(response) => {
+            #[derive(Deserialize)]
+            struct GitHubRelease {
+                tag_name: String,
+            }
+
+            if let Ok(release) = response.into_json::<GitHubRelease>() {
+                let latest = release.tag_name.trim_start_matches('v').to_string();
+
+                // Save to cache
+                let cache = UpdateCache {
+                    latest_version: latest.clone(),
+                    last_checked: now,
+                };
+                if let Ok(json) = serde_json::to_string(&cache) {
+                    let _ = fs::create_dir_all(cache_path.parent().unwrap());
+                    let _ = fs::write(&cache_path, json);
+                }
+
+                if is_newer(&latest, current_version) {
+                    return Some(latest);
+                }
+            }
+        }
+        Err(_) => {
+            // Fail silently on network errors
+        }
+    }
+
+    None
+}
+
+fn is_newer(latest: &str, current: &str) -> bool {
+    let v1: Vec<u32> = latest.split('.').filter_map(|s| s.parse().ok()).collect();
+    let v2: Vec<u32> = current.split('.').filter_map(|s| s.parse().ok()).collect();
+
+    for (a, b) in v1.iter().zip(v2.iter()) {
+        if a > b {
+            return true;
+        }
+        if a < b {
+            return false;
+        }
+    }
+    v1.len() > v2.len()
+}
+
+pub fn print_notification(latest: &str) {
+    println!(
+        "\n  {} A new version of OMNI is available: {} → {}",
+        "✨".yellow(),
+        env!("CARGO_PKG_VERSION").bright_black(),
+        latest.green().bold()
+    );
+    println!(
+        "      Run: {} to upgrade.\n",
+        "brew upgrade fajarhide/tap/omni".cyan()
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_newer() {
+        assert!(is_newer("0.5.3", "0.5.2"));
+        assert!(is_newer("0.6.0", "0.5.9"));
+        assert!(is_newer("1.0.0", "0.9.9"));
+        assert!(!is_newer("0.5.2", "0.5.2"));
+        assert!(!is_newer("0.5.1", "0.5.2"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,6 +95,7 @@ fn print_help() {
         "  {: <12} Clean uninstall (for backups config)",
         "reset".cyan()
     );
+    println!("  {: <12} Upgrade OMNI to latest", "update".cyan());
     println!("  {: <12} Print version info", "version, -v".cyan());
     println!("  {: <12} Show this help message", "help, -h".cyan());
 
@@ -112,6 +113,10 @@ fn print_help() {
         "# Distill long output".bright_black()
     );
     println!();
+
+    if let Some(latest) = crate::guard::update::check() {
+        crate::guard::update::print_notification(&latest);
+    }
 }
 
 // ─── Main ───────────────────────────────────────────────
@@ -253,6 +258,13 @@ fn main() {
                 "doctor" => {
                     if let Err(e) = cli::doctor::run(&args) {
                         eprintln!("[omni] Doctor error: {}", e);
+                        std::process::exit(1);
+                    }
+                }
+
+                "update" => {
+                    if let Err(e) = cli::update::run(&args) {
+                        eprintln!("[omni] Update error: {}", e);
                         std::process::exit(1);
                     }
                 }


### PR DESCRIPTION
## Pull Request

### Checklist

* [x] `cargo fmt` — code is formatted
* [x] `cargo clippy -- -D warnings` — no lint warnings
* [x] `cargo test` — all tests pass (147+)
* [x] `cargo insta review` — all snapshots approved
* [x] New functionality has tests 

### Type of Change

- [x] Bug fix
- [x] New feature
- [x] Documentation
- [ ] Refactoring
- [x] Performance improvement



## PR Auto Describe
## 🚀 Summary
This PR ships OMNI v0.5.3, a patch release focused on improving user safety, maintainability, and diagnostic clarity. It adds a new `omni update` command for one-click Homebrew upgrades, automated 24h-cached version checks that notify users on `help` and `doctor` screens, and interactive confirmation prompts to prevent accidental destructive actions. It also resolves PreToolUse hook detection and cleanup bugs, and refines diagnostic output for easier troubleshooting.

---

## 🔑 Key Changes
### New Features
- `omni update` command for Homebrew-based upgrades
- Automated GitHub version checks (24h cached) that notify users of new releases
- Safety confirmation prompts for `omni reset` and `omni update`
- Full PreToolUse hook status diagnostics in `omni doctor`
### Fixes
- PreToolUse hook cleanup during reset/uninstall
- Hook detection logic that supports all valid Claude hook flag variants
- Clippy lints in the new update module
### Improvements
- Refined `omni doctor` output with clear section labels for hooks and MCP servers
- Updated Homebrew caveats to reflect current `omni init --all` usage

---

## 📋 Detailed Breakdown
- `CHANGELOG.md`: Added v0.5.3 release entry aligned with Keep a Changelog and SemVer standards.
- `omni.rb`: Updated Homebrew formula caveats to replace the old bare `omni init` quick start with the correct `omni init --all`.
- `src/cli/doctor.rs`: Added version check notifications to help and main doctor flows; updated hook detection to support all valid Claude hook flags; split hook and MCP server sections with clear labeling; added explicit PreToolUse hook status checks; refined missing-component warning text.
- `src/cli/init.rs`: Updated hook removal logic to detect all valid hook flags (including `--pre-hook`) for full cleanup during uninstall.
- `src/cli/mod.rs`, `src/guard/mod.rs`: Added new `update` modules to register CLI and core update functionality.
- `src/cli/reset.rs`: Added interactive [y/N] confirmation prompt for resets; added `--yes/-y` flags to bypass prompts for scripting.
- `src/cli/update.rs`: Implemented full `omni update` logic including help text, version check integration, confirmation prompts, and Homebrew upgrade execution.
- `src/guard/update.rs`: Built 24h cached GitHub release check logic, semantic version comparison, update notifications, and unit tests; includes fail-silent network error handling.
- `src/main.rs`: Added `update` to the main help menu; added version check notifications to global help; wired the new command to the core CLI router.

---

## 🧠 Notes
Version check logic uses a 2s total network timeout and fails silently to avoid disrupting offline users or those with restrictive network policies.

---

## ⚠️ Breaking Changes
None. All existing functionality remains fully backwards compatible.