### PR TITLE
fix: resolve TOML filter priority conflicts and extend coverage

### DIFF
--- a/filters/00_vitest.toml
+++ b/filters/00_vitest.toml
@@ -6,7 +6,6 @@ match_command = "(vitest|jest|pnpm test|npm test|bun test|bun run test)"
 strip_ansi = true
 strip_lines_matching = [
     "^\\s*✓ ",
-    "^\\s*✓ ",
     "^\\s*√ ",
     "^\\s*PASS ",
     "^stdout ",

--- a/filters/kubectl.toml
+++ b/filters/kubectl.toml
@@ -1,6 +1,6 @@
 schema_version = 1
 [filters.kubectl]
-match_command = "kubectl"
+match_command = "^kubectl (get|describe|apply|delete|create|patch|scale|exec|port-forward|rollout|top|wait|config|cluster-info|version|api-resources|api-versions)"
 strip_ansi = true
 
 [[filters.kubectl.match_output]]

--- a/filters/terraform.toml
+++ b/filters/terraform.toml
@@ -1,7 +1,7 @@
 schema_version = 1
 
 [filters.terraform]
-match_command = "terraform plan"
+match_command = "^terraform (plan|apply|destroy|init)"
 strip_ansi = true
 
 [[filters.terraform.match_output]]
@@ -12,7 +12,19 @@ message = "terraform: $1 add, $2 change, $3 destroy"
 pattern = "No changes. Your infrastructure matches the configuration."
 message = "terraform: no changes"
 
-strip_lines_matching = ["^Refreshing state...", "^Reading..."]
+[[filters.terraform.match_output]]
+pattern = "Apply complete! Resources: (\\d+) added, (\\d+) changed, (\\d+) destroyed"
+message = "terraform apply: $1 added, $2 changed, $3 destroyed"
+
+[[filters.terraform.match_output]]
+pattern = "Destroy complete! Resources: (\\d+) destroyed"
+message = "terraform destroy: $1 destroyed"
+
+[[filters.terraform.match_output]]
+pattern = "Terraform has been successfully initialized!"
+message = "terraform init: success"
+
+strip_lines_matching = ["^Refreshing state...", "^Reading...", "Still destroying:", "Still creating:", "Still modifying...", "\\|\\s*[~+-]\\s*$"]
 max_lines = 50
 
 [[tests.terraform]]
@@ -30,3 +42,33 @@ Refreshing state...
 Plan: 2 to add, 0 to change, 1 to destroy.
 """
 expected = "terraform: 2 add, 0 change, 1 destroy"
+
+[[tests.terraform]]
+name = "apply success"
+input = """
+Refreshing state...
+Still creating... [10s elapsed]
+Still creating... [20s elapsed]
+Apply complete! Resources: 2 added, 0 changed, 1 destroyed.
+"""
+expected = "terraform apply: 2 added, 0 changed, 1 destroyed"
+
+[[tests.terraform]]
+name = "destroy success"
+input = """
+Refreshing state...
+Still destroying... [10s elapsed]
+Destroy complete! Resources: 3 destroyed.
+"""
+expected = "terraform destroy: 3 destroyed"
+
+[[tests.terraform]]
+name = "init success"
+input = """
+Initializing the backend...
+Initializing provider plugins...
+- Finding hashicorp/aws versions matching ~> 5.0...
+- Installing hashicorp/aws v5.45.0...
+Terraform has been successfully initialized!
+"""
+expected = "terraform init: success"

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -19,18 +19,48 @@ pub fn run_exec(
     let cmd = &args[2];
     let cmd_args = &args[3..];
 
-    let child_res = Command::new(cmd)
-        .args(cmd_args)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::inherit()) // Let stderr bypass OMNI directly to the terminal
-        .spawn();
+    // Detect if we need to run via shell
+    let needs_shell = cmd_args.iter().any(|arg| {
+        arg.contains('|')
+            || arg.contains('>')
+            || arg.contains('<')
+            || arg.contains('&')
+            || arg.contains(';')
+    }) || cmd.contains('|')
+        || cmd.contains('>')
+        || cmd.contains('<')
+        || cmd.contains('&')
+        || cmd.contains(';');
 
-    let child = match child_res {
-        Ok(c) => c,
-        Err(e) => {
-            eprintln!("omni exec: failed to execute '{}': {}", cmd, e);
-            std::process::exit(1);
-        }
+    let (child, cmd_name) = if needs_shell {
+        let full_cmd = if cmd_args.is_empty() {
+            cmd.to_string()
+        } else {
+            format!("{} {}", cmd, cmd_args.join(" "))
+        };
+
+        let c = Command::new("sh")
+            .arg("-c")
+            .arg(&full_cmd)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "omni exec: failed to execute shell command '{}': {}",
+                    full_cmd,
+                    e
+                )
+            })?;
+        (c, cmd.clone())
+    } else {
+        let c = Command::new(cmd)
+            .args(cmd_args)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .map_err(|e| anyhow::anyhow!("omni exec: failed to execute '{}': {}", cmd, e))?;
+        (c, cmd.clone())
     };
 
     let output = child.wait_with_output()?;
@@ -45,7 +75,7 @@ pub fn run_exec(
         stderr,
         store,
         session,
-        Some(cmd),
+        Some(&cmd_name),
     )?;
 
     if !output.status.success() {

--- a/src/cli/rewrite.rs
+++ b/src/cli/rewrite.rs
@@ -27,25 +27,19 @@ pub fn rewrite_logic(cmd_str: &str) -> Option<String> {
         "node ",
         "python ",
         "go ",
+        "bash ",
+        "sh ",
     ];
 
     let wants_rewrite = allow_list.iter().any(|&p| cmd_str.starts_with(p));
 
     if wants_rewrite {
-        // Do not rewrite if it contains shell symbols
-        let has_shell_symbols = cmd_str.contains('|')
-            || cmd_str.contains('>')
-            || cmd_str.contains('<')
-            || cmd_str.contains("&&")
-            || cmd_str.contains(';');
+        // We always try to rewrite recognized tools to capture them.
+        // run_exec will handle whether to use a shell or not.
+        let exe_path = std::env::current_exe().unwrap_or_else(|_| std::path::PathBuf::from("omni"));
+        let exe_name = exe_path.to_string_lossy();
 
-        if !has_shell_symbols {
-            let exe_path =
-                std::env::current_exe().unwrap_or_else(|_| std::path::PathBuf::from("omni"));
-            let exe_name = exe_path.to_string_lossy();
-
-            return Some(format!("{} exec {}", exe_name, cmd_str));
-        }
+        return Some(format!("{} exec {}", exe_name, cmd_str));
     }
 
     None

--- a/src/cli/stats.rs
+++ b/src/cli/stats.rs
@@ -199,7 +199,7 @@ pub fn run(args: &[String], store: &Store) -> Result<()> {
             };
 
             println!(
-                "  {:>2}. {:<12} {:>4}x  {:>3.0}%  {}{}",
+                "  {:>2}. {:<24} {:>4}x  {:>3.0}%  {}{}",
                 i + 1,
                 name.bright_cyan(),
                 cnt,

--- a/src/hooks/pre_tool.rs
+++ b/src/hooks/pre_tool.rs
@@ -99,7 +99,7 @@ mod tests {
     }
 
     #[test]
-    fn test_pre_hook_ignores_shell_pipes() {
+    fn test_pre_hook_handles_shell_pipes() {
         let input = json!({
             "tool_input": {
                 "command": "git status | grep foo"
@@ -107,7 +107,7 @@ mod tests {
         })
         .to_string();
 
-        let output = process_payload(&input);
-        assert!(output.is_none());
+        let output = process_payload(&input).expect("Should rewrite");
+        assert!(output.contains("exec git status | grep foo"));
     }
 }

--- a/src/pipeline/toml_filter.rs
+++ b/src/pipeline/toml_filter.rs
@@ -311,7 +311,9 @@ pub fn load_from_dir(dir: &Path) -> Vec<TomlFilter> {
 
 pub fn load_embedded_filters() -> Vec<TomlFilter> {
     let mut all_filters = Vec::new();
-    for file in Asset::iter() {
+    let mut files: Vec<String> = Asset::iter().map(|s| s.to_string()).collect();
+    files.sort(); // Sort alphabetically so specific filters (e.g., 00_vitest.toml) load before general ones (e.g., npm.toml)
+    for file in files {
         if file.ends_with(".toml")
             && let Some(content) = Asset::get(&file)
         {

--- a/src/session/tracker.rs
+++ b/src/session/tracker.rs
@@ -259,13 +259,13 @@ pub fn infer_domain(session: &SessionState) -> Option<String> {
 }
 
 fn save_async(session: Arc<Mutex<SessionState>>, store: Arc<Store>) {
-    // Actually we already saved in thread earlier or we can just spawn again explicitly over the requirement bounds
-    // Since we spawned thread inside track_command, this just does the synchronous DB hit natively detached.
-    let s = match session.lock() {
-        Ok(l) => l.clone(),
-        Err(_) => return,
-    };
-    store.upsert_session(&s);
+    thread::spawn(move || {
+        let s = match session.lock() {
+            Ok(l) => l.clone(),
+            Err(_) => return,
+        };
+        store.upsert_session(&s);
+    });
 }
 
 #[cfg(test)]

--- a/tests/toml_filter_integration.rs
+++ b/tests/toml_filter_integration.rs
@@ -464,11 +464,24 @@ mod terraform {
     }
 
     #[test]
+    fn matches_terraform_apply_destroy_init() {
+        let filters = load_filters();
+        let f = get_filter(&filters, "terraform");
+        assert_matches(f, "terraform apply");
+        assert_matches(f, "terraform apply -auto-approve");
+        assert_matches(f, "terraform destroy");
+        assert_matches(f, "terraform destroy -auto-approve");
+        assert_matches(f, "terraform init");
+        assert_matches(f, "terraform init -upgrade");
+    }
+
+    #[test]
     fn does_not_match_unrelated() {
         let filters = load_filters();
         let f = get_filter(&filters, "terraform");
-        assert_not_matches(f, "terraform apply");
-        assert_not_matches(f, "terraform init");
+        assert_not_matches(f, "terraform fmt");
+        assert_not_matches(f, "terraform validate");
+        assert_not_matches(f, "terrafirma plan");
     }
 }
 


### PR DESCRIPTION
- Fix BUG-1: Rename vitest.toml → 00_vitest.toml to load before npm.toml (sort alphabetically) so "bun run test" matches vitest filter
- Fix BUG-2: Make kubectl.toml specific to non-logs commands using anchored regex, allowing kubectl_logs.toml to handle "kubectl logs"
- Fix GAP-1: Extend terraform.toml to cover apply/destroy/init commands with appropriate match_output rules and strip patterns
- Sort embedded filters alphabetically in load_embedded_filters() to enable deterministic filter priority via filename prefixing
- Fix `omni stats` before and after update

### Before 

<img width="382" height="290" alt="Screenshot 2026-03-25 at 09 10 16" src="https://github.com/user-attachments/assets/4da7d247-185f-47a4-bbcb-5f49af0ff513" />

### After update
<img width="462" height="294" alt="Screenshot 2026-03-25 at 09 09 06" src="https://github.com/user-attachments/assets/5aa80ecf-f83e-4e09-89d1-bf0146c95016" />


## Pull Request

### Checklist

* [x] `cargo fmt` — code is formatted
* [x] `cargo clippy -- -D warnings` — no lint warnings
* [x] `cargo test` — all tests pass (147+)
* [x] `cargo insta review` — all snapshots approved
* [x] New functionality has tests 

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactoring
- [x] Performance improvement



## PR Auto Describe
## 🚀 Summary
This PR adds full shell command support to omni's exec workflow, enabling capture and filtering of piped, redirected, or chained commands that were previously ignored. It expands output filter coverage for Terraform, kubectl, and Vitest, adds new output parsing for additional Terraform commands, and fixes filter loading order to ensure specific filters run before generic ones. All new functionality is validated with expanded unit and integration tests.

---

## 🔑 Key Changes
- Core CLI: Added shell passthrough for piped/chained commands, removed restrictions on rewriting shell-based tool invocations to ensure full capture
- Filters: Expanded support for Terraform, kubectl, and Vitest, adding new output parsing for Terraform's apply/destroy/init commands
- Reliability: Fixed filter loading order to prevent generic filters from overriding specific, prioritized ones
- Test coverage: Added new unit and integration tests for all new functionality

---

## 📋 Detailed Breakdown
### Core CLI Changes
- src/cli/exec.rs: Added detection for shell metachars (|, >, <, &, ;) in commands/args; triggers execution via `sh -c` to preserve shell functionality while capturing output, maintains original stderr pass-through behavior
- src/cli/rewrite.rs: Removed shell symbol block that prevented rewriting commands with pipes/chaining; added bash/sh to the tool allowlist, now rewrites all eligible tools to run through omni exec
- src/hooks/pre_tool.rs: Updated unit test to confirm shell pipe commands are processed correctly instead of ignored
- src/cli/stats.rs: Widened command name column in stats output from 12 to 24 characters to support longer command names
### Filter & Pipeline Changes
- filters/00_vitest.toml: Removed duplicate test success line entry in the strip list
- filters/kubectl.toml: Updated match_command from generic "kubectl" to a regex that only matches common kubectl subcommands, avoiding unintended filtering
- filters/terraform.toml: Expanded match_command to support plan/apply/destroy/init; added 3 new output matchers to parse success messages for the 3 new commands; added in-progress progress lines and progress bar clutter to the strip list; added 3 new test cases for apply/destroy/init output parsing
- src/pipeline/toml_filter.rs: Added alphabetical sorting of embedded filters to load numbered, specific filters (e.g. 00_vitest.toml) before generic ones, preventing early matching by less specific filters
- tests/toml_filter_integration.rs: Updated Terraform filter tests to confirm it matches supported subcommands, rejects unrelated ones, and works as expected

---

## 🧠 Notes
Kubectl filter is intentionally limited to common production subcommands; add any rare custom kubectl subcommands to the match_command regex if you require filtering for them.

---

## ⚠️ Breaking Changes
None, all changes are backward-compatible for standard use cases.