### PR TITLE
refactor: reimplement update checking with a detailed status enum, pre-release version handling, and integrate it into the `doctor` and `update` CLI commands.

### DIFF
--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -76,12 +76,25 @@ pub fn run(args: &[String]) -> anyhow::Result<()> {
     );
 
     // 1. Binary Version
-    println!(
-        "  {:<15} omni v{} {}",
-        "Binary:".bright_black(),
-        env!("CARGO_PKG_VERSION"),
-        "[OK]".green().bold()
-    );
+    let status = crate::guard::update::get_status();
+    let version_info = match status {
+        crate::guard::update::Status::Latest => {
+            format!("omni v{} {}", env!("CARGO_PKG_VERSION"), "[LATEST]".green())
+        }
+        crate::guard::update::Status::UpdateAvailable(v) => format!(
+            "omni v{} {} (Latest: {})",
+            env!("CARGO_PKG_VERSION"),
+            "[UPDATE]".yellow().bold(),
+            v.green()
+        ),
+        crate::guard::update::Status::Ahead => format!(
+            "omni v{} {}",
+            env!("CARGO_PKG_VERSION"),
+            "[AHEAD/RC]".blue().bold()
+        ),
+    };
+
+    println!("  {:<15} {}", "Binary:".bright_black(), version_info);
 
     // 2. Config Dir
     let conf_dir = dirs::home_dir()

--- a/src/cli/update.rs
+++ b/src/cli/update.rs
@@ -26,63 +26,74 @@ pub fn run(args: &[String]) -> Result<(), String> {
         return Ok(());
     }
 
-    let latest = crate::guard::update::check();
+    let status = crate::guard::update::get_status();
 
-    if let Some(latest_ver) = latest {
-        println!(
-            "\n{} A new version is available: {} → {}",
-            "✨".yellow(),
-            env!("CARGO_PKG_VERSION").bright_black(),
-            latest_ver.green().bold()
-        );
+    match status {
+        crate::guard::update::Status::UpdateAvailable(latest_ver) => {
+            println!(
+                "\n{} A new version is available: {} → {}",
+                "✨".yellow(),
+                env!("CARGO_PKG_VERSION").bright_black(),
+                latest_ver.green().bold()
+            );
 
-        print!(
-            "   Confirm update to version {}? [y/N]: ",
-            latest_ver.green().bold()
-        );
-        io::stdout().flush().unwrap();
+            print!(
+                "   Confirm update to version {}? [y/N]: ",
+                latest_ver.green().bold()
+            );
+            io::stdout().flush().unwrap();
 
-        let mut input = String::new();
-        if io::stdin().read_line(&mut input).is_err() {
-            return Err("Failed to read input".to_string());
-        }
-
-        let input = input.trim().to_lowercase();
-        if input != "y" && input != "yes" {
-            println!("Update aborted.");
-            return Ok(());
-        }
-
-        println!("{} Updating OMNI via Homebrew...", "🚀".cyan());
-
-        // Run brew upgrade
-        let status = Command::new("brew")
-            .args(["upgrade", "fajarhide/tap/omni"])
-            .status();
-
-        match status {
-            Ok(s) if s.success() => {
-                println!("\n{} OMNI updated successfully!", "✓".green());
+            let mut input = String::new();
+            if io::stdin().read_line(&mut input).is_err() {
+                return Err("Failed to read input".to_string());
             }
-            Ok(s) => {
-                return Err(format!(
-                    "Brew upgrade failed with exit code: {}. You may need to run 'brew update' first.",
-                    s.code().unwrap_or(1)
-                ));
+
+            let input = input.trim().to_lowercase();
+            if input != "y" && input != "yes" {
+                println!("Update aborted.");
+                return Ok(());
             }
-            Err(e) => {
-                return Err(format!(
-                    "Failed to execute 'brew': {}. Please run 'brew upgrade fajarhide/tap/omni' manually.",
-                    e
-                ));
+
+            println!("{} Updating OMNI via Homebrew...", "🚀".cyan());
+
+            // Run brew upgrade
+            let status = Command::new("brew")
+                .args(["upgrade", "fajarhide/tap/omni"])
+                .status();
+
+            match status {
+                Ok(s) if s.success() => {
+                    println!("\n{} OMNI updated successfully!", "✓".green());
+                }
+                Ok(s) => {
+                    return Err(format!(
+                        "Brew upgrade failed with exit code: {}. You may need to run 'brew update' first.",
+                        s.code().unwrap_or(1)
+                    ));
+                }
+                Err(e) => {
+                    return Err(format!(
+                        "Failed to execute 'brew': {}. Please run 'brew upgrade fajarhide/tap/omni' manually.",
+                        e
+                    ));
+                }
             }
         }
-    } else {
-        println!(
-            "\n{} OMNI is already up to date (v{}).",
-            "✓".green(),
-            env!("CARGO_PKG_VERSION")
-        );
+        crate::guard::update::Status::Ahead => {
+            println!(
+                "\n{} OMNI is ahead of the latest stable release (v{}).",
+                "🚀".blue(),
+                env!("CARGO_PKG_VERSION")
+            );
+            println!("   You are currently on a pre-release or development version.");
+        }
+        crate::guard::update::Status::Latest => {
+            println!(
+                "\n{} OMNI is already up to date (v{}).",
+                "✓".green(),
+                env!("CARGO_PKG_VERSION")
+            );
+        }
     }
 
     Ok(())

--- a/src/guard/update.rs
+++ b/src/guard/update.rs
@@ -17,7 +17,13 @@ fn get_cache_path() -> PathBuf {
         .join("update_cache.json")
 }
 
-pub fn check() -> Option<String> {
+pub enum Status {
+    Latest,
+    UpdateAvailable(String),
+    Ahead,
+}
+
+pub fn get_status() -> Status {
     let current_version = env!("CARGO_PKG_VERSION");
     let cache_path = get_cache_path();
 
@@ -26,63 +32,79 @@ pub fn check() -> Option<String> {
         .unwrap_or_default()
         .as_secs();
 
-    // 1. Try to load from cache
-    if let Ok(content) = fs::read_to_string(&cache_path)
+    // Try to get latest version from cache or fetch it
+    let latest = if let Ok(content) = fs::read_to_string(&cache_path)
         && let Ok(cache) = serde_json::from_str::<UpdateCache>(&content)
         && now < cache.last_checked + 86400
     {
-        if is_newer(&cache.latest_version, current_version) {
-            return Some(cache.latest_version);
-        }
-        return None;
-    }
+        Some(cache.latest_version)
+    } else {
+        // Fetch from GitHub
+        let url = "https://api.github.com/repos/fajarhide/omni/releases/latest";
+        let agent = ureq::AgentBuilder::new()
+            .timeout_read(std::time::Duration::from_secs(2))
+            .timeout_connect(std::time::Duration::from_secs(2))
+            .build();
 
-    // 2. Not in cache or cache expired: Fetch from GitHub
-    // We do this synchronously but with a very short timeout (2s)
-    let url = "https://api.github.com/repos/fajarhide/omni/releases/latest";
-    let agent = ureq::AgentBuilder::new()
-        .timeout_read(std::time::Duration::from_secs(2))
-        .timeout_connect(std::time::Duration::from_secs(2))
-        .build();
-
-    let resp = agent.get(url).set("User-Agent", "omni-cli").call();
-
-    match resp {
-        Ok(response) => {
-            #[derive(Deserialize)]
-            struct GitHubRelease {
-                tag_name: String,
-            }
-
-            if let Ok(release) = response.into_json::<GitHubRelease>() {
-                let latest = release.tag_name.trim_start_matches('v').to_string();
-
-                // Save to cache
-                let cache = UpdateCache {
-                    latest_version: latest.clone(),
-                    last_checked: now,
-                };
-                if let Ok(json) = serde_json::to_string(&cache) {
-                    let _ = fs::create_dir_all(cache_path.parent().unwrap());
-                    let _ = fs::write(&cache_path, json);
+        match agent.get(url).set("User-Agent", "omni-cli").call() {
+            Ok(response) => {
+                #[derive(Deserialize)]
+                struct GitHubRelease {
+                    tag_name: String,
                 }
-
-                if is_newer(&latest, current_version) {
-                    return Some(latest);
+                if let Ok(release) = response.into_json::<GitHubRelease>() {
+                    let v = release.tag_name.trim_start_matches('v').to_string();
+                    // Save to cache
+                    let cache = UpdateCache {
+                        latest_version: v.clone(),
+                        last_checked: now,
+                    };
+                    if let Ok(json) = serde_json::to_string(&cache) {
+                        let _ = fs::create_dir_all(cache_path.parent().unwrap());
+                        let _ = fs::write(&cache_path, json);
+                    }
+                    Some(v)
+                } else {
+                    None
                 }
             }
+            Err(_) => None,
         }
-        Err(_) => {
-            // Fail silently on network errors
-        }
-    }
+    };
 
-    None
+    match latest {
+        Some(v) => {
+            if is_newer(&v, current_version) {
+                Status::UpdateAvailable(v)
+            } else if is_newer(current_version, &v) {
+                Status::Ahead
+            } else {
+                Status::Latest
+            }
+        }
+        None => Status::Latest, // Assume latest if offline
+    }
+}
+
+pub fn check() -> Option<String> {
+    match get_status() {
+        Status::UpdateAvailable(v) => Some(v),
+        _ => None,
+    }
 }
 
 fn is_newer(latest: &str, current: &str) -> bool {
-    let v1: Vec<u32> = latest.split('.').filter_map(|s| s.parse().ok()).collect();
-    let v2: Vec<u32> = current.split('.').filter_map(|s| s.parse().ok()).collect();
+    let parse_v = |v: &str| -> Vec<u32> {
+        v.split('.')
+            .map(|s| {
+                // Take only the numeric part before any hyphen
+                s.split('-').next().unwrap_or("0").parse().unwrap_or(0)
+            })
+            .collect()
+    };
+
+    let v1 = parse_v(latest);
+    let v2 = parse_v(current);
 
     for (a, b) in v1.iter().zip(v2.iter()) {
         if a > b {
@@ -92,6 +114,21 @@ fn is_newer(latest: &str, current: &str) -> bool {
             return false;
         }
     }
+
+    // If numeric parts are equal, check pre-release suffixes
+    if v1 == v2 {
+        let s1 = latest.split('-').nth(1).unwrap_or("");
+        let s2 = current.split('-').nth(1).unwrap_or("");
+
+        if s1.is_empty() && !s2.is_empty() {
+            return true;
+        } // "0.5.4" > "0.5.4-rc1"
+        if !s1.is_empty() && s2.is_empty() {
+            return false;
+        } // "0.5.4-rc1" < "0.5.4"
+        return s1 > s2; // "0.5.4-rc2" > "0.5.4-rc1"
+    }
+
     v1.len() > v2.len()
 }
 
@@ -119,5 +156,11 @@ mod tests {
         assert!(is_newer("1.0.0", "0.9.9"));
         assert!(!is_newer("0.5.2", "0.5.2"));
         assert!(!is_newer("0.5.1", "0.5.2"));
+
+        // Pre-release tests
+        assert!(is_newer("0.5.4", "0.5.4-rc1"));
+        assert!(!is_newer("0.5.4-rc1", "0.5.4"));
+        assert!(!is_newer("0.5.3", "0.5.4-rc1"));
+        assert!(is_newer("0.5.4-rc2", "0.5.4-rc1"));
     }
 }


### PR DESCRIPTION
## Pull Request

### Checklist

* [x] `cargo fmt` — code is formatted
* [x] `cargo clippy -- -D warnings` — no lint warnings
* [x] `cargo test` — all tests pass (147+)
* [x] `cargo insta review` — all snapshots approved
* [x] New functionality has tests 

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactoring
- [x] Performance improvement




## PR Auto Describe
## 🚀 Summary
This PR unifies and improves version update checking across the omni CLI, extending functionality to both the `doctor` and `update` commands. It adds structured version status tracking to correctly classify up-to-date, update-eligible, and pre-release/development (ahead of stable) versions, with enhanced semantic version comparison that properly handles pre-release suffixes. The change centralizes update logic to eliminate duplication across CLI workflows.

---

## 🔑 Key Changes
- Centralized shared update status logic in `src/guard/update.rs` for cross-command use
- Enhanced semantic version comparison to support pre-release and dev version tagging
- Updated `doctor` command to display contextual version status instead of a generic OK flag
- Refactored `update` command to leverage shared logic, add dedicated messaging for pre-release users

---

## 📋 Detailed Breakdown
### src/guard/update.rs
- Added new `Status` enum with 3 version states: `Latest`, `UpdateAvailable(String)`, `Ahead`
- Replaced legacy `check()` with `get_status()` as primary entry point; retained `check()` for backward compatibility (wraps `get_status()` to preserve the original `Option<String>` signature)
- Rewrote `is_newer()` version comparator: strips pre-release hyphen suffixes for base numeric comparison, ranks stable releases above pre-releases, and compares pre-release suffixes for proper ordering
- Retained 24h cache TTL for GitHub release checks, 2s network timeout, defaults to `Latest` if network/cache reads fail
- Added 4 new unit tests for pre-release version comparison logic
### src/cli/doctor.rs
- Rewrote binary version output to fetch status via `get_status()`, displays colored context-aware labels:
  - `[LATEST]` (green) for up-to-date stable versions
  - `[UPDATE]` (yellow, bold) + latest version number for outdated installs
  - `[AHEAD/RC]` (blue, bold) for pre-release/dev versions ahead of stable
- Replaced the original generic "[OK]" status tag
### src/cli/update.rs
- Refactored to use `get_status()` instead of legacy `check()` to trigger update flows
- Added dedicated output for `Ahead` status, notifying users they are running a pre-release/development version
- Retained all existing update workflow logic: Homebrew upgrade flow, user confirmation prompt, and brew execution error handling

---

## 🧠 Notes
All update logic remains non-blocking, failing silently on network errors to avoid disrupting core CLI usage. The legacy `check()` function is fully retained, so no existing internal calls to this utility break.

---

## ⚠️ Breaking Changes
None. All existing functionality, APIs, and user-facing workflows are fully preserved.