### PR TITLE
Implement command-aware content classification heuristics

### DIFF
--- a/benches/pipeline.rs
+++ b/benches/pipeline.rs
@@ -25,7 +25,7 @@ fn bench_classify(c: &mut Criterion) {
 
     for (name, input) in &fixtures {
         c.bench_with_input(BenchmarkId::new("classify", name), input, |b, i| {
-            b.iter(|| classifier::classify(i))
+            b.iter(|| classifier::classify(i, None))
         });
     }
 }
@@ -35,7 +35,7 @@ fn bench_full_pipeline(c: &mut Criterion) {
 
     c.bench_function("full_pipeline_cargo_build", |b| {
         b.iter(|| {
-            let ctype = classifier::classify(input);
+            let ctype = classifier::classify(input, None);
             let segments = scorer::score_segments(input, &ctype, None);
             let distiller = distillers::get_distiller(&ctype);
             distiller.distill(&segments, input, None)
@@ -49,7 +49,7 @@ fn bench_hook_roundtrip(c: &mut Criterion) {
 
     c.bench_function("hook_roundtrip_50kb", |b| {
         b.iter(|| {
-            let ctype = classifier::classify(&large_input);
+            let ctype = classifier::classify(&large_input, None);
             let segments = scorer::score_segments(&large_input, &ctype, None);
             let distiller = distillers::get_distiller(&ctype);
             distiller.distill(&segments, &large_input, None)

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -430,6 +430,47 @@ pub fn run(args: &[String]) -> anyhow::Result<()> {
         println!("   {:<15} none", "Project:".bright_black());
     }
 
+    // 10. Intelligence Consistency
+    println!("\n {}", "Intelligence:".bold().bright_white());
+    if let Ok(store) = Store::open() {
+        if fix_mode {
+            match store.reclassify_historical_data() {
+                Ok(count) => {
+                    if count > 0 {
+                        println!(
+                            "   {:<15} {} records upgraded to new categories {}",
+                            "Upgrade:".bright_black(),
+                            count.to_string().yellow().bold(),
+                            "[FIXED]".green().bold()
+                        );
+                    } else {
+                        println!(
+                            "   {:<15} historical statistics are up to date {}",
+                            "Status:".bright_black(),
+                            "[OK]".green().bold()
+                        );
+                    }
+                }
+                Err(e) => {
+                    println!(
+                        "   {:<15} upgrade failed: {} {}",
+                        "Upgrade:".bright_black(),
+                        e,
+                        "[ERROR]".red().bold()
+                    );
+                }
+            }
+        } else {
+            // Diagnostic mode: check how many could be upgraded
+            // For now, simpler to just say 'Run with --fix to upgrade'
+            println!(
+                "   {:<15} Run with {} to upgrade historical stats",
+                "Status:".bright_black(),
+                "--fix".cyan()
+            );
+        }
+    }
+
     if let Some(latest) = crate::guard::update::check() {
         crate::guard::update::print_notification(&latest);
     }

--- a/src/cli/learn.rs
+++ b/src/cli/learn.rs
@@ -236,8 +236,11 @@ pub fn run_learn(args: &[String]) -> Result<()> {
 
     let filter_name = format!("learned_{}", Utc::now().timestamp());
 
+    let command_hint = executions.first().map(|e| e.command.as_str());
+
     if dry_run {
-        let generated = crate::session::learn::generate_toml(&candidates, &filter_name);
+        let generated =
+            crate::session::learn::generate_toml(&candidates, &filter_name, command_hint);
         println!(
             "\n{}",
             "─────────────────────────────────────────"
@@ -264,7 +267,7 @@ pub fn run_learn(args: &[String]) -> Result<()> {
     } else if apply {
         let path = crate::paths::learned_filters_path();
         let _ = crate::paths::ensure_omni_home();
-        let added = apply_to_config(&candidates, &filter_name, &path)?;
+        let added = apply_to_config(&candidates, &filter_name, &path, command_hint)?;
         if added > 0 {
             println!(
                 "\n{}",

--- a/src/cli/stats.rs
+++ b/src/cli/stats.rs
@@ -235,7 +235,7 @@ fn run_default(store: &Store) -> Result<()> {
 
     if !top_types.is_empty() {
         println!("\n  {}", "Top Savings by Type:".bold().bright_white());
-        for (content_type, count, pct, commands) in &top_types {
+        for (content_type, count, pct, _commands) in &top_types {
             let bar = format_bar_with_empty(*pct);
             let bar_colored = if *pct > 80.0 {
                 bar.bright_green()
@@ -245,16 +245,7 @@ fn run_default(store: &Store) -> Result<()> {
                 bar.bright_red()
             };
 
-            let label_display = if content_type == "Unknown" {
-                let cmds = truncate_commands(commands, 2);
-                if !cmds.is_empty() {
-                    format!("Unknown ({})", cmds)
-                } else {
-                    "Unknown".to_string()
-                }
-            } else {
-                content_type.clone()
-            };
+            let label_display = content_type.clone();
 
             println!(
                 "    {:<13} {}  {:>5.1}%  ({}x)",
@@ -286,6 +277,14 @@ fn run_default(store: &Store) -> Result<()> {
         "  💡 {} for content type mapping",
         "omni stats --by-type".bright_cyan()
     );
+
+    if store.has_upgradable_history() {
+        println!(
+            "  💡 Run {} to upgrade historical stats",
+            "omni doctor --fix".bright_cyan()
+        );
+    }
+
     println!();
     Ok(())
 }

--- a/src/cli/stats.rs
+++ b/src/cli/stats.rs
@@ -285,6 +285,11 @@ fn run_default(store: &Store) -> Result<()> {
         );
     }
 
+    // Update Notification (4h cache)
+    if let Some(latest) = crate::guard::update::check() {
+        crate::guard::update::print_notification(&latest);
+    }
+
     println!();
     Ok(())
 }

--- a/src/cli/stats.rs
+++ b/src/cli/stats.rs
@@ -137,13 +137,21 @@ pub fn run(args: &[String], store: &Store) -> Result<()> {
         return Ok(());
     }
 
-    // Mode detection
-    let mode = if args.iter().any(|a| a == "--detail") {
+    let detail_flag = args.iter().any(|a| a == "--detail");
+    let type_flag = args.iter().any(|a| a == "--by-type");
+    let json_flag = args.iter().any(|a| a == "--json");
+    let filter_flag = args
+        .iter()
+        .any(|a| a == "--today" || a == "--week" || a == "--month" || a == "--all-commands");
+
+    let mode = if detail_flag {
         "detail"
-    } else if args.iter().any(|a| a == "--by-type") {
+    } else if type_flag {
         "by-type"
-    } else if args.iter().any(|a| a == "--json") {
+    } else if json_flag {
         "json"
+    } else if filter_flag {
+        "detail" // Implicit detail mode for scoped queries
     } else {
         "default"
     };
@@ -227,7 +235,7 @@ fn run_default(store: &Store) -> Result<()> {
 
     if !top_types.is_empty() {
         println!("\n  {}", "Top Savings by Type:".bold().bright_white());
-        for (content_type, count, pct, _) in &top_types {
+        for (content_type, count, pct, commands) in &top_types {
             let bar = format_bar_with_empty(*pct);
             let bar_colored = if *pct > 80.0 {
                 bar.bright_green()
@@ -237,12 +245,23 @@ fn run_default(store: &Store) -> Result<()> {
                 bar.bright_red()
             };
 
+            let label_display = if content_type == "Unknown" {
+                let cmds = truncate_commands(commands, 2);
+                if !cmds.is_empty() {
+                    format!("Unknown ({})", cmds)
+                } else {
+                    "Unknown".to_string()
+                }
+            } else {
+                content_type.clone()
+            };
+
             println!(
                 "    {:<13} {}  {:>5.1}%  ({}x)",
-                content_type.bright_cyan(),
+                label_display.bright_cyan(),
                 bar_colored,
                 pct,
-                count,
+                count
             );
         }
     }
@@ -368,13 +387,18 @@ fn run_detail(args: &[String], store: &Store) -> Result<()> {
         );
     }
 
-    // By Command — top 10, filter 0% savings
+    // By Command — top 10 (or all if requested), filter 0% savings
     let filters = store.filter_breakdown(since)?;
-    let display_filters: Vec<_> = filters
-        .iter()
-        .filter(|(_, _, pct)| *pct > 0.0)
-        .take(10)
-        .collect();
+    let all_flag = args.iter().any(|a| a == "--all-commands");
+    let display_filters: Vec<_> = if all_flag {
+        filters.iter().collect()
+    } else {
+        filters
+            .iter()
+            .filter(|(_, _, pct)| *pct > 0.0)
+            .take(10)
+            .collect()
+    };
 
     if !display_filters.is_empty() {
         println!("\n {}", "By Command:".bold().bright_white());
@@ -416,16 +440,30 @@ fn run_detail(args: &[String], store: &Store) -> Result<()> {
             );
         }
 
-        if filters.len() > 10 {
-            println!(
-                "\n   {}",
-                format!(
-                    "Run `omni stats --detail --all-commands` for all {} commands.",
-                    filters.len()
-                )
-                .bright_black()
-                .italic()
-            );
+        if !all_flag {
+            let filtered_count = filters.iter().filter(|(_, _, pct)| *pct > 0.0).count();
+            let hidden_zero = filters.len() - filtered_count;
+
+            if filtered_count > 10 {
+                println!(
+                    "\n   {}",
+                    format!(
+                        "Showing top 10 of {} commands with active savings.",
+                        filtered_count
+                    )
+                    .bright_black()
+                    .italic()
+                );
+            }
+
+            if hidden_zero > 0 {
+                println!(
+                     "   {}",
+                     format!("({} noise commands with 0% savings hidden. Use --all-commands to see all).", hidden_zero)
+                         .bright_black()
+                         .italic()
+                 );
+            }
         }
     }
 

--- a/src/guard/update.rs
+++ b/src/guard/update.rs
@@ -32,10 +32,10 @@ pub fn get_status() -> Status {
         .unwrap_or_default()
         .as_secs();
 
-    // Try to get latest version from cache or fetch it
+    // Try to get latest version from cache or fetch it (Cache: 4 hours)
     let latest = if let Ok(content) = fs::read_to_string(&cache_path)
         && let Ok(cache) = serde_json::from_str::<UpdateCache>(&content)
-        && now < cache.last_checked + 86400
+        && now < cache.last_checked + 14400
     {
         Some(cache.latest_version)
     } else {

--- a/src/hooks/pipe.rs
+++ b/src/hooks/pipe.rs
@@ -179,47 +179,65 @@ fn distill(
         }
     }
 
-    let (output, filter_name, ctype, rewind_hash, kept_count, dropped_count) =
-        if let Some(filter) = matched_toml {
-            let out = filter.apply(&input_text);
-            (out, filter.name.clone(), ContentType::Unknown, None, 0, 0)
-        } else {
-            let c = classifier::classify(&input_text);
+    let (output, filter_name, ctype, rewind_hash, kept_count, dropped_count) = if let Some(filter) =
+        matched_toml
+    {
+        let out = filter.apply(&input_text);
+        (out, filter.name.clone(), ContentType::Unknown, None, 0, 0)
+    } else {
+        let c = classifier::classify(&input_text, command_name);
 
-            let collapse_result = collapse::collapse(&input_text, &c);
-            let effective_input = collapse_result.collapsed_lines.join("\n");
+        let collapse_result = collapse::collapse(&input_text, &c);
+        let effective_input = collapse_result.collapsed_lines.join("\n");
 
-            let active_session_opt = session.as_ref().and_then(|m| m.lock().ok());
-            let scored_segments =
-                scorer::score_segments(&effective_input, &c, active_session_opt.as_deref());
-            drop(active_session_opt);
+        let active_session_opt = session.as_ref().and_then(|m| m.lock().ok());
+        let scored_segments =
+            scorer::score_segments(&effective_input, &c, active_session_opt.as_deref());
 
-            let compose_config = composer::ComposeConfig::default();
-            let decision = composer::decide_rewind(&scored_segments, &c);
+        let distiller = crate::distillers::get_distiller(&c);
+        let mut out =
+            distiller.distill(&scored_segments, &input_text, active_session_opt.as_deref());
 
-            let k_count = scored_segments
-                .iter()
-                .filter(|s| s.final_score() >= compose_config.threshold)
-                .count();
-            let d_count = scored_segments.len() - k_count;
+        let compose_config = composer::ComposeConfig::default();
+        let decision = composer::decide_rewind(&scored_segments, &c);
 
-            let store_for_compose = if decision.should_store { store } else { None };
+        let k_count = scored_segments
+            .iter()
+            .filter(|s| s.final_score() >= compose_config.threshold)
+            .count();
+        let d_count = scored_segments.len() - k_count;
 
-            let (out, r_hash) = composer::compose(
-                scored_segments,
-                if decision.should_store {
-                    Some(input_text.clone())
-                } else {
-                    None
-                }, // Temporary clone for compose drops
-                &compose_config,
-                store_for_compose,
-                &input_text,
-                &c,
-            );
+        crate::pipeline::composer::evaluate_learning(
+            &c,
+            &input_text,
+            scored_segments.len(),
+            d_count,
+            command_name.unwrap_or(""),
+        );
 
-            (out, format!("{:?}", c), c, r_hash, k_count, d_count)
-        };
+        let mut r_hash = None;
+        if decision.should_store
+            && let Some(s) = store
+        {
+            let hash = s.store_rewind(&input_text);
+            out.push_str(&format!(
+                "\n{} {} {} {} lines. The hash {} stores the full output in RewindStore for retrieval.\n",
+                "⏺".cyan(),
+                "OMNI".bold().bright_white(),
+                "distilled".bright_green(),
+                d_count,
+                hash.cyan().bold()
+            ));
+            r_hash = Some(hash);
+        }
+
+        if out.len() > compose_config.max_output_chars {
+            out.truncate(compose_config.max_output_chars);
+            out.push_str("\n[OMNI: output truncated]\n");
+        }
+
+        (out, format!("{:?}", c), c, r_hash, k_count, d_count)
+    };
 
     PipelineResult {
         session_id,

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -115,7 +115,7 @@ pub fn process_payload(
         (output, fname, None)
     } else {
         // Fallback to Rust distiller pipeline
-        let ctype = classifier::classify(&content);
+        let ctype = classifier::classify(&content, Some(&command));
 
         // Pre-processing: collapse repetitive lines before scoring
         let collapse_result = collapse::collapse(&content, &ctype);
@@ -158,28 +158,35 @@ pub fn process_payload(
 
         let decision = composer::decide_rewind(&scored_segments, ctype);
 
-        if decision.should_store {
-            if let Some(ref s) = store {
-                let hash = s.store_rewind(&content);
-                let dropped_lines = scored_segments
-                    .iter()
-                    .filter(|s| s.final_score() < decision.threshold)
-                    .map(|s| s.content.lines().count())
-                    .sum::<usize>();
+        let dropped_lines = scored_segments
+            .iter()
+            .filter(|s| s.final_score() < decision.threshold)
+            .map(|s| s.content.lines().count())
+            .sum::<usize>();
 
-                final_out.push_str(&format!(
-                    "\n[OMNI: {} lines omitted — omni_retrieve(\"{}\") for full output]",
-                    dropped_lines, hash
-                ));
-                rewind_hash = hash;
-            } else {
-                let dropped_lines = scored_segments
-                    .iter()
-                    .filter(|s| s.final_score() < decision.threshold)
-                    .map(|s| s.content.lines().count())
-                    .sum::<usize>();
-                final_out.push_str(&format!("\n[OMNI: {} lines omitted]", dropped_lines));
-            }
+        // Trigger Auto-Learn
+        crate::pipeline::composer::evaluate_learning(
+            ctype,
+            &content,
+            scored_segments.len(),
+            scored_segments
+                .iter()
+                .filter(|s| s.final_score() < decision.threshold)
+                .count(),
+            &command,
+        );
+
+        if decision.should_store
+            && let Some(ref s) = store
+        {
+            let hash = s.store_rewind(&content);
+            final_out.push_str(&format!(
+                "\n[OMNI: {} lines omitted — omni_retrieve(\"{}\") for full output]",
+                dropped_lines, hash
+            ));
+            rewind_hash = hash;
+        } else if decision.should_store {
+            final_out.push_str(&format!("\n[OMNI: {} lines omitted]", dropped_lines));
         }
 
         // Update session state (only for Rust pipeline)
@@ -241,6 +248,13 @@ pub fn process_payload(
             let tracker = crate::session::tracker::SessionTracker::new(sess.clone(), s.clone());
             tracker.track_command(&command, &content, &result);
         }
+    }
+
+    // Safety Truncation
+    let max_chars = composer::ComposeConfig::default().max_output_chars;
+    if final_out.len() > max_chars {
+        final_out.truncate(max_chars);
+        final_out.push_str("\n[OMNI: output truncated]");
     }
 
     serde_json::to_string(&HookOutput {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -98,7 +98,7 @@ impl OmniServer {
         description = "Measure how much signal vs noise in text"
     )]
     pub async fn omni_density(&self, #[tool(param)] text: String) -> String {
-        let content_type = classify(&text);
+        let content_type = classify(&text, None);
         let current_session = self.session.lock().unwrap().clone();
 
         let segments = score_segments(&text, &content_type, Some(&current_session));

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -63,12 +63,12 @@ impl OmniServer {
         // 3. If apply=true: write to ~/.omni/filters/learned.toml
         if apply {
             let filter_name = format!("learned_{}", chrono::Utc::now().timestamp());
-            let _toml_content = generate_toml(&candidates, &filter_name);
+            let _toml_content = generate_toml(&candidates, &filter_name, None);
 
             let config_path = crate::paths::learned_filters_path();
             let _ = crate::paths::ensure_omni_home();
 
-            match apply_to_config(&candidates, &filter_name, &config_path) {
+            match apply_to_config(&candidates, &filter_name, &config_path, None) {
                 Ok(added) => {
                     report.push_str(&format!(
                         "\n✓ Applied {} filters to {}\n  Run: omni doctor to verify",

--- a/src/pipeline/classifier.rs
+++ b/src/pipeline/classifier.rs
@@ -16,56 +16,57 @@ lazy_static! {
 }
 
 pub fn classify(input: &str, command_name: Option<&str>) -> ContentType {
-    // Stage 1 restrictions: Only check first 50 lines max for speed
-    let mut lines_iter = input.lines().take(50).peekable();
-    if lines_iter.peek().is_none() {
-        return ContentType::Unknown;
-    }
+    // Stage 0: Pre-Stage: Command-Aware Heuristics
+    // Moved to top so re-classification works even if input is empty
+    if let Some(command_name) = command_name {
+        let cmd_low = command_name.to_lowercase();
+        let cmd_full = cmd_low.split_whitespace().next().unwrap_or(&cmd_low);
 
-    let trimmed = input.trim();
-    if (trimmed.starts_with('{') && trimmed.ends_with('}'))
-        || (trimmed.starts_with('[') && trimmed.ends_with(']'))
-    {
-        return ContentType::StructuredData;
-    }
+        // Handle absolute paths (e.g., /usr/bin/git -> git)
+        let cmd_base = std::path::Path::new(cmd_full)
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or(cmd_full);
 
-    let lines: Vec<&str> = lines_iter.collect();
-
-    // 0. Pre-Stage: Command-Aware Heuristics
-    if let Some(cmd) = command_name {
-        let cmd_low = cmd.to_lowercase();
-
-        // Git branch / checkout
-        if (cmd_low.contains("git branch") || cmd_low.contains("git checkout"))
-            && lines.iter().any(|l| RE_GIT_BRANCH_LIST.is_match(l))
-        {
-            return ContentType::GitStatus;
-        }
-
-        // Git diff --stat
-        if cmd_low.contains("git diff")
-            && cmd_low.contains("--stat")
-            && lines.iter().any(|l| RE_GIT_DIFF_STAT.is_match(l))
-        {
-            return ContentType::GitStatus; // Grouped with status/metadata
-        }
-
-        // Generic Git catch-all
-        if cmd_low.starts_with("git ") {
-            let git_keywords = ["On branch", "Changes", "Untracked", "commit", "Author:"];
-            if lines
-                .iter()
-                .any(|l| git_keywords.iter().any(|k| l.contains(k)))
-            {
-                return ContentType::GitStatus;
+        // Subcommand awareness for Git
+        if cmd_base == "git" {
+            let parts: Vec<&str> = cmd_low.split_whitespace().collect();
+            if parts.len() > 1 {
+                let sub = parts[1];
+                // Status & Metadata (Branch, Tag, etc.)
+                if [
+                    "status",
+                    "branch",
+                    "tag",
+                    "remote",
+                    "show-ref",
+                    "rev-parse",
+                    "symbolic-ref",
+                    "checkout",
+                    "stash",
+                    "config",
+                ]
+                .contains(&sub)
+                {
+                    return ContentType::GitStatus;
+                }
+                // Diffs
+                if ["diff", "show", "whatchanged"].contains(&sub) {
+                    // git diff --stat is metadata
+                    if cmd_low.contains("--stat") {
+                        return ContentType::GitStatus;
+                    }
+                    return ContentType::GitDiff;
+                }
+                // Logs
+                if ["log", "shortlog", "reflog"].contains(&sub) {
+                    return ContentType::GitLog;
+                }
             }
         }
 
-        // =========================================================
-        // SystemOps Bias (Operations, Exploration, Networking, etc.)
-        // =========================================================
+        // Broad SystemOps Bias
         let sys_cmds = [
-            // File & Directory
             "ls",
             "tree",
             "pwd",
@@ -79,14 +80,12 @@ pub fn classify(input: &str, command_name: Option<&str>) -> ContentType {
             "ln",
             "stat",
             "file",
-            // File Viewing / Reading
             "cat",
             "less",
             "more",
             "head",
             "tail",
             "nl",
-            // Text Processing / Parsing
             "grep",
             "egrep",
             "fgrep",
@@ -99,12 +98,10 @@ pub fn classify(input: &str, command_name: Option<&str>) -> ContentType {
             "wc",
             "tr",
             "xargs",
-            // Search
             "find",
             "locate",
             "which",
             "whereis",
-            // System Info
             "ps",
             "top",
             "htop",
@@ -114,7 +111,6 @@ pub fn classify(input: &str, command_name: Option<&str>) -> ContentType {
             "du",
             "uname",
             "hostname",
-            // Process Control
             "kill",
             "killall",
             "pkill",
@@ -125,21 +121,18 @@ pub fn classify(input: &str, command_name: Option<&str>) -> ContentType {
             "nice",
             "renice",
             "watch",
-            // Users / Permissions
             "whoami",
             "who",
             "id",
             "chmod",
             "chown",
             "groups",
-            // Environment
             "env",
             "printenv",
             "export",
             "unset",
             "alias",
             "source",
-            // Networking
             "ifconfig",
             "ip",
             "netstat",
@@ -155,18 +148,15 @@ pub fn classify(input: &str, command_name: Option<&str>) -> ContentType {
             "whois",
             "nc",
             "telnet",
-            // Archive / Compression
             "tar",
             "gzip",
             "gunzip",
             "zip",
             "unzip",
-            // Disk / Hardware
             "mount",
             "umount",
             "lsblk",
             "blkid",
-            // Package Managers
             "apt",
             "apt-get",
             "yum",
@@ -174,7 +164,6 @@ pub fn classify(input: &str, command_name: Option<&str>) -> ContentType {
             "pacman",
             "snap",
             "brew",
-            // Misc Utilities
             "clear",
             "reset",
             "time",
@@ -182,25 +171,20 @@ pub fn classify(input: &str, command_name: Option<&str>) -> ContentType {
             "sleep",
             "history",
         ];
-        if sys_cmds.iter().any(|&sc| cmd_low.starts_with(sc)) {
+        if sys_cmds.contains(&cmd_base) || sys_cmds.iter().any(|&sc| cmd_low.starts_with(sc)) {
             return ContentType::SystemOps;
         }
 
-        // =========================================================
-        // Build & Dev Bias (Compiler, Runtimes, Build Tools)
-        // =========================================================
+        // Build Tools Bias
         let build_cmds = [
             "make", "cmake", "cargo", "rustc", "go", "python", "python3", "pip", "pip3", "java",
-            "javac", "gcc", "g++", "clang",
+            "javac", "gcc", "g++", "clang", "gcc", "g++",
         ];
-        if build_cmds.iter().any(|&bc| cmd_low.starts_with(bc)) {
-            // Bias towards BuildOutput but let Stage 4 do heavy lifting if needed
+        if build_cmds.contains(&cmd_base) || build_cmds.iter().any(|&bc| cmd_low.starts_with(bc)) {
             return ContentType::BuildOutput;
         }
 
-        // =========================================================
-        // Web & JS/TS Bias
-        // =========================================================
+        // Web Tools Bias
         let web_cmds = [
             "node",
             "npm",
@@ -211,11 +195,44 @@ pub fn classify(input: &str, command_name: Option<&str>) -> ContentType {
             "playwright",
             "tsc",
             "eslint",
+            "prettier",
+            "esbuild",
+            "vite",
         ];
-        if web_cmds.iter().any(|&wc| cmd_low.starts_with(wc)) {
+        if web_cmds.contains(&cmd_base) || web_cmds.iter().any(|&wc| cmd_low.starts_with(wc)) {
             return ContentType::JsTs;
         }
+
+        // Cloud & Infra Bias
+        let cloud_cmds = [
+            "docker",
+            "kubectl",
+            "terraform",
+            "helm",
+            "aws",
+            "gcloud",
+            "az",
+            "doctl",
+        ];
+        if cloud_cmds.contains(&cmd_base) || cloud_cmds.iter().any(|&cc| cmd_low.starts_with(cc)) {
+            return ContentType::Cloud;
+        }
     }
+
+    // Stage 1 restrictions: Only check first 50 lines max for speed
+    let mut lines_iter = input.lines().take(50).peekable();
+    if lines_iter.peek().is_none() {
+        return ContentType::Unknown;
+    }
+
+    let trimmed = input.trim();
+    if (trimmed.starts_with('{') && trimmed.ends_with('}'))
+        || (trimmed.starts_with('[') && trimmed.ends_with(']'))
+    {
+        return ContentType::StructuredData;
+    }
+
+    let lines: Vec<&str> = lines_iter.collect();
 
     // 1. GitDiff
     if let Some(&first) = lines.first() {

--- a/src/pipeline/classifier.rs
+++ b/src/pipeline/classifier.rs
@@ -10,9 +10,12 @@ lazy_static! {
     static ref RE_LOG_SEV: Regex =
         Regex::new(r"(?i)\[?(INFO|ERROR|WARN|WARNING|DEBUG|FATAL)\]?[:\s]").unwrap();
     static ref RE_TABULAR_SPACES: Regex = Regex::new(r" {2,}").unwrap();
+    static ref RE_GIT_DIFF_STAT: Regex =
+        Regex::new(r"\d+ files? changed, \d+ insertions?\(\+\), \d+ deletions?\(-\)").unwrap();
+    static ref RE_GIT_BRANCH_LIST: Regex = Regex::new(r"^\*? +[a-zA-Z0-9/_.-]+").unwrap();
 }
 
-pub fn classify(input: &str) -> ContentType {
+pub fn classify(input: &str, command_name: Option<&str>) -> ContentType {
     // Stage 1 restrictions: Only check first 50 lines max for speed
     let mut lines_iter = input.lines().take(50).peekable();
     if lines_iter.peek().is_none() {
@@ -27,6 +30,192 @@ pub fn classify(input: &str) -> ContentType {
     }
 
     let lines: Vec<&str> = lines_iter.collect();
+
+    // 0. Pre-Stage: Command-Aware Heuristics
+    if let Some(cmd) = command_name {
+        let cmd_low = cmd.to_lowercase();
+
+        // Git branch / checkout
+        if (cmd_low.contains("git branch") || cmd_low.contains("git checkout"))
+            && lines.iter().any(|l| RE_GIT_BRANCH_LIST.is_match(l))
+        {
+            return ContentType::GitStatus;
+        }
+
+        // Git diff --stat
+        if cmd_low.contains("git diff")
+            && cmd_low.contains("--stat")
+            && lines.iter().any(|l| RE_GIT_DIFF_STAT.is_match(l))
+        {
+            return ContentType::GitStatus; // Grouped with status/metadata
+        }
+
+        // Generic Git catch-all
+        if cmd_low.starts_with("git ") {
+            let git_keywords = ["On branch", "Changes", "Untracked", "commit", "Author:"];
+            if lines
+                .iter()
+                .any(|l| git_keywords.iter().any(|k| l.contains(k)))
+            {
+                return ContentType::GitStatus;
+            }
+        }
+
+        // =========================================================
+        // SystemOps Bias (Operations, Exploration, Networking, etc.)
+        // =========================================================
+        let sys_cmds = [
+            // File & Directory
+            "ls",
+            "tree",
+            "pwd",
+            "cd",
+            "cp",
+            "mv",
+            "rm",
+            "mkdir",
+            "rmdir",
+            "touch",
+            "ln",
+            "stat",
+            "file",
+            // File Viewing / Reading
+            "cat",
+            "less",
+            "more",
+            "head",
+            "tail",
+            "nl",
+            // Text Processing / Parsing
+            "grep",
+            "egrep",
+            "fgrep",
+            "rg",
+            "awk",
+            "sed",
+            "cut",
+            "sort",
+            "uniq",
+            "wc",
+            "tr",
+            "xargs",
+            // Search
+            "find",
+            "locate",
+            "which",
+            "whereis",
+            // System Info
+            "ps",
+            "top",
+            "htop",
+            "free",
+            "uptime",
+            "df",
+            "du",
+            "uname",
+            "hostname",
+            // Process Control
+            "kill",
+            "killall",
+            "pkill",
+            "bg",
+            "fg",
+            "jobs",
+            "nohup",
+            "nice",
+            "renice",
+            "watch",
+            // Users / Permissions
+            "whoami",
+            "who",
+            "id",
+            "chmod",
+            "chown",
+            "groups",
+            // Environment
+            "env",
+            "printenv",
+            "export",
+            "unset",
+            "alias",
+            "source",
+            // Networking
+            "ifconfig",
+            "ip",
+            "netstat",
+            "ss",
+            "lsof",
+            "ping",
+            "traceroute",
+            "curl",
+            "wget",
+            "dig",
+            "nslookup",
+            "host",
+            "whois",
+            "nc",
+            "telnet",
+            // Archive / Compression
+            "tar",
+            "gzip",
+            "gunzip",
+            "zip",
+            "unzip",
+            // Disk / Hardware
+            "mount",
+            "umount",
+            "lsblk",
+            "blkid",
+            // Package Managers
+            "apt",
+            "apt-get",
+            "yum",
+            "dnf",
+            "pacman",
+            "snap",
+            "brew",
+            // Misc Utilities
+            "clear",
+            "reset",
+            "time",
+            "date",
+            "sleep",
+            "history",
+        ];
+        if sys_cmds.iter().any(|&sc| cmd_low.starts_with(sc)) {
+            return ContentType::SystemOps;
+        }
+
+        // =========================================================
+        // Build & Dev Bias (Compiler, Runtimes, Build Tools)
+        // =========================================================
+        let build_cmds = [
+            "make", "cmake", "cargo", "rustc", "go", "python", "python3", "pip", "pip3", "java",
+            "javac", "gcc", "g++", "clang",
+        ];
+        if build_cmds.iter().any(|&bc| cmd_low.starts_with(bc)) {
+            // Bias towards BuildOutput but let Stage 4 do heavy lifting if needed
+            return ContentType::BuildOutput;
+        }
+
+        // =========================================================
+        // Web & JS/TS Bias
+        // =========================================================
+        let web_cmds = [
+            "node",
+            "npm",
+            "npx",
+            "yarn",
+            "pnpm",
+            "vitest",
+            "playwright",
+            "tsc",
+            "eslint",
+        ];
+        if web_cmds.iter().any(|&wc| cmd_low.starts_with(wc)) {
+            return ContentType::JsTs;
+        }
+    }
 
     // 1. GitDiff
     if let Some(&first) = lines.first() {
@@ -300,110 +489,126 @@ mod tests {
     #[test]
     fn test_classify_git_diff_output() {
         let input = "diff --git a/src/main.rs b/src/main.rs\nindex 123..456 100644\n--- a/src/main.rs\n+++ b/src/main.rs";
-        assert_eq!(classify(input), ContentType::GitDiff);
+        assert_eq!(classify(input, None), ContentType::GitDiff);
 
         let patch = "@@ -1,5 +1,6 @@\n fn main() {}";
-        assert_eq!(classify(patch), ContentType::GitDiff);
+        assert_eq!(classify(patch, None), ContentType::GitDiff);
     }
 
     #[test]
     fn test_classify_git_status_dirty() {
         let input =
             "On branch feature/omni\nChanges not staged for commit:\n  modified:   src/main.rs";
-        assert_eq!(classify(input), ContentType::GitStatus);
+        assert_eq!(classify(input, None), ContentType::GitStatus);
+    }
+
+    #[test]
+    fn test_classify_git_branch_command_aware() {
+        let input = "  main\n* feature/omni\n  develop";
+        // Without command context, this might be Unknown or TabularData
+        assert_eq!(classify(input, Some("git branch")), ContentType::GitStatus);
+    }
+
+    #[test]
+    fn test_classify_git_diff_stat_command_aware() {
+        let input = " src/main.rs | 10 +++++++++-\n README.md   |  2 +-\n 2 files changed, 10 insertions(+), 2 deletions(-)";
+        assert_eq!(
+            classify(input, Some("git diff --stat")),
+            ContentType::GitStatus
+        );
     }
 
     #[test]
     fn test_classify_git_log() {
         let input = "commit 3e51feb6f039a4a4ef493ea4a4ef493ea4a4ef49\nAuthor: John\nDate: Mon";
-        assert_eq!(classify(input), ContentType::GitLog);
+        assert_eq!(classify(input, None), ContentType::GitLog);
 
         let short = "3e51feb Fix bug\na4a4ef4 Add feature\n3e51feb Fix bug\na4a4ef4 Add feature\n3e51feb Fix bug";
-        assert_eq!(classify(short), ContentType::GitLog);
+        assert_eq!(classify(short, None), ContentType::GitLog);
     }
 
     #[test]
     fn test_classify_cargo_build_with_errors() {
         let rust_err = "error[E0432]: unresolved import `std::collections`\n  --> src/main.rs:1:5";
-        assert_eq!(classify(rust_err), ContentType::BuildOutput);
+        assert_eq!(classify(rust_err, None), ContentType::BuildOutput);
 
         let building = "Compiling omni v0.5.0\nFinished `dev` profile";
-        assert_eq!(classify(building), ContentType::BuildOutput);
+        assert_eq!(classify(building, None), ContentType::BuildOutput);
     }
 
     #[test]
     fn test_classify_pytest_output_with_failures() {
         let py = "================ test session starts ================\npytest 7.0.1\nFAILED tests/test_core.py";
-        assert_eq!(classify(py), ContentType::TestOutput);
+        assert_eq!(classify(py, None), ContentType::TestOutput);
 
         let cargo_test = "running 15 tests\ntest foo ... ok\ntest result: ok. 15 passed";
-        assert_eq!(classify(cargo_test), ContentType::TestOutput);
+        assert_eq!(classify(cargo_test, None), ContentType::TestOutput);
 
         let cargo_test_diff = "running 1 test\ntest my_test ... FAILED\n\nfailures:\n\n---- my_test stdout ----\nthread 'my_test' panicked at ...\n@@ -1,5 +1,6 @@\n+ foo\n- bar";
-        assert_eq!(classify(cargo_test_diff), ContentType::TestOutput);
+        assert_eq!(classify(cargo_test_diff, None), ContentType::TestOutput);
     }
 
     #[test]
     fn test_classify_go_test_output() {
         let go_test =
             "ok  \tgithub.com/user/pkg1\t0.123s\nFAIL\tgithub.com/user/pkg2\t0.456s\nFAIL";
-        assert_eq!(classify(go_test), ContentType::TestOutput);
+        assert_eq!(classify(go_test, None), ContentType::TestOutput);
 
         let go_fail = "FAIL\tgithub.com/user/pkg\t0.123s";
-        assert_eq!(classify(go_fail), ContentType::TestOutput);
+        assert_eq!(classify(go_fail, None), ContentType::TestOutput);
     }
 
     #[test]
     fn test_classify_kubectl_get_pods() {
         let kube = "NAME                               READY   STATUS    RESTARTS   AGE\nnginx-deployment-7fb96c846b-f4jnm   1/1     Running   0          5d";
-        assert_eq!(classify(kube), ContentType::Cloud); // Kubectl specific is now Cloud
+        assert_eq!(classify(kube, None), ContentType::Cloud); // Kubectl specific is now Cloud
     }
 
     #[test]
     fn test_classify_docker_build_output() {
         let docker =
             "Step 1/5 : FROM alpine:latest\n ---> 49f356fa4eb1\nStep 2/5 : RUN apk add curl";
-        assert_eq!(classify(docker), ContentType::InfraOutput); // Still infra output right now
+        assert_eq!(classify(docker, None), ContentType::InfraOutput); // Still infra output right now
 
         let terra = "Terraform will perform the following actions:";
-        assert_eq!(classify(terra), ContentType::InfraOutput);
+        assert_eq!(classify(terra, None), ContentType::InfraOutput);
     }
 
     #[test]
     fn test_classify_nginx_access_log() {
         let access = "127.0.0.1 - - [10/Oct/2000:13:55:36 -0700] \"GET /apache_pb.gif HTTP/1.0\" 200 2326\n127.0.0.1 - - [10/Oct/2000:14:55:36 -0700]";
-        assert_eq!(classify(access), ContentType::LogOutput); // Contains date pattern
+        assert_eq!(classify(access, None), ContentType::LogOutput); // Contains date pattern
 
         let app_log = "[INFO] Starting application server...\n[ERROR] Failed to bind port 8080";
-        assert_eq!(classify(app_log), ContentType::LogOutput);
+        assert_eq!(classify(app_log, None), ContentType::LogOutput);
     }
 
     #[test]
     fn test_classify_tabular_data() {
         let table = "Header1      Header2      Header3\nRow1Val1     Row1Val2     Row1Val3\nRow2Val1     Row2Val2     Row2Val3";
-        assert_eq!(classify(table), ContentType::TabularData);
+        assert_eq!(classify(table, None), ContentType::TabularData);
     }
 
     #[test]
     fn test_classify_json_output() {
         let obj = "{\n  \"status\": \"ok\",\n  \"data\": []\n}";
-        assert_eq!(classify(obj), ContentType::StructuredData);
+        assert_eq!(classify(obj, None), ContentType::StructuredData);
 
         let arr = "[\n  1,\n  2,\n  3\n]";
-        assert_eq!(classify(arr), ContentType::StructuredData);
+        assert_eq!(classify(arr, None), ContentType::StructuredData);
     }
 
     #[test]
     fn test_classify_unknown_random_text() {
         let text = "Did you hear the tragedy of Darth Plagueis The Wise?\nI thought not.\nIt's not a story the Jedi would tell you.";
-        assert_eq!(classify(text), ContentType::Unknown);
+        assert_eq!(classify(text, None), ContentType::Unknown);
     }
 
     #[test]
     fn test_classify_short_output_to_unknown() {
         let short = "foo";
         // It should match Unknown, unless it looks like structured data e.g. "{}".
-        assert_eq!(classify(short), ContentType::Unknown);
+        assert_eq!(classify(short, None), ContentType::Unknown);
     }
 
     #[test]
@@ -413,7 +618,7 @@ mod tests {
         let start = Instant::now();
         let iters = 10_000;
         for _ in 0..iters {
-            std::hint::black_box(classify(&input));
+            std::hint::black_box(classify(&input, None));
         }
         let elapsed_us = start.elapsed().as_micros();
         let per_iter_us = elapsed_us / iters;
@@ -437,7 +642,7 @@ mod tests {
         let start = Instant::now();
         let iters = 1_000;
         for _ in 0..iters {
-            std::hint::black_box(classify(&input));
+            std::hint::black_box(classify(&input, None));
         }
         let elapsed_us = start.elapsed().as_micros();
         let per_iter_us = elapsed_us / iters;

--- a/src/pipeline/composer.rs
+++ b/src/pipeline/composer.rs
@@ -1,6 +1,5 @@
 use crate::pipeline::{ContentType, OutputSegment};
 use crate::store::sqlite::Store;
-use colored::Colorize;
 use std::sync::Arc;
 
 pub struct RewindDecision {
@@ -36,264 +35,31 @@ impl Default for ComposeConfig {
     }
 }
 
-pub fn compose(
-    segments: Vec<OutputSegment>,
-    dropped_content: Option<String>,
-    config: &ComposeConfig,
-    store: Option<&Store>,
-    // Metadata hooks for learn logics
-    original_text: &str,
+pub fn evaluate_learning(
     route: &ContentType,
-) -> (String, Option<String>) {
-    if segments.is_empty() && !original_text.is_empty() {
-        return ("".to_string(), None); // Fully dropped
+    original_text: &str,
+    input_lines_count: usize,
+    dropped_lines_count: usize,
+    command: &str,
+) {
+    if original_text.len() < 100 || matches!(route, ContentType::StructuredData) {
+        return;
     }
 
-    // Auto-Learn execution:
-    // Trigger learning if:
-    // 1. ContentType is Unknown
-    // 2. OR Distillation was poor (less than 30% of lines dropped) for a large enough output.
-    // This captures cases like Podman which might be classified as InfraOutput but have no matching filters.
-    let total_lines = segments.len();
-    let dropped_lines_count = segments
-        .iter()
-        .filter(|s| s.final_score() < config.threshold)
-        .count();
+    let poor_distillation = input_lines_count > 5
+        && (dropped_lines_count as f32 / input_lines_count.max(1) as f32) < 0.3;
 
-    let poor_distillation =
-        total_lines > 5 && (dropped_lines_count as f32 / total_lines.max(1) as f32) < 0.3;
-
-    if (matches!(route, ContentType::Unknown) || poor_distillation)
-        && original_text.len() > 100
-        && !matches!(route, ContentType::StructuredData)
-    {
-        crate::session::learn::queue_for_learn(
-            original_text,
-            &format!("omni_eval_{:?}", route).to_lowercase(),
-        );
-    }
-
-    let mut kept_ordered: Vec<&OutputSegment> = segments
-        .iter()
-        .filter(|s| s.final_score() >= config.threshold)
-        .collect();
-
-    let dropped_count = segments.len() - kept_ordered.len();
-    let dropped_lines: usize = segments
-        .iter()
-        .filter(|s| s.final_score() < config.threshold)
-        .map(|s| s.content.lines().count())
-        .sum();
-
-    // Preserve original line order for coherent output structures
-    kept_ordered.sort_by_key(|s| s.line_range.0);
-
-    let mut output = String::new();
-    for segment in &kept_ordered {
-        output.push_str(&segment.content);
-        if !segment.content.ends_with('\n') {
-            output.push('\n');
-        }
-    }
-
-    let mut rewind_hash = None;
-
-    if dropped_count > 0
-        && let Some(content) = dropped_content
-    {
-        if let Some(s) = store {
-            let hash = s.store_rewind(&content);
-            let reduction = (dropped_lines as f32 / total_lines.max(1) as f32) * 100.0;
-
-            output.push_str(&format!(
-                "\n{} {} {} {} lines to an optimized state ({}% reduction). The hash {} stores the full output in RewindStore for retrieval.\n",
-                "⏺".cyan(),
-                "OMNI".bold().bright_white(),
-                "distilled".bright_green(),
-                dropped_lines.to_string().bold(),
-                format!("{:.1}", reduction).yellow(),
-                hash.cyan().bold()
-            ));
-            rewind_hash = Some(hash);
+    if matches!(route, ContentType::Unknown) || poor_distillation {
+        let category = if command.is_empty() {
+            format!("omni_eval_{:?}", route).to_lowercase()
         } else {
-            output.push_str(&format!(
-                "\n{} {} {} lines omitted for efficiency.\n",
-                "⏺".cyan(),
-                "OMNI:".bold().bright_white(),
-                dropped_lines
-            ));
-        }
+            command.to_string()
+        };
+        crate::session::learn::queue_for_learn(original_text, &category);
     }
-
-    if output.len() > config.max_output_chars {
-        output.truncate(config.max_output_chars);
-        output.push_str("\n[OMNI: output truncated]\n");
-    }
-
-    (output, rewind_hash)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::pipeline::SignalTier;
-    use tempfile::tempdir;
-
-    fn create_segment(
-        content: &str,
-        tier: SignalTier,
-        base_score: f32,
-        line: usize,
-    ) -> OutputSegment {
-        OutputSegment {
-            content: content.to_string(),
-            tier,
-            base_score,
-            context_score: 0.0,
-            line_range: (line, line),
-        }
-    }
-
-    #[test]
-    fn test_compose_keeps_critical_segments() {
-        let segments = vec![
-            create_segment("error: bad failure", SignalTier::Critical, 0.9, 1),
-            create_segment("compiling lib", SignalTier::Noise, 0.05, 2),
-            create_segment("warning: unused msg", SignalTier::Important, 0.7, 3),
-        ];
-
-        let config = ComposeConfig {
-            threshold: 0.3,
-            max_output_chars: 1000,
-            rewind_store: None,
-        };
-
-        let (out, hash) = compose(segments, None, &config, None, "", &ContentType::Unknown);
-        assert!(out.contains("error: bad failure"));
-        assert!(out.contains("warning: unused msg"));
-        assert!(!out.contains("compiling lib"));
-        assert_eq!(hash, None); // Hash None because dropped_content is None
-    }
-
-    #[test]
-    fn test_compose_drops_noise_segments_below_threshold() {
-        let segments = vec![
-            create_segment("A", SignalTier::Noise, 0.1, 1),
-            create_segment("B", SignalTier::Critical, 0.9, 2),
-            create_segment("C", SignalTier::Noise, 0.2, 3),
-        ];
-
-        let (out, _) = compose(
-            segments,
-            None,
-            &ComposeConfig::default(),
-            None,
-            "",
-            &ContentType::Unknown,
-        );
-        assert_eq!(out, "B\n");
-    }
-
-    #[test]
-    fn test_compose_adds_rewind_notice_when_content_dropped() {
-        let dir = tempdir().unwrap();
-        let db_path = dir.path().join("omni.db");
-        let store = Store::open_path(&db_path).unwrap();
-
-        let segments = vec![
-            create_segment("bad loop", SignalTier::Critical, 0.9, 1),
-            create_segment("ignored noise", SignalTier::Noise, 0.05, 2),
-        ];
-
-        let dropped = Some("ignored noise".to_string());
-        let (out, hash) = compose(
-            segments,
-            dropped,
-            &ComposeConfig::default(),
-            Some(&store),
-            "",
-            &ContentType::Unknown,
-        );
-
-        assert!(out.contains("bad loop"));
-        assert!(!out.contains("ignored noise")); // Not in main output
-        assert!(out.contains("distilled"));
-        assert!(out.contains("lines to an optimized state"));
-        assert!(hash.is_some());
-    }
-
-    #[test]
-    fn test_compose_preserves_original_line_order() {
-        let segments = vec![
-            create_segment("Critical 2", SignalTier::Critical, 0.9, 3),
-            create_segment("Critical 1", SignalTier::Important, 0.8, 1),
-        ];
-
-        let (out, _) = compose(
-            segments,
-            None,
-            &ComposeConfig::default(),
-            None,
-            "",
-            &ContentType::Unknown,
-        );
-        assert_eq!(out, "Critical 1\nCritical 2\n");
-    }
-
-    #[test]
-    fn test_compose_safety_truncation_at_max_output_chars() {
-        let content = "a".repeat(100);
-        let segments = vec![create_segment(&content, SignalTier::Critical, 0.9, 1)];
-
-        let config = ComposeConfig {
-            threshold: 0.3,
-            max_output_chars: 50,
-            rewind_store: None,
-        };
-
-        let (out, _) = compose(segments, None, &config, None, "", &ContentType::Unknown);
-        // Truncated to exactly 50 bytes + \n[OMNI: output truncated]\n
-        assert!(out.starts_with(&"a".repeat(50)));
-        assert!(out.contains("output truncated"));
-    }
-
-    #[test]
-    fn test_compose_dengan_empty_segments_returns_empty() {
-        let (out, _) = compose(
-            vec![],
-            None,
-            &ComposeConfig::default(),
-            None,
-            "",
-            &ContentType::Unknown,
-        );
-        assert_eq!(out, "");
-    }
-
-    #[test]
-    fn test_rewind_store_roundtrip_via_compose_retrieve() {
-        let dir = tempdir().unwrap();
-        let db_path = dir.path().join("omni.db");
-        let store = Store::open_path(&db_path).unwrap();
-
-        let segments = vec![
-            create_segment("error!", SignalTier::Critical, 0.9, 1),
-            create_segment("dropped detail", SignalTier::Noise, 0.1, 2),
-        ];
-
-        let dropped_str = "error!\ndropped detail";
-        let (_, hash_opt) = compose(
-            segments,
-            Some(dropped_str.to_string()),
-            &ComposeConfig::default(),
-            Some(&store),
-            "",
-            &ContentType::Unknown,
-        );
-
-        let hash = hash_opt.unwrap();
-        // Retrieve full payload back
-        let retrieved = store.retrieve_rewind(&hash).unwrap();
-        assert_eq!(retrieved, dropped_str);
-    }
+    // Tests specific to decide_rewind and evaluate_learning would go here
 }

--- a/src/session/learn.rs
+++ b/src/session/learn.rs
@@ -82,10 +82,23 @@ pub fn detect_patterns(input: &str) -> Vec<PatternCandidate> {
     candidates.into_iter().take(16).collect()
 }
 
-pub fn generate_toml(candidates: &[PatternCandidate], filter_name: &str) -> String {
+pub fn generate_toml(
+    candidates: &[PatternCandidate],
+    filter_name: &str,
+    command: Option<&str>,
+) -> String {
     let mut toml = format!("\n[filters.{}]\n", filter_name);
-    toml.push_str("description = \"Auto-learned filter\"\n");
-    toml.push_str(&format!("match_command = \"{}.*\"\n", filter_name));
+    toml.push_str(&format!(
+        "description = \"Auto-learned filter for {}\"\n",
+        command.unwrap_or("general output")
+    ));
+
+    if let Some(cmd) = command {
+        // Create a simple prefix-based match for the command
+        let cmd_base = cmd.split_whitespace().next().unwrap_or(cmd);
+        toml.push_str(&format!("match_command = \"{}.*\"\n", cmd_base));
+    }
+
     toml.push_str("strip_ansi = true\n");
     toml.push_str("confidence = 0.85\n\n");
 
@@ -146,6 +159,7 @@ pub fn apply_to_config(
     candidates: &[PatternCandidate],
     filter_name: &str,
     config_path: &Path,
+    command: Option<&str>,
 ) -> anyhow::Result<usize> {
     if candidates.is_empty() {
         return Ok(0);
@@ -189,7 +203,7 @@ pub fn apply_to_config(
         return Ok(0);
     }
 
-    let generated = generate_toml(&new_candidates, filter_name);
+    let generated = generate_toml(&new_candidates, filter_name, command);
 
     if !config_path.exists() {
         if let Some(p) = config_path.parent() {
@@ -275,7 +289,7 @@ mod tests {
             confidence: 0.9,
             suggested_action: LearnAction::Strip,
         }];
-        let toml = generate_toml(&c, "gen_test");
+        let toml = generate_toml(&c, "gen_test", None);
         // schema_version is now handled by apply_to_config, not generation
         assert!(toml.contains("[filters.gen_test]"));
         assert!(toml.contains("\"^Test Prefix Gen\""));
@@ -291,7 +305,7 @@ mod tests {
             confidence: 0.9,
             suggested_action: LearnAction::Strip,
         }];
-        apply_to_config(&c, "dummy", file.path()).unwrap();
+        apply_to_config(&c, "dummy", file.path(), None).unwrap();
         let content = fs::read_to_string(file.path()).unwrap();
         assert!(content.contains("[filters.dummy]"));
     }

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -4,6 +4,7 @@ use sha2::{Digest, Sha256};
 use std::sync::Mutex;
 
 use crate::paths;
+use crate::pipeline::classifier::classify;
 use crate::pipeline::{DistillResult, SessionState};
 
 pub struct FilterStats {
@@ -531,6 +532,81 @@ impl Store {
         results
     }
 
+    pub fn reclassify_historical_data(&self) -> Result<usize> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT id, command, content_type FROM distillations 
+             WHERE (content_type = 'Unknown' OR content_type = 'TabularData') 
+             AND command != ''",
+        )?;
+
+        let rows = stmt.query_map([], |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+            ))
+        })?;
+
+        let mut updated_count = 0;
+        let mut updates = Vec::new();
+
+        for row in rows.flatten() {
+            let (id, command, old_filter) = row;
+            // Re-classify using only command context (input is empty)
+            let new_type = classify("", Some(&command));
+            let new_filter = format!("{:?}", new_type);
+
+            if new_filter != old_filter && new_filter != "Unknown" {
+                updates.push((id, new_filter));
+            }
+        }
+
+        // Apply updates in a transaction for efficiency
+        if !updates.is_empty() {
+            let mut update_stmt = conn.prepare(
+                "UPDATE distillations SET filter_name = ?1, content_type = ?1 WHERE id = ?2",
+            )?;
+            for (id, new_filter) in updates {
+                update_stmt.execute(params![new_filter, id])?;
+                updated_count += 1;
+            }
+        }
+
+        Ok(updated_count)
+    }
+
+    pub fn has_upgradable_history(&self) -> bool {
+        let conn = match self.conn.lock() {
+            Ok(c) => c,
+            Err(_) => return false,
+        };
+        let mut stmt = match conn.prepare(
+            "SELECT command, content_type FROM distillations 
+             WHERE (content_type = 'Unknown' OR content_type = 'TabularData') 
+             AND command != ''",
+        ) {
+            Ok(s) => s,
+            Err(_) => return false,
+        };
+
+        let mut rows = match stmt.query([]) {
+            Ok(r) => r,
+            Err(_) => return false,
+        };
+
+        while let Ok(Some(row)) = rows.next() {
+            let cmd: String = row.get(0).unwrap_or_default();
+            let old_type: String = row.get(1).unwrap_or_default();
+            let new_type = crate::pipeline::classifier::classify("", Some(&cmd));
+            let new_type_str = format!("{:?}", new_type);
+            if new_type_str != old_type && new_type_str != "Unknown" {
+                return true;
+            }
+        }
+        false
+    }
+
     pub fn get_summary(&self, since_secs: i64) -> Result<StoreSummary> {
         let conn = self.conn.lock().unwrap();
 
@@ -690,6 +766,7 @@ mod tests {
     fn test_open_creates_database_and_schema() {
         let dir = tempdir().unwrap();
         let db_path = dir.path().join("omni.db");
+
         let store = Store::open_path(&db_path).unwrap();
 
         let conn = store.conn.lock().unwrap();
@@ -878,5 +955,50 @@ mod tests {
         assert_eq!(summary.by_route.len(), 1);
         assert_eq!(summary.by_route[0].route, "Keep");
         assert_eq!(summary.by_route[0].count, 2);
+    }
+
+    #[test]
+    fn test_reclassify_historical_data() {
+        use crate::pipeline::ContentType;
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_path(&dir.path().join("omni.db")).unwrap();
+
+        // 1. Insert a record that WAS Unknown but SHOULD BE GitStatus
+        let res = DistillResult {
+            output: "".to_string(),
+            route: crate::pipeline::Route::Keep,
+            filter_name: "Unknown".to_string(), // Legacy label
+            content_type: ContentType::Unknown,
+            score: 0.0,
+            context_score: 0.0,
+            input_bytes: 100,
+            output_bytes: 50,
+            latency_ms: 0,
+            rewind_hash: None,
+            segments_kept: 0,
+            segments_dropped: 0,
+            collapse_savings: None,
+        };
+        store.record_distillation("s1", &res, "git status");
+
+        // 2. Verify it's Unknown initially
+        let _summary_pre = store.get_summary(3600).unwrap();
+        // Since get_summary uses 'command' if filter_name == '', and our record_distillation sets it...
+        // Wait, get_summary grp_name logic:
+        // CASE WHEN command != '' THEN command ELSE filter_name END as grp_name
+        // This is for the UI grouping. The actual content_type/filter_name is still recorded as 'Unknown'.
+
+        // 3. Run re-classification
+        let count = store.reclassify_historical_data().unwrap();
+        assert_eq!(count, 1);
+
+        // 4. Verify the database record itself
+        let conn = store.conn.lock().unwrap();
+        let final_filter: String = conn
+            .query_row("SELECT filter_name FROM distillations LIMIT 1", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(final_filter, "GitStatus");
     }
 }

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -607,8 +607,8 @@ impl Store {
             "SELECT content_type, COUNT(*),
                     CASE WHEN SUM(input_bytes)=0 THEN 0.0
                          ELSE ROUND(100.0*(1.0 - CAST(SUM(output_bytes) AS REAL)/SUM(input_bytes)),1) END,
-                    COALESCE(GROUP_CONCAT(DISTINCT command), '')
-             FROM distillations WHERE ts >= ?1 AND command != ''
+                    COALESCE(GROUP_CONCAT(DISTINCT CASE WHEN command != '' THEN command END), '[pipe]')
+             FROM distillations WHERE ts >= ?1
              GROUP BY content_type ORDER BY COUNT(*) DESC",
         )?;
         let rows = stmt

--- a/tests/savings_assertions.rs
+++ b/tests/savings_assertions.rs
@@ -3,10 +3,10 @@ use omni::distillers;
 ///
 /// This integration test runs the full pipeline (classify → score → compose) on real
 /// fixture files and asserts each achieves a minimum savings percentage.
-use omni::pipeline::{classifier, composer, scorer};
+use omni::pipeline::{classifier, scorer};
 use std::time::Instant;
 fn run_pipeline(input: &str) -> (usize, usize, f64) {
-    let ctype = classifier::classify(input);
+    let ctype = classifier::classify(input, None);
     let segments = scorer::score_segments(input, &ctype, None);
 
     // Use the actual distiller logic from post_tool.rs
@@ -123,7 +123,7 @@ fn test_pipeline_latency_under_50ms_debug() {
     let input = include_str!("../tests/fixtures/git_diff_multi_file.txt").repeat(3); // ~30KB input
 
     let start = Instant::now();
-    let ctype = classifier::classify(&input);
+    let ctype = classifier::classify(&input, None);
     let segments = scorer::score_segments(&input, &ctype, None);
     let distiller = distillers::get_distiller(&ctype);
     distiller.distill(&segments, &input, None);
@@ -142,7 +142,7 @@ fn test_classifier_latency_under_5ms_debug() {
 
     let start = Instant::now();
     for _ in 0..10 {
-        classifier::classify(&input);
+        classifier::classify(&input, None);
     }
     let elapsed = start.elapsed();
     let avg_ms = elapsed.as_millis() / 10;
@@ -159,11 +159,11 @@ fn test_hook_no_panic_on_large_input() {
     // Safety: 500KB input harus tidak crash
     let large = "error: cannot find type\n".repeat(20000);
 
-    let ctype = classifier::classify(&large);
+    let ctype = classifier::classify(&large, None);
     let segments = scorer::score_segments(&large, &ctype, None);
 
-    let config = composer::ComposeConfig::default();
-    let (output, _) = composer::compose(segments, None, &config, None, &large, &ctype);
+    let distiller = omni::distillers::get_distiller(&ctype);
+    let output = distiller.distill(&segments, &large, None);
 
     assert!(!output.is_empty());
 }

--- a/tests/security_tests.rs
+++ b/tests/security_tests.rs
@@ -1,12 +1,11 @@
 /// Security tests — verify OMNI does not introduce attack vectors.
-use omni::pipeline::{classifier, composer, scorer};
+use omni::pipeline::{classifier, scorer};
 
 fn run_pipeline(input: &str) -> String {
-    let ctype = classifier::classify(input);
+    let ctype = classifier::classify(input, None);
     let segments = scorer::score_segments(input, &ctype, None);
-    let config = composer::ComposeConfig::default();
-    let (output, _) = composer::compose(segments, None, &config, None, input, &ctype);
-    output
+    let distiller = omni::distillers::get_distiller(&ctype);
+    distiller.distill(&segments, input, None)
 }
 
 #[test]


### PR DESCRIPTION
## PR Auto Describe
## Summary
This PR delivers a major overhaul of omni's content processing pipeline, including command-aware content classification, historical data repair via `omni doctor`, pipeline refactoring, and CLI tooling improvements to boost detection accuracy and user experience.

---

## Key Changes
- **Command-Aware Content Classification**: Rewrote the core `classify` function to use command context for far more accurate content type detection, with built-in heuristics for git, system, build, web, and cloud commands.
- **Historical Stats Repair**: Added `omni doctor --fix` to reclassify outdated, mislabeled historical distillation records in the local SQLite store.
- **Pipeline Refactor**: Simplified hook and pipeline logic, replaced the legacy `compose` function with dedicated distillation and auto-learn evaluation code, added output truncation safety.
- **CLI & Tooling Updates**: Refined `omni stats` with better filtering and clearer messaging, updated `omni learn` to include command context in generated filters, reduced update check cache TTL to 4 hours.

---

## Detailed Breakdown
### Core Classification System
Rewrote `pipeline/classifier.rs` to add an optional `command_name` parameter to `classify()`, with pre-stage heuristics that extract the base command (e.g. `git` from `git status`) and route outputs to correct content types: git subcommands, system utilities, build tools, web/JS tools, and cloud tools. Updated all existing tests to use the new API, added new test cases for command-specific classification, and updated all benchmarks/tests to pass `None` as context where unavailable.

### Pipeline & Hook Logic
Refactored `hooks/pipe.rs` and `hooks/post_tool.rs` to pass command context to `classify()`, replaced legacy `compose` calls with direct distiller usage, added auto-learn evaluation via `evaluate_learning()`, and added output truncation safety checks. Split `composer.rs`'s `compose` function into a dedicated `evaluate_learning()` function for auto-learn triggers, removed the unused `colored` import, and deleted the legacy `compose` function entirely. Added properly formatted rewind store notifications in both hook files.

### Data Store & Doctor Command
Added `reclassify_historical_data()` and `has_upgradable_history()` to `sqlite.rs` to update old misclassified distillation records using their stored command context. Updated `cli/doctor.rs` to add an Intelligence Consistency check section: prompts users to run `--fix` to upgrade historical stats, or runs repairs automatically when the flag is present. Updated `stats.rs` to show a prompt to run `omni doctor --fix` when upgradable history exists, added filter flag support (--today/--week/--month/--all-commands) that defaults to detail mode, improved messaging for hidden zero-savings commands, and cleaned up default stats labeling.

### CLI Learn & MCP Server
Updated `cli/learn.rs` to pass command context to `generate_toml()` and `apply_to_config()`, so auto-generated filters include the triggering command as a `match_command` rule and better descriptions. Updated `mcp/server.rs` to use the new `classify()` API and pass None context, updated filter generation calls to match the new signature.

### Minor Updates
Reduced the update check cache TTL in `guard/update.rs` from 24 hours to 4 hours. Updated all test files (`savings_assertions.rs`, `security_tests.rs`) to use the new `classify()` API and replace legacy `compose` calls with direct distiller usage. Updated all benchmark calls in `benches/pipeline.rs` to pass the new command context parameter.

---

## Notes
- The command-aware classification drastically improves accuracy for tool-specific output (e.g. git diffs, cargo build logs, kubectl outputs) by using the original executed command as context.
- The historical reclassification fixes long-standing issues with mislabeled old stats records.

---

## Breaking Changes
1.  **`classifier::classify` API Break**: The function now requires an optional `command_name` parameter; all existing calls must be updated to pass `None` if no command context is available (e.g. `classifier::classify(input, None)`).
2.  **Removed `composer::compose` Function**: Direct calls to this legacy function will fail; use the distiller directly alongside `evaluate_learning()` for auto-learn logic.
3.  **Updated `generate_toml` and `apply_to_config` Signatures**: These functions now accept an optional `command` parameter; callers must add this argument (pass `None` if unused).