### PR TITLE
fix: Claude Code stats not recording — stdout fallback + snake_case alias + doctor sandbox detection

### DIFF
--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -103,20 +103,34 @@ pub fn run(args: &[String]) -> anyhow::Result<()> {
 
     println!("  {:<15} {}", "Binary:".bright_black(), version_info);
 
-    // 2. Config Dir
+    // 2. Config Dir (with actual write test for sandbox detection)
     let conf_dir = dirs::home_dir()
         .unwrap_or_else(|| PathBuf::from("."))
         .join(".omni");
-    if conf_dir.exists()
-        && fs::metadata(&conf_dir)
-            .map(|m| !m.permissions().readonly())
-            .unwrap_or(false)
-    {
-        println!(
-            "  {:<15} ~/.omni/ {}",
-            "Config dir:".bright_black(),
-            "[OK]".green().bold()
-        );
+    if conf_dir.exists() {
+        // Actual write test catches sandbox restrictions
+        let test_file = conf_dir.join(".write_test");
+        match fs::write(&test_file, "ok") {
+            Ok(_) => {
+                let _ = fs::remove_file(&test_file);
+                println!(
+                    "  {:<15} ~/.omni/ {}",
+                    "Config dir:".bright_black(),
+                    "[OK]".green().bold()
+                );
+            }
+            Err(_) => {
+                println!(
+                    "  {:<15} ~/.omni/ {}",
+                    "Config dir:".bright_black(),
+                    "[ERROR]".red().bold()
+                );
+                warnings.push(
+                    "Cannot write to ~/.omni/. If using Claude Code, add ~/.omni to sandbox.filesystem.allowWrite in ~/.claude/settings.json",
+                );
+                all_ok = false;
+            }
+        }
     } else {
         if fix_mode && fs::create_dir_all(&conf_dir).is_ok() {
             println!(
@@ -145,6 +159,25 @@ pub fn run(args: &[String]) -> anyhow::Result<()> {
                 sessions.to_string().yellow(),
                 "[OK]".green().bold()
             );
+
+            // DB write test (catches sandbox restrictions on the database itself)
+            if store.test_write() {
+                println!(
+                    "  {:<15} writable {}",
+                    "DB Write:".bright_black(),
+                    "[OK]".green().bold()
+                );
+            } else {
+                println!(
+                    "  {:<15} read-only {}",
+                    "DB Write:".bright_black(),
+                    "[ERROR]".red().bold()
+                );
+                warnings.push(
+                    "Database is read-only. Claude Code sandbox may be blocking writes to ~/.omni/omni.db. Add ~/.omni to sandbox.filesystem.allowWrite in ~/.claude/settings.json",
+                );
+                all_ok = false;
+            }
 
             if store.check_fts5() {
                 println!(

--- a/src/hooks/dispatcher.rs
+++ b/src/hooks/dispatcher.rs
@@ -8,7 +8,7 @@ use std::sync::{Arc, Mutex};
 
 #[derive(Deserialize)]
 struct HookPeeker {
-    #[serde(rename = "hookEventName")]
+    #[serde(rename = "hookEventName", alias = "hook_event_name")]
     hook_event_name: Option<String>,
 }
 

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -21,6 +21,8 @@ struct ToolInput {
 #[derive(Deserialize)]
 struct ToolResponse {
     content: Option<serde_json::Value>,
+    stdout: Option<String>,
+    stderr: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -62,6 +64,35 @@ fn extract_content(value: &serde_json::Value) -> Option<String> {
     None
 }
 
+/// Extracts content from tool_response, trying `content` first (Cursor, Windsurf)
+/// then falling back to `stdout`/`stderr` (Claude Code format).
+fn extract_tool_content(input: &HookInput) -> Option<String> {
+    let response = input.tool_response.as_ref()?;
+
+    // Try structured `content` field first
+    if let Some(ref val) = response.content
+        && let Some(s) = extract_content(val)
+    {
+        return Some(s);
+    }
+
+    // Fall back to stdout/stderr (Claude Code format)
+    if let Some(ref stdout) = response.stdout
+        && !stdout.is_empty()
+    {
+        let mut result = stdout.clone();
+        if let Some(ref stderr) = response.stderr
+            && !stderr.is_empty()
+        {
+            result.push_str("\n[stderr]\n");
+            result.push_str(stderr);
+        }
+        return Some(result);
+    }
+
+    None
+}
+
 pub fn process_payload(
     input_str: &str,
     store: Option<Arc<Store>>,
@@ -79,12 +110,7 @@ pub fn process_payload(
         return None;
     }
 
-    let raw_val = parsed
-        .tool_response
-        .as_ref()
-        .and_then(|r| r.content.as_ref())?;
-
-    let content = extract_content(raw_val)?;
+    let content = extract_tool_content(&parsed)?;
 
     if content.len() < 50 {
         return None;
@@ -356,5 +382,93 @@ mod tests {
         assert!(extracted.contains("hello"));
         assert!(extracted.contains("world world"));
         assert!(extracted.ends_with("!"));
+    }
+
+    #[test]
+    fn test_claude_code_stdout_format() {
+        let mut big_output =
+            "total 42\ndrwxr-xr-x  15 user  staff  480 Apr 10 10:00 .\n".to_string();
+        for i in 0..30 {
+            big_output.push_str(&format!(
+                "-rw-r--r--   1 user  staff  {} Apr 10 10:00 file{}.rs\n",
+                i * 100,
+                i
+            ));
+        }
+        let input = json!({
+            "tool_name": "Bash",
+            "tool_input": { "command": "ls -la" },
+            "tool_response": {
+                "stdout": big_output,
+                "stderr": "",
+                "interrupted": false,
+                "isImage": false,
+                "noOutputExpected": false
+            }
+        });
+        let out = process_payload(&input.to_string(), None, None);
+        assert!(out.is_some(), "Claude Code stdout format must be processed");
+        let res = out.expect("must succeed");
+        assert!(res.contains("PostToolUse"));
+    }
+
+    #[test]
+    fn test_claude_code_stdout_with_stderr() {
+        let mut big_output = String::new();
+        for i in 0..30 {
+            big_output.push_str(&format!("line {} of output\n", i));
+        }
+        let input = json!({
+            "tool_name": "Bash",
+            "tool_input": { "command": "cargo build" },
+            "tool_response": {
+                "stdout": big_output,
+                "stderr": "warning: unused variable",
+                "interrupted": false
+            }
+        });
+        let parsed: HookInput = serde_json::from_value(input).expect("must parse");
+        let content = extract_tool_content(&parsed).expect("must extract");
+        assert!(content.contains("line 0 of output"));
+        assert!(content.contains("[stderr]"));
+        assert!(content.contains("warning: unused variable"));
+    }
+
+    #[test]
+    fn test_claude_code_empty_stdout_ignored() {
+        let input = json!({
+            "tool_name": "Bash",
+            "tool_input": { "command": "true" },
+            "tool_response": {
+                "stdout": "",
+                "stderr": "",
+                "interrupted": false
+            }
+        });
+        let out = process_payload(&input.to_string(), None, None);
+        assert!(out.is_none(), "Empty stdout should exit early");
+    }
+
+    #[test]
+    fn test_content_field_still_preferred_over_stdout() {
+        let mut big_diff = "diff --git a/test.txt b/test.txt\nindex 123..456 100644\n--- a/test.txt\n+++ b/test.txt\n@@ -1,1 +1,2 @@\n-old\n+new line 1\n+new line 2\n".to_string();
+        for _ in 0..50 {
+            big_diff.push_str(" \n");
+        }
+        let input = json!({
+            "tool_name": "Bash",
+            "tool_input": { "command": "git diff" },
+            "tool_response": {
+                "content": big_diff,
+                "stdout": "should be ignored when content is present"
+            }
+        });
+        let out = process_payload(&input.to_string(), None, None);
+        assert!(out.is_some());
+        let res = out.expect("must succeed");
+        assert!(
+            res.contains("test.txt"),
+            "content field should be used, not stdout"
+        );
     }
 }

--- a/src/hooks/session_start.rs
+++ b/src/hooks/session_start.rs
@@ -7,11 +7,11 @@ use std::sync::Arc;
 
 #[derive(Deserialize)]
 struct HookInput {
-    #[serde(rename = "hookEventName")]
+    #[serde(rename = "hookEventName", alias = "hook_event_name")]
     hook_event_name: String,
-    #[serde(rename = "sessionId")]
+    #[serde(rename = "sessionId", alias = "session_id")]
     session_id: String,
-    #[serde(rename = "workingDirectory")]
+    #[serde(rename = "workingDirectory", alias = "working_directory")]
     working_directory: String,
 }
 

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -748,6 +748,21 @@ impl Store {
             params![ts_threshold],
         );
     }
+
+    /// Test that the database is actually writable (catches sandbox restrictions)
+    pub fn test_write(&self) -> bool {
+        let conn = match self.conn.lock() {
+            Ok(c) => c,
+            Err(_) => return false,
+        };
+        match conn.execute("CREATE TABLE IF NOT EXISTS _write_test (id INTEGER)", []) {
+            Ok(_) => {
+                let _ = conn.execute("DROP TABLE IF EXISTS _write_test", []);
+                true
+            }
+            Err(_) => false,
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
<!-- AI-PR-DESCRIPTION-START -->
## PR Auto Describe
## Summary
>This PR improves omni's diagnostic tools, cross-tool hook compatibility, and filesystem sandbox detection. It upgrades the `doctor` command to catch Claude Code-style filesystem restrictions via real write tests, adds support for Claude Code's tool response format, and unifies hook field naming between camelCase and snake_case.

## Key Changes
-  Enhanced `omni doctor` to validate actual filesystem/database write access instead of static permission checks, with actionable Claude Code sandbox warnings
-  Added cross-tool hook compatibility by supporting both camelCase and snake_case field names
-  Added support for Claude Code's stdout/stderr tool response format
-  Added a SQLite store writability test utility

## Detailed Breakdown
-  **`src/cli/doctor.rs`**:
   -  Rewrote the ~/.omni config dir check: Replaced simplistic metadata permission tests with a real write test (creates + cleans up a temporary `.write_test` file)
   -  Added a new database writability scan using the new `Store::test_write()` method, with tailored warnings for Claude Code users
   -  Preserved existing fix-mode directory creation logic
-  **`src/hooks/dispatcher.rs` + `src/hooks/session_start.rs`**: Added serde deserialization aliases to support both camelCase (e.g. `hookEventName`) and snake_case (e.g. `hook_event_name`) field names
-  **`src/hooks/post_tool.rs`**:
   -  Extended `ToolResponse` struct to accept `stdout` and `stderr` fields
   -  Created `extract_tool_content()` that prioritizes structured `content` fields (used by Cursor/Windsurf) then falls back to concatenated stdout/stderr (Claude Code format)
   -  Replaced legacy content extraction logic with this new handler
   -  Added 4 new test cases covering Claude Code payloads, mixed stdout/stderr, empty output, and structured content field precedence
-  **`src/store/sqlite.rs`**: Added `test_write()` helper that validates database writability by creating and dropping a temporary test table, handling poisoned mutexes gracefully

## Notes
All `omni doctor` warnings now include specific instructions for Claude Code users: add `~/.omni` to `sandbox.filesystem.allowWrite` in `~/.claude/settings.json` to resolve sandboxed write blocks.

## Breaking Changes
None. All changes are backwards-compatible, with existing tooling and workflows unaffected.

_Last updated: 2026-04-10 04:09:00_
<!-- AI-PR-DESCRIPTION-END -->