### PR TITLE
Update and fix OpenClaw plugin

### DIFF
--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -61,10 +61,12 @@ omni stats --today
 
 OMNI is built with a **Privacy-First** design intent. This plugin acts as a secure proxy to facilitate safe execution:
 
-- **Node-Level Sanitization**: This plugin explicitly strips ~25 dangerous environment variables (like `LD_PRELOAD`, `NODE_OPTIONS`, `BASH_ENV`) at the process level before execution.
+- **Node-Level Sanitization**: This plugin explicitly strips ~25 dangerous environment variables (like `LD_PRELOAD`, `NODE_OPTIONS`, `BASH_ENV`) at the process level before execution. Other environment variables are passed through to the command.
 - **Local-Only Architecture**: The OMNI engine is designed for local processing. No terminal output is ever sent to external cloud services by the engine.
 - **Local Persistence**: Usage statistics are stored strictly in a local SQLite database at `~/.omni/omni.db`.
 - **Trust & Verification**: As OMNI is a tool for developers, we encourage you to audit the full source code and security policies at the [OMNI GitHub Repository](https://github.com/fajarhide/omni/blob/main/SECURITY.md) to verify these claims for yourself.
+
+> ⚠️ **Note**: This plugin passes through most environment variables to the invoked command. If you run untrusted commands, consider doing so in a restricted environment (container, CI runner, or limited account) with minimal secrets in the environment.
 
 ## Benefits
 - **Cheaper Tasks**: Massive savings on API bills for long-running autonomous tasks.

--- a/integrations/openclaw/index.ts
+++ b/integrations/openclaw/index.ts
@@ -36,7 +36,9 @@ const OmniCmdParams = Type.Object({
   command: Type.String({ description: "The terminal command to execute (e.g. 'npm install' or 'git diff')" })
 });
 
-function createOmniCmdTool(): AnyAgentTool {
+type PluginConfig = { omniPath?: string };
+
+function createOmniCmdTool(api: OpenClawPluginApi): AnyAgentTool {
   return {
     name: "omni_cmd",
     label: "OMNI Command",
@@ -44,7 +46,8 @@ function createOmniCmdTool(): AnyAgentTool {
     parameters: OmniCmdParams,
     async execute(_toolCallId: string, params: Record<string, unknown>) {
       const command = params.command as string;
-      const omniPath = "omni";
+      const config = (api.pluginConfig ?? {}) as PluginConfig;
+      const omniPath = config.omniPath || "omni";
 
       try {
         const { stdout, stderr, code } = await runOmni(omniPath, ["exec", "--", command]);
@@ -81,6 +84,6 @@ export default definePluginEntry({
     if (api.registrationMode !== "full") {
       return;
     }
-    api.registerTool(createOmniCmdTool() as OpenClawPluginToolFactory, { optional: true });
+    api.registerTool(createOmniCmdTool(api) as OpenClawPluginToolFactory, { optional: true });
   }
 });


### PR DESCRIPTION
<!-- AI-PR-DESCRIPTION-START -->
## PR Auto Describe
## Summary
This PR enhances the OpenClaw OMNI terminal command plugin. It adds support for custom OMNI binary paths, clarifies environment variable sanitization behavior in the README, and adds a critical security note for running untrusted commands.

---

## Key Changes
- Documentation: Updated README to document env var pass-through and add untrusted command security warning
- Code: Added configurable `omniPath` plugin setting, refactored tool factory to use plugin API, implemented dynamic binary path lookup

---

## Detailed Breakdown
### integrations/openclaw/README.md
1.  Expanded the Node-Level Sanitization section to specify that ~25 dangerous environment variables are stripped, while most other vars are passed through to the invoked command
2.  Added a new security callout warning users to run untrusted commands in restricted environments (containers, limited accounts) to avoid exposing environment secrets
### integrations/openclaw/index.ts
1.  Defined a new `PluginConfig` type with an optional `omniPath` string property for custom OMNI binary location
2.  Updated the `createOmniCmdTool` function to accept an `OpenClawPluginApi` parameter (previously took no arguments)
3.  Modified the plugin registration logic to pass the API instance to the tool factory
4.  Replaced the hardcoded `omni` binary path with a config-backed lookup, falling back to the default `omni` executable if no custom path is provided

---

## Notes
The security warning emphasizes that users should minimize environment secrets when running untrusted commands, and use isolated environments where possible.

---

## Breaking Changes (If any)
No end-user facing breaking changes. The internal `createOmniCmdTool` function signature was updated, but the plugin registration was adjusted to match this change automatically, so existing plugin deployments will continue to work without modification.

_Last updated: 2026-04-12 17:56:24_
<!-- AI-PR-DESCRIPTION-END -->