### PR TITLE
fix(rewrite): use forward slashes on Windows so Git Bash does not mangle path

### DIFF
--- a/src/cli/rewrite.rs
+++ b/src/cli/rewrite.rs
@@ -38,9 +38,33 @@ pub fn rewrite_logic(cmd_str: &str) -> Option<String> {
         // run_exec will handle whether to use a shell or not.
         let exe_path = std::env::current_exe().unwrap_or_else(|_| std::path::PathBuf::from("omni"));
         let exe_name = exe_path.to_string_lossy();
+        // Claude Code on Windows runs hook output via Git Bash, which interprets
+        // backslashes as escape characters and mangles the path
+        // (`C:\Users\...` -> `C:Users...`). Use forward slashes so the path
+        // survives bash unquoting; Windows accepts `/` in absolute paths.
+        #[cfg(windows)]
+        let exe_name = exe_name.replace('\\', "/");
 
         return Some(format!("{} exec {}", exe_name, cmd_str));
     }
 
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[cfg(windows)]
+    fn test_rewrite_uses_forward_slashes_on_windows() {
+        // On Windows, the rewritten command must not contain backslashes from
+        // the omni exe path; Git Bash strips them as escape characters.
+        let rewritten = rewrite_logic("git status").expect("git should rewrite");
+        let exe_part = rewritten.trim_end_matches(" exec git status");
+        assert!(
+            !exe_part.contains('\\'),
+            "rewritten exe path should not contain backslashes: {exe_part}"
+        );
+    }
 }

--- a/src/cli/rewrite.rs
+++ b/src/cli/rewrite.rs
@@ -53,7 +53,8 @@ pub fn rewrite_logic(cmd_str: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    #[cfg(windows)]
+    use super::rewrite_logic;
 
     #[test]
     #[cfg(windows)]


### PR DESCRIPTION
## Summary

On Windows, the `PreToolUse` hook in Claude Code (and any other agent that runs the rewritten command through Git Bash) fails for every recognized tool — `git`, `cargo`, `npm`, `pytest`, etc. — with:

```
/usr/bin/bash: line 3: C:Usersserge.localbinomni.exe: command not found
```

## Root cause

`rewrite_logic` (`src/cli/rewrite.rs`) takes `std::env::current_exe()`, which on Windows returns a backslash path:

```
C:\Users\serge\.local\bin\omni.exe
```

It formats this verbatim into the `updatedInput.command` payload that Claude Code feeds back through `bash -c`. Bash interprets `\U`, `\s`, `\.`, `\b`, `\o` as escape sequences and strips the backslashes, mangling the path to `C:Usersserge.localbinomni.exe` — hence the "command not found".

This affects every Windows user with the standard install (`scripts/install.ps1` puts `omni.exe` under `%USERPROFILE%\.local\bin`), since Claude Code's Bash tool runs through Git Bash.

## Fix

Replace backslashes with forward slashes on Windows before formatting the rewritten command. Absolute paths with `/` are accepted by both Git Bash and the Windows API, and they survive bash word/escape processing intact.

```rust
let exe_name = exe_path.to_string_lossy();
#[cfg(windows)]
let exe_name = exe_name.replace('\', "/");
```

Three lines, gated behind `#[cfg(windows)]` so non-Windows builds are unchanged.

## Verification

- All 316 existing tests pass.
- Added a Windows-only regression test (`test_rewrite_uses_forward_slashes_on_windows`) asserting no backslashes appear in the rewritten exe path.
- End-to-end: with the patched binary deployed to `%USERPROFILE%\.local\bin\omni.exe`, `git status` and `git remote -v` both succeed through the live `PreToolUse` hook on Windows 10 + Git Bash. Same commands fail on the unpatched 0.5.7 binary.

## Test plan

- [x] `cargo test --release` — all tests pass on Windows
- [x] Manual: `echo '{"tool_input":{"command":"git status"}}' | omni.exe --pre-hook` outputs forward-slash path
- [x] Manual: live `git`/`cargo`/`npm` commands run successfully through Claude Code on Windows after deploying the patched binary

<!-- AI-PR-DESCRIPTION-START -->
## PR Auto Describe
## Summary
This PR fixes a Windows path mangling bug where Git Bash (used by Claude Code) stripped backslashes from the omni executable’s absolute path. It adds Windows-specific normalization of the executable path to use forward slashes (supported by Windows) and includes a test for this behavior.

---

## Key Changes
- Windows-specific path separator normalization in `rewrite_logic`
- Added Windows-only unit test for the path handling fix

---

## Detailed Breakdown
- Modified `src/cli/rewrite.rs::rewrite_logic`: Added a `#[cfg(windows)]` conditional block that replaces all backslashes in the resolved executable path with forward slashes to avoid Git Bash escaping path separators.
- Added a gated test module: The test validates rewritten Windows commands contain no backslashes in the executable path by parsing the output of `rewrite_logic("git status")`.
- Non-Windows platforms are unaffected, as all new logic is gated behind a Windows-only compile flag.

---

## Notes
This fix addresses hook execution issues in Claude Code's Windows Git Bash environment, which misinterprets backslashes as escape characters and mangles absolute Windows paths.

---

## Breaking Changes
None, as all new code is conditional to Windows builds and does not alter cross-platform functionality.

_Last updated: 2026-04-30 03:40:47_
<!-- AI-PR-DESCRIPTION-END -->