### PR TITLE
fix: increase rewind hash from 8 to 16 hex chars (64-bit entropy)

### DIFF
--- a/src/cli/rewind.rs
+++ b/src/cli/rewind.rs
@@ -30,7 +30,7 @@ pub fn run_rewind(args: &[String], store: &Store) -> Result<()> {
         }
         _ => {
             // Default to list if it looks like a hash or unknown
-            if subcmd.len() == 8 {
+            if subcmd.len() >= 8 {
                 show_rewind(store, subcmd)
             } else {
                 list_rewinds(store)

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -486,7 +486,7 @@ impl Store {
         hasher.update(content.as_bytes());
         let hash_result = hasher.finalize();
         let full_hash = hex::encode(hash_result);
-        let short_hash = full_hash[..8].to_string();
+        let short_hash = full_hash[..16].to_string();
 
         let conn = match self.conn.lock() {
             Ok(c) => c,
@@ -1214,7 +1214,7 @@ mod tests {
         let content = "this is some compressed content";
         let hash = store.store_rewind(content);
 
-        assert_eq!(hash.len(), 8);
+        assert_eq!(hash.len(), 16);
 
         let retrieved = store.retrieve_rewind(&hash);
         assert_eq!(retrieved, Some(content.to_string()));


### PR DESCRIPTION
## Summary

`store_rewind` truncates SHA-256 to **8 hex chars (32 bits)** before using as the SQLite primary key. This causes `INSERT OR IGNORE` to silently discard newer entries when content hashes collide within 32 bits — silent data loss.

## Analysis

**Birthday bound for 8 chars (32 bits):** ~77,000 entries for 50% collision probability.

For a tool processing Claude Code terminal output continuously over months, `rewind_store` can accumulate tens of thousands of entries. The `INSERT OR IGNORE` constraint means a newer entry with a colliding 8-char prefix is permanently dropped — the `[OMNI: ... omni_retrieve("hash")]` notice references the **older** content, not the newer one.

**Fix:** Truncate to **16 hex chars (64 bits)**. Birthday bound becomes ~5 billion entries — collision practically impossible for any realistic installation.

## Changes

| File | Change |
|------|--------|
| `src/store/sqlite.rs:489` | `full_hash[..8]` → `full_hash[..16]` |
| `src/store/sqlite.rs:1217` | Test assertion updated: `hash.len() == 16` |
| `src/cli/rewind.rs:33` | `subcmd.len() == 8` → `subcmd.len() >= 8` (accept both 8 and 16 char hashes for forward/backward compat) |

## Breaking Change Note

Rewind notices change from `omni_retrieve("a1b2c3d4")` (8 chars) to `omni_retrieve("a1b2c3d4e5f60718")` (16 chars). Old 8-char hashes stored in existing session history still work — the DB key space is unchanged for pre-existing entries. Only newly archived content uses the 16-char format.

## Testing

```bash
cargo test --lib rewind  # 2/2 pass
```

<!-- AI-PR-DESCRIPTION-START -->
## PR Auto Describe
## Summary
This PR upgrades the rewind feature's short hash implementation, increasing the truncated hex hash length from 8 to 16 characters for improved collision resistance. It also adjusts the CLI's fallback logic and fixes associated unit tests to align with the new hash parameters.

## Key Changes
- Bumped rewind short hash length from 8 → 16 hex characters in SQLite storage
- Updated CLI rewind default fallback to trigger detail view for inputs ≥8 characters
- Fixed unit test validation for the new hash length

## Detailed Breakdown
- `src/cli/rewind.rs`: Adjusted the fallback default subcommand check, changing `subcmd.len() == 8` to `subcmd.len() >= 8` to support the new longer short hash.
- `src/store/sqlite.rs`:
  - Updated short hash generation to use the first 16 characters of the full hex hash instead of 8
  - Patched the existing unit test to assert the new 16-character hash length instead of 8.

## Breaking Changes
This modifies the short rewind hash format, breaking compatibility with all previously stored rewind entries referenced via the original 8-character short hash.

_Last updated: 2026-05-02 08:30:35_
<!-- AI-PR-DESCRIPTION-END -->