### PR TITLE
docs: add Hermes Agent integration link

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ enable_readfile_distillation = false
 **For Users:**
 - [The Ultimate Guide (HOW_TO_USE.md)](docs/HOW_TO_USE.md) — Everything you need: Installation, `omni learn`, Custom TOML Filters, and CLI Commands.
 - [OpenClaw Integration](https://clawhub.ai/fajarhide/omni-signal-engine) — Official OpenClaw plugin for native OMNI distillation. Install: `openclaw plugins install clawhub:@fajarhide/omni-signal-engine`
+- [Hermes Agent Integration](https://github.com/wysie/hermes-omni-plugin) — Community Hermes Agent plugin for native OMNI distillation. Install: `uv pip install --python ~/.hermes/hermes-agent/venv/bin/python git+https://github.com/wysie/hermes-omni-plugin.git`
 
 **For Developers & System Integrators:**
 - [Development Guide](docs/DEVELOPMENT.md) — How to build and contribute to the OMNI codebase.


### PR DESCRIPTION
## Summary
- Add the community Hermes Agent OMNI plugin to the README Documentation Index
- Include a one-line install command matching the existing OpenClaw integration entry style

## Test Plan
- git diff --check

<!-- AI-PR-DESCRIPTION-START -->
## PR Auto Describe
## Summary
The PR updates the README to include a new community plugin for Hermes Agent, providing a ready‑to‑install link and command. This addition expands the native OMNI distillation options for users and developers.

---

## Key Changes
- Added “Hermes Agent Integration” section with link and installation instruction.
- Updated documentation list under **For Users**.

---

## Detailed Breakdown
- **README.md**:  
  *Inserted a new bullet point under “For Users”:
  ```
  - [Hermes Agent Integration](https://github.com/wysie/hermes-omni-plugin) — Community Hermes Agent plugin for native OMNI distillation. Install: `uv pip install --python ~/.hermes/hermes-agent/venv/bin/python git+https://github.com/wysie/hermes-omni-plugin.git`
  ```  
  *No other file changes. The new entry mirrors the existing OpenClaw plugin format, ensuring consistency in documentation.

---

## Notes (Optional)
None.

---

## Breaking Changes
None.

_Last updated: 2026-05-03 09:26:53_
<!-- AI-PR-DESCRIPTION-END -->