### PR TITLE
fix: detect packaged Hermes OMNI plugin

### DIFF
--- a/src/agents/hermes.rs
+++ b/src/agents/hermes.rs
@@ -1,15 +1,52 @@
 use crate::agents::AgentIntegration;
 use colored::*;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 pub struct HermesIntegration;
 
 /// Returns the Hermes plugin directory.
 fn plugin_dir() -> PathBuf {
+    hermes_home_dir().join("plugins").join("omni-signal-engine")
+}
+
+fn hermes_home_dir() -> PathBuf {
     dirs::home_dir()
         .unwrap_or_else(|| PathBuf::from("."))
-        .join(".hermes/plugins/omni-signal-engine")
+        .join(".hermes")
+}
+
+fn hermes_config_path() -> PathBuf {
+    hermes_home_dir().join("config.yaml")
+}
+
+fn config_mentions_omni_plugin(config: &str) -> Option<&'static str> {
+    if config.contains("hermes-omni-plugin") {
+        Some("hermes-omni-plugin")
+    } else if config.contains("omni-signal-engine") {
+        Some("omni-signal-engine")
+    } else {
+        None
+    }
+}
+
+fn config_mentions_omni_mcp(config: &str) -> bool {
+    let has_mcp_section = config.contains("mcp_servers:") || config.contains("mcp:");
+    let has_omni_server = config.contains("omni:");
+    let has_omni_command = config.contains("--mcp") || config.contains("OMNI_AGENT_ID");
+    has_mcp_section && has_omni_server && has_omni_command
+}
+
+fn configured_omni_plugin(config_path: &Path) -> Option<&'static str> {
+    fs::read_to_string(config_path)
+        .ok()
+        .and_then(|config| config_mentions_omni_plugin(&config))
+}
+
+fn configured_omni_mcp(config_path: &Path) -> bool {
+    fs::read_to_string(config_path)
+        .map(|config| config_mentions_omni_mcp(&config))
+        .unwrap_or(false)
 }
 
 impl AgentIntegration for HermesIntegration {
@@ -111,28 +148,113 @@ def register(ctx):
 
     fn doctor_check(&self, _fix_mode: bool, _warnings: &mut Vec<String>) -> bool {
         let dest = plugin_dir();
+        let config_path = hermes_config_path();
+        let directory_plugin_installed = dest.join("plugin.yaml").exists();
+        let configured_plugin = configured_omni_plugin(&config_path);
+        let mcp_configured = configured_omni_mcp(&config_path);
+        let installed = directory_plugin_installed || configured_plugin.is_some();
 
         println!("\n  {}", "Hermes Agent:".cyan());
-        if dest.join("plugin.yaml").exists() {
+        if directory_plugin_installed {
             println!(
                 "   {:<15} {} {}",
                 "Plugin:".bright_black(),
                 "~/.hermes/plugins/omni-signal-engine/".bright_black(),
                 "[OK]".green().bold()
             );
+        } else if let Some(plugin_name) = configured_plugin {
             println!(
-                "   {:<15} {}",
-                "Note:".bright_black(),
-                "Verify OMNI is under mcp_servers in ~/.hermes/config.yaml".bright_black()
+                "   {:<15} {} {}",
+                "Plugin:".bright_black(),
+                format!("{} in ~/.hermes/config.yaml", plugin_name).bright_black(),
+                "[OK]".green().bold()
             );
-            true
         } else {
             println!(
                 "   {:<15} {}",
                 "Plugin:".bright_black(),
                 "not installed".bright_black()
             );
-            false
         }
+
+        println!(
+            "   {:<15} {}",
+            "MCP Server:".bright_black(),
+            if mcp_configured {
+                "configured in ~/.hermes/config.yaml [OK]".green().bold()
+            } else {
+                "not configured".bright_black()
+            }
+        );
+
+        if installed && !mcp_configured {
+            println!(
+                "   {:<15} {}",
+                "Note:".bright_black(),
+                "MCP is optional; native Hermes plugin detection passed.".bright_black()
+            );
+        }
+
+        installed
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{config_mentions_omni_mcp, config_mentions_omni_plugin};
+
+    #[test]
+    fn detects_packaged_hermes_omni_plugin_in_config() {
+        let config = r#"
+plugins:
+  enabled:
+    - disk-cleanup
+    - hermes-omni-plugin
+"#;
+
+        assert_eq!(
+            config_mentions_omni_plugin(config),
+            Some("hermes-omni-plugin")
+        );
+    }
+
+    #[test]
+    fn detects_legacy_omni_signal_engine_plugin_in_config() {
+        let config = r#"
+plugins:
+  enabled:
+    - omni-signal-engine
+"#;
+
+        assert_eq!(
+            config_mentions_omni_plugin(config),
+            Some("omni-signal-engine")
+        );
+    }
+
+    #[test]
+    fn detects_hermes_omni_mcp_config() {
+        let config = r#"
+mcp_servers:
+  omni:
+    command: "omni"
+    args: ["--mcp"]
+    env:
+      OMNI_AGENT_ID: "hermes"
+"#;
+
+        assert!(config_mentions_omni_mcp(config));
+    }
+
+    #[test]
+    fn missing_plugin_and_mcp_config_are_not_detected() {
+        let config = r#"
+plugins:
+  enabled:
+    - unrelated-plugin
+"#;
+
+        assert_eq!(config_mentions_omni_plugin(config), None);
+        assert!(!config_mentions_omni_mcp(config));
     }
 }


### PR DESCRIPTION
## Summary
- detect the packaged Hermes OMNI plugin when it is enabled via `~/.hermes/config.yaml`
- keep support for the generated `~/.hermes/plugins/omni-signal-engine` integration
- report optional Hermes MCP configuration separately
- add unit coverage for packaged plugin, legacy plugin, MCP, and missing-config cases

## Why
OMNI's README points Hermes users to the community `hermes-omni-plugin` package, but `omni doctor` only checked for the generated directory plugin at `~/.hermes/plugins/omni-signal-engine/plugin.yaml`. That made working Hermes installs show `Plugin: not installed`.

## Test plan
- `cargo fmt --check`
- `cargo test agents::hermes -- --nocapture`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- verified `cargo run -- doctor` reports `hermes-omni-plugin in ~/.hermes/config.yaml [OK]` on a packaged-plugin install

<!-- AI-PR-DESCRIPTION-START -->
## PR Auto Describe
## Summary
Added comprehensive Hermes integration detection: new helpers locate the Hermes home, config, and parse config for plugin and MCP settings. `doctor_check` now reports on both directory‑installed and config‑declared plugins, as well as MCP server configuration, and returns an overall status. Included unit tests for config parsing.

---

## Key Changes
- New helper functions: `hermes_home_dir`, `hermes_config_path`, `config_mentions_omni_plugin`, `config_mentions_omni_mcp`, `configured_omni_plugin`, `configured_omni_mcp`.
- `plugin_dir` now builds on `hermes_home_dir` and returns `plugins/omni-signal-engine`.
- `doctor_check` uses the new helpers to report plugin and MCP status.
- Added tests for config parsing helpers.
- Updated imports to include `Path`.

---

## Detailed Breakdown
- **Imports**: Added `use std::path::Path;` for path handling.
- **Path helpers**:
  - `hermes_home_dir()` → `~/.hermes` (fallback to current dir).
  - `hermes_config_path()` → `~/.hermes/config.yaml`.
- **Config parsing**:
  - `config_mentions_omni_plugin(config: &str)` returns `"hermes-omni-plugin"` or `"omni-signal-engine"` if present.
  - `config_mentions_omni_mcp(config: &str)` checks for MCP section, omni server, and command/ENV flags.
  - `configured_omni_plugin(path)` reads file and applies `config_mentions_omni_plugin`.
  - `configured_omni_mcp(path)` reads file and applies `config_mentions_omni_mcp`.
- **`plugin_dir` update**: now `hermes_home_dir().join("plugins").join("omni-signal-engine")`.
- **`doctor_check`**:
  - Determines `directory_plugin_installed` (`plugin.yaml` existence).
  - Reads config path, detects `configured_plugin` and `mcp_configured`.
  - `installed` is true if directory plugin exists or config declares plugin.
  - Prints status for Plugin, MCP Server, and optional note if MCP missing but plugin present.
  - Returns `installed`.
- **Tests** (`#[cfg(test)] mod tests`):
  - Verify detection of packaged and legacy plugins.
  - Verify MCP config detection.
  - Verify non‑detections.

---

## Notes
The logic now considers plugins defined in `config.yaml`, not just the filesystem. This may alter the output of `doctor_check` in environments that rely on config‑declared plugins.

---

## Breaking Changes
- `doctor_check` now returns `true` when a plugin is configured in `config.yaml` even if no `plugin.yaml` exists. Existing consumers expecting false in that scenario may need adjustment.

_Last updated: 2026-05-10 12:24:53_
<!-- AI-PR-DESCRIPTION-END -->