### PR TITLE
fix(claude): emit empty matcher for async hook entries

### DIFF
--- a/src/agents/claude.rs
+++ b/src/agents/claude.rs
@@ -408,6 +408,7 @@ pub fn install_omni_hooks(val: &mut Value, exe_path: &str) {
             }
         }
         arr.push(json!({
+            "matcher": "",
             "hooks": [{
                 "type": "command",
                 "command": hook_cmd,
@@ -594,6 +595,23 @@ mod tests {
         // Check status with incorrect path
         let (post_f, sess_f, pre_f) = check_status(&val, "/different/omni");
         assert!(!post_f && !sess_f && !pre_f);
+    }
+
+    #[test]
+    fn test_init_hook_writes_matcher_for_all_events() {
+        let mut val = json!({});
+        install_omni_hooks(&mut val, "/usr/bin/omni");
+
+        let hooks = val.get("hooks").unwrap().as_object().unwrap();
+        for (event, entries) in hooks {
+            for entry in entries.as_array().unwrap() {
+                let matcher = entry.get("matcher");
+                assert!(
+                    matches!(matcher, Some(v) if v.is_string()),
+                    "{event} entry missing string matcher: {entry}"
+                );
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
## What

`install_omni_hooks` writes `SessionEnd`, `PostToolUseFailure`, and `FileChanged` entries without a `matcher` field. This patch makes `ensure_async_hook` emit `"matcher": ""` the same way its sibling `ensure_hook` already does.

## Why

Claude Code's hook entries expect `matcher` as a string, or for the field to be absent. Absent is fine on its own; Claude Code tolerates a missing key. The problem appears when another tool reads `settings.json` and re-serializes it: a missing object property typically round-trips back as literal `null`, and Claude Code rejects the file with:

```
matcher: Expected string, but received null
```

I hit this when peon-ping's installer (`install.ps1`) rewrote `settings.json` to register its own hooks and preserved omni's existing entries. PowerShell's `ConvertFrom-Json` returns `$null` for the missing `matcher` property, then `ConvertTo-Json` writes it back as literal JSON `null`. Fixing it on omni's side (emit the field explicitly) keeps the file valid even when third-party tools rewrite it.

## Reproduction on current main

```rust
let mut val = serde_json::json!({});
install_omni_hooks(&mut val, "/usr/bin/omni");
println!("{}", serde_json::to_string_pretty(&val).unwrap());
```

Output:
- `SessionEnd`, `PostToolUseFailure`, `FileChanged`: no `matcher` field
- `PreToolUse`, `PostToolUse`, `SessionStart`, `PreCompact`, `SubagentStart`: `"matcher": ""` (or `"matcher": "Bash"`)

## References

- Claude Code hooks docs: https://code.claude.com/docs/en/hooks. The documented matcher values are `"*"`, `""`, or omitted; null is not one of them.
- Claude Code's validation hint when it rejects the broken file: "The matcher is a string: a tool name (`"Bash"`), pipe-separated list (`"Edit|Write"`), or empty to match all."

## Test

Added `test_init_hook_writes_matcher_for_all_events`. It walks every entry produced by `install_omni_hooks` and asserts each has a string `matcher`. Without this patch it fails on the three async events.
