### PR TITLE
Implement build metadata and machine-readable JSON modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,15 +132,17 @@ OMNI is built in Rust for zero-overhead execution and ruthless efficiency. Here 
 - **Omission Visibility**: OMNI explicitly labels removed content (e.g., `[OMNI: omitted X lines of noise]`) in the output, giving your AI agent perfect situational awareness.
 
 ### Multi-Agent & Workspace Intelligence
-- **Multi-Agent Collaboration**: Fully aware of its environment via `omni_agents`. If you have Cursor running alongside Claude CLI, they seamlessly share the same filtered memory streams and active errors without clashing.
+- **Native MCP Server (`omni mcp`)**: OMNI operates as a high-performance Native Model Context Protocol (MCP) server. Agents can instantly query OMNI for active errors, historical engrams, token budgets, and contextual file insights via a direct `stdio` connection without any subprocess latency.
+- **Multi-Agent Collaboration**: Fully aware of its environment via `OMNI_AGENT_ID`. If you have Cursor running alongside Claude CLI or Hermes, they seamlessly share the same filtered memory streams and active errors without clashing.
 - **Session Intelligence**: OMNI remembers what you are doing. It knows which files you are actively editing and stops feeding the AI redundant context. Fixes are preserved permanently via `omni_knowledge`.
 - **Structured ReadFile + Grep**: Instead of raw file dumps, OMNI returns structured outlines (imports, public API) and grouped grep summaries (priority lines first).
 - **Lightweight Dependency Graph**: OMNI builds a fast local file relationship graph at hook time (no daemon). If your AI reads a heavily-imported file, OMNI warns it of the impact map.
 
 ### Context Fidelity & Session Recovery
+- **Proactive Context Pressure**: OMNI actively acts as a "Token Traffic Light." Via the `omni_insight` MCP tool, OMNI pro-actively warns the agent when its context window hits "Warning" or "Critical" thresholds, triggering the agent to compress its memory *before* it crashes or hallucinates.
 - **Engrams (Automatic Subtask Digests)**: OMNI automatically detects when a subtask is completed (e.g., resolving a compiler error, committing code, or fixing a broken test). It creates a highly compressed snapshot (an "Engram") without wasting tokens on LLM calls, so your agent never suffers from "context amnesia" during long sessions.
 - **Smart Context Compaction**: When your context window gets full, OMNI doesn't blindly trim tokens. It uses a priority-aware algorithm to pack the most important data first (Pinned Files > Active Errors > Engrams > Tool Activity > Hot Files), saving massive overhead.
-- **Session Handoffs**: Switching from Claude Code to Cursor? Use the `omni_handoff` tool to instantly export the current session's memory (hot files, recent commands, active errors) into a portable markdown summary that your new agent can instantly absorb.
+- **Session Handoffs**: Switching from Claude Code to Cursor or Hermes? Use the `omni_handoff` tool to instantly export the current session's memory (hot files, recent commands, active errors) into a portable summary that your new agent can instantly absorb.
 
 ### Monitoring & Debugging
 - **Session Health Dashboard**: Run `omni session --health` for a beautiful visual dashboard of your context pressure, active engrams, rolling tool activity, and token savings.

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,21 @@
+use std::process::Command;
+
+fn main() {
+    // Re-run if .git/HEAD changes
+    println!("cargo:rerun-if-changed=.git/HEAD");
+
+    let git_hash = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_else(|_| "unknown".to_string());
+
+    let build_date = Command::new("date")
+        .args(["+%Y-%m-%d %H:%M:%S"])
+        .output()
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_else(|_| "unknown".to_string());
+
+    println!("cargo:rustc-env=OMNI_GIT_HASH={}", git_hash);
+    println!("cargo:rustc-env=OMNI_BUILD_DATE={}", build_date);
+}

--- a/src/agents/hermes.rs
+++ b/src/agents/hermes.rs
@@ -199,6 +199,37 @@ def register(ctx):
     }
 }
 
+/// Hermes-optimized agent config defaults.
+///
+/// Hermes agent uses pipe mode with `OMNI_CMD` env var — no PreToolUse hook.
+/// Sessions tend to be longer and Hermes benefits from more aggressive
+/// compression since it manages its own context summarization.
+pub fn hermes_default_config() -> crate::guard::config::AgentConfig {
+    crate::guard::config::AgentConfig {
+        mode: Some(crate::guard::config::DistillationMode::Efficient),
+        enable_readfile_distillation: Some(true),
+        enable_grep_distillation: Some(true),
+        enable_webfetch_distillation: Some(true),
+        pinned_files: Some(vec![
+            "AGENTS.md".to_string(),
+            ".omni/CONTEXT.md".to_string(),
+        ]),
+    }
+}
+
+/// Command patterns commonly issued by Hermes agent tool calls
+pub fn hermes_command_patterns() -> Vec<&'static str> {
+    vec![
+        "terminal", "hermes", "shell", "python", "node", "npm", "pip",
+    ]
+}
+
+/// Check if a given agent_id looks like Hermes
+pub fn is_hermes_agent(agent_id: &str) -> bool {
+    let id = agent_id.to_lowercase();
+    id == "hermes" || id.starts_with("hermes-") || id.contains("hermes")
+}
+
 #[cfg(test)]
 mod tests {
     use super::{config_mentions_omni_mcp, config_mentions_omni_plugin};
@@ -256,5 +287,15 @@ plugins:
 
         assert_eq!(config_mentions_omni_plugin(config), None);
         assert!(!config_mentions_omni_mcp(config));
+    }
+
+    #[test]
+    fn detects_hermes_agent_id() {
+        assert!(super::is_hermes_agent("hermes"));
+        assert!(super::is_hermes_agent("HERMES"));
+        assert!(super::is_hermes_agent("hermes-cli"));
+        assert!(super::is_hermes_agent("my-hermes-agent"));
+        assert!(!super::is_hermes_agent("claude"));
+        assert!(!super::is_hermes_agent("cursor"));
     }
 }

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -67,6 +67,146 @@ fn format_time_ago(ts: u64) -> String {
     }
 }
 
+#[derive(serde::Serialize)]
+pub struct DoctorJson {
+    pub version: String,
+    pub healthy: bool,
+    pub checks: Vec<DoctorCheck>,
+    pub fix_available: bool,
+}
+
+#[derive(serde::Serialize)]
+pub struct DoctorCheck {
+    pub name: String,
+    pub ok: bool,
+    pub message: String,
+}
+
+fn run_json(args: &[String]) -> anyhow::Result<()> {
+    let fix_mode = args.iter().any(|a| a == "--fix");
+    let mut checks = Vec::new();
+    let mut all_ok = true;
+    let mut fix_available = false;
+
+    // 1. Binary
+    checks.push(DoctorCheck {
+        name: "binary".to_string(),
+        ok: true,
+        message: format!("omni v{}", env!("CARGO_PKG_VERSION")),
+    });
+
+    // 2. Config Dir
+    let conf_dir = dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".omni");
+    if conf_dir.exists() {
+        let test_file = conf_dir.join(".write_test");
+        if fs::write(&test_file, "ok").is_ok() {
+            let _ = fs::remove_file(&test_file);
+            checks.push(DoctorCheck {
+                name: "config".to_string(),
+                ok: true,
+                message: "config valid".to_string(),
+            });
+        } else {
+            checks.push(DoctorCheck {
+                name: "config".to_string(),
+                ok: false,
+                message: "Cannot write to ~/.omni/. Sandbox issue?".to_string(),
+            });
+            all_ok = false;
+        }
+    } else {
+        if fix_mode && fs::create_dir_all(&conf_dir).is_ok() {
+            checks.push(DoctorCheck {
+                name: "config".to_string(),
+                ok: true,
+                message: "config directory created".to_string(),
+            });
+        } else {
+            checks.push(DoctorCheck {
+                name: "config".to_string(),
+                ok: false,
+                message: "missing ~/.omni/".to_string(),
+            });
+            all_ok = false;
+            fix_available = true;
+        }
+    }
+
+    // 3. Database
+    match Store::open() {
+        Ok(store) => {
+            let (sessions, _) = store.stats().unwrap_or_default();
+            checks.push(DoctorCheck {
+                name: "sqlite".to_string(),
+                ok: true,
+                message: format!("database healthy, {} events", sessions),
+            });
+
+            if !store.check_fts5() {
+                checks.push(DoctorCheck {
+                    name: "sqlite_fts5".to_string(),
+                    ok: false,
+                    message: "FTS5 missing".to_string(),
+                });
+                all_ok = false;
+            }
+            if !store.test_write() {
+                checks.push(DoctorCheck {
+                    name: "sqlite_write".to_string(),
+                    ok: false,
+                    message: "database read-only".to_string(),
+                });
+                all_ok = false;
+            }
+        }
+        Err(_) => {
+            checks.push(DoctorCheck {
+                name: "sqlite".to_string(),
+                ok: false,
+                message: "database inaccessible".to_string(),
+            });
+            all_ok = false;
+        }
+    }
+
+    // 4. Agents
+    let integrations = crate::agents::all_integrations();
+    let mut any_agent_ok = false;
+    let mut warnings = Vec::new();
+    for agent in integrations {
+        if agent.doctor_check(fix_mode, &mut warnings) {
+            any_agent_ok = true;
+        }
+    }
+    if any_agent_ok {
+        checks.push(DoctorCheck {
+            name: "hooks".to_string(),
+            ok: true,
+            message: "hooks installed".to_string(),
+        });
+    } else {
+        checks.push(DoctorCheck {
+            name: "hooks".to_string(),
+            ok: false,
+            message: "no agents configured".to_string(),
+        });
+        all_ok = false;
+        fix_available = true;
+    }
+
+    let output = DoctorJson {
+        version: "1".to_string(),
+        healthy: all_ok,
+        checks,
+        fix_available,
+    };
+
+    println!("{}", serde_json::to_string_pretty(&output)?);
+    Ok(())
+}
+
 pub fn run(args: &[String]) -> anyhow::Result<()> {
     if args
         .iter()
@@ -74,6 +214,10 @@ pub fn run(args: &[String]) -> anyhow::Result<()> {
     {
         print_help();
         return Ok(());
+    }
+
+    if args.iter().any(|a| a == "--json") {
+        return run_json(args);
     }
 
     let mut i = 1; // Assuming args[0] is "doctor"

--- a/src/cli/engram.rs
+++ b/src/cli/engram.rs
@@ -1,0 +1,101 @@
+use crate::store::sqlite::Store;
+use chrono::Utc;
+use colored::*;
+use std::sync::Arc;
+
+#[derive(serde::Serialize)]
+pub struct EngramListJson {
+    pub version: String,
+    pub session_id: String,
+    pub engrams: Vec<EngramJson>,
+}
+
+#[derive(serde::Serialize)]
+pub struct EngramJson {
+    pub id: String,
+    pub created_at: i64,
+    pub trigger: String,
+    pub headline: String,
+    pub files_changed: Vec<String>,
+    pub errors_resolved: Vec<String>,
+    pub commands_run: u32,
+    pub tokens_saved: u64,
+    pub age_seconds: u64,
+}
+
+pub fn run_engram(args: &[String], store: Arc<Store>) -> anyhow::Result<()> {
+    if args
+        .iter()
+        .any(|a| a == "--help" || a == "-h" || a == "help")
+    {
+        println!("omni engram — View engrams (subtask digests)");
+        return Ok(());
+    }
+
+    let is_json = args.iter().any(|a| a == "--json");
+    let is_list = args.iter().any(|a| a == "list");
+
+    if is_json && is_list {
+        let state = match store.find_latest_session() {
+            Some(s) => s,
+            None => {
+                println!("{{}}");
+                return Ok(());
+            }
+        };
+
+        let now = Utc::now().timestamp();
+        let mut engrams_json = Vec::new();
+
+        for (i, engram) in state.engrams.iter().enumerate() {
+            let mut errors_resolved = Vec::new();
+            if let Some(detail) = &engram.detail {
+                errors_resolved.push(detail.clone());
+            }
+
+            engrams_json.push(EngramJson {
+                id: format!(
+                    "{}-{}",
+                    state.session_id.chars().take(8).collect::<String>(),
+                    i
+                ),
+                created_at: engram.timestamp,
+                trigger: engram.trigger.to_string(),
+                headline: engram.label.clone(),
+                files_changed: engram.files.clone(),
+                errors_resolved,
+                commands_run: 0, // Not explicitly tracked per engram
+                tokens_saved: 0, // Not explicitly tracked per engram
+                age_seconds: (now - engram.timestamp) as u64,
+            });
+        }
+
+        let output = EngramListJson {
+            version: "1".to_string(),
+            session_id: state.session_id.clone(),
+            engrams: engrams_json,
+        };
+
+        println!("{}", serde_json::to_string_pretty(&output)?);
+        return Ok(());
+    }
+
+    // Default plain text behavior
+    let state = match store.find_latest_session() {
+        Some(s) => s,
+        None => {
+            println!("No active session found.");
+            return Ok(());
+        }
+    };
+
+    println!("\n {}", "Session Engrams:".bold().bright_white());
+    if state.engrams.is_empty() {
+        println!("  none yet");
+    } else {
+        for engram in &state.engrams {
+            println!("  {}", engram.compact());
+        }
+    }
+    Ok(())
+}

--- a/src/cli/handoff.rs
+++ b/src/cli/handoff.rs
@@ -1,0 +1,114 @@
+use crate::store::sqlite::Store;
+use colored::*;
+use std::sync::Arc;
+
+#[derive(serde::Serialize)]
+pub struct HandoffJson {
+    pub version: String,
+    pub session_id: String,
+    pub markdown_export: String,
+}
+
+pub fn run_handoff(args: &[String], store: Arc<Store>) -> anyhow::Result<()> {
+    if args
+        .iter()
+        .any(|a| a == "--help" || a == "-h" || a == "help")
+    {
+        println!("omni handoff — Export session state for context transfer");
+        return Ok(());
+    }
+
+    let is_json = args.iter().any(|a| a == "--json");
+
+    let state = match store.find_latest_session() {
+        Some(s) => s,
+        None => {
+            if is_json {
+                println!("{{}}");
+            } else {
+                println!("No active session found to handoff.");
+            }
+            return Ok(());
+        }
+    };
+
+    let task = state
+        .inferred_task
+        .as_deref()
+        .unwrap_or("general development");
+    let domain = state.inferred_domain.as_deref().unwrap_or("unknown");
+    let agent_id = std::env::var("OMNI_AGENT_ID")
+        .unwrap_or_else(|_| crate::agents::multiagent::detect_agent_id());
+
+    let mut md = String::from("# OMNI Session Handoff\n\n");
+    md.push_str(&format!("**Session:** {}\n", state.session_id));
+    md.push_str(&format!("**Agent:** {}\n", agent_id));
+    md.push_str(&format!("**Task:** {}\n", task));
+    md.push_str(&format!("**Domain:** {}\n", domain));
+    md.push_str(&format!("**Commands:** {}\n", state.command_count));
+    md.push_str(&format!(
+        "**Tokens Saved:** ~{}\n\n",
+        state.estimated_tokens_saved()
+    ));
+
+    md.push_str("## Active Errors\n");
+    if state.active_errors.is_empty() {
+        md.push_str("None\n");
+    } else {
+        for err in &state.active_errors {
+            let clean = err.replace('\n', " ");
+            md.push_str(&format!("- {}\n", &clean[..clean.len().min(120)]));
+        }
+    }
+
+    md.push_str("\n## Subtask Progress\n");
+    if state.engrams.is_empty() {
+        md.push_str("No engrams recorded.\n");
+    } else {
+        for engram in &state.engrams {
+            md.push_str(&engram.compact());
+            md.push('\n');
+        }
+    }
+
+    md.push_str("\n## Hot Files\n");
+    let mut hot_vec: Vec<(&String, &u32)> = state.hot_files.iter().collect();
+    hot_vec.sort_by_key(|a| std::cmp::Reverse(a.1));
+    if hot_vec.is_empty() {
+        md.push_str("None\n");
+    } else {
+        for (path, count) in hot_vec.iter().take(10) {
+            md.push_str(&format!("- {} ({}x)\n", path, count));
+        }
+    }
+
+    let tool_summary = crate::session::engram::format_tool_summary(&state.tool_call_log);
+    if !tool_summary.is_empty() {
+        md.push('\n');
+        md.push_str(&tool_summary);
+    }
+
+    md.push_str("\n## Recent Commands\n");
+    for cmd in state.last_commands.iter().take(10) {
+        md.push_str(&format!("- `{}`\n", &cmd[..cmd.len().min(80)]));
+    }
+
+    md.push_str(&format!(
+        "\n## Context Pressure: {}\n",
+        state.context_pressure
+    ));
+    md.push_str("\n---\n*Paste this into a new session to continue where you left off.*\n");
+
+    if is_json {
+        let output = HandoffJson {
+            version: "1".to_string(),
+            session_id: state.session_id.clone(),
+            markdown_export: md,
+        };
+        println!("{}", serde_json::to_string_pretty(&output)?);
+    } else {
+        println!("{}", md.bright_white());
+    }
+
+    Ok(())
+}

--- a/src/cli/handoff.rs
+++ b/src/cli/handoff.rs
@@ -112,3 +112,22 @@ pub fn run_handoff(args: &[String], store: Arc<Store>) -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::HandoffJson;
+
+    #[test]
+    fn test_handoff_json_schema_validation() {
+        let json_struct = HandoffJson {
+            version: "1".to_string(),
+            session_id: "test-session".to_string(),
+            markdown_export: "# Markdown Data".to_string(),
+        };
+
+        let json_str = serde_json::to_string(&json_struct).unwrap();
+        assert!(json_str.contains("\"version\":\"1\""));
+        assert!(json_str.contains("\"session_id\":\"test-session\""));
+        assert!(json_str.contains("\"markdown_export\":\"# Markdown Data\""));
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,6 +1,8 @@
 pub mod diff;
 pub mod doctor;
+pub mod engram;
 pub mod exec;
+pub mod handoff;
 pub mod init;
 pub mod learn;
 pub mod optimize;
@@ -12,3 +14,4 @@ pub mod rewrite;
 pub mod session;
 pub mod stats;
 pub mod update;
+pub mod version;

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -69,6 +69,7 @@ pub fn run_session(args: &[String], store: Arc<Store>) -> anyhow::Result<()> {
     let is_resume = args.iter().any(|a| a == "--resume");
     let is_transcript = args.iter().any(|a| a == "--transcript");
     let is_health = args.iter().any(|a| a == "--health");
+    let is_json = args.iter().any(|a| a == "--json");
 
     // If no flags, show help
     if !is_history
@@ -79,6 +80,7 @@ pub fn run_session(args: &[String], store: Arc<Store>) -> anyhow::Result<()> {
         && !is_resume
         && !is_transcript
         && !is_health
+        && !is_json
     {
         print_help();
         return Ok(());
@@ -136,6 +138,10 @@ pub fn run_session(args: &[String], store: Arc<Store>) -> anyhow::Result<()> {
     let mut state = match store.find_latest_session() {
         Some(s) => s,
         None => {
+            if is_json {
+                println!("{{}}");
+                return Ok(());
+            }
             if is_inject {
                 return Ok(());
             }
@@ -143,6 +149,10 @@ pub fn run_session(args: &[String], store: Arc<Store>) -> anyhow::Result<()> {
             return Ok(());
         }
     };
+
+    if is_json {
+        return run_json(&state);
+    }
 
     if is_clear {
         let _ = store.delete_session(&state.session_id);
@@ -649,6 +659,75 @@ fn run_health(store: &Store) -> anyhow::Result<()> {
             .bold()
     );
     Ok(())
+}
+
+// ─── JSON Mode: Machine-Readable ────────────────────────
+
+fn run_json(state: &crate::pipeline::SessionState) -> anyhow::Result<()> {
+    let mut hot_vec: Vec<(&String, &u32)> = state.hot_files.iter().collect();
+    hot_vec.sort_by_key(|a| std::cmp::Reverse(a.1));
+    let hot_files: Vec<HotFileJson> = hot_vec
+        .into_iter()
+        .take(5)
+        .map(|(p, c)| HotFileJson {
+            path: p.clone(),
+            count: *c,
+        })
+        .collect();
+
+    let agent_id = std::env::var("OMNI_AGENT_ID")
+        .unwrap_or_else(|_| crate::agents::multiagent::detect_agent_id());
+    let project_path = std::env::current_dir()
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_else(|_| "unknown".to_string());
+
+    let session_age_seconds = Utc::now().timestamp() - state.started_at;
+
+    let output = SessionJson {
+        version: "1".to_string(),
+        session_id: state.session_id.clone(),
+        agent_id,
+        project_path,
+        task: state.inferred_task.clone(),
+        domain: state.inferred_domain.clone(),
+        estimated_tokens: state.estimated_current_tokens,
+        context_pressure: state.context_pressure.to_string(),
+        should_warn: state.should_emit_pressure_warning(),
+        tokens_saved: state.estimated_tokens_saved(),
+        command_count: state.command_count,
+        active_errors: state.active_errors.clone(),
+        hot_files,
+        recent_commands: state.last_commands.to_vec(),
+        session_age_seconds,
+    };
+
+    println!("{}", serde_json::to_string_pretty(&output)?);
+    Ok(())
+}
+
+#[derive(serde::Serialize)]
+pub struct SessionJson {
+    pub version: String,
+    pub session_id: String,
+    pub agent_id: String,
+    pub project_path: String,
+    pub task: Option<String>,
+    pub domain: Option<String>,
+    pub estimated_tokens: u64,
+    pub context_pressure: String,
+    pub should_warn: bool,
+    pub tokens_saved: u64,
+    pub command_count: u32,
+    pub active_errors: Vec<String>,
+    pub hot_files: Vec<HotFileJson>,
+    pub recent_commands: Vec<String>,
+    pub session_age_seconds: i64,
+}
+
+#[derive(serde::Serialize)]
+pub struct HotFileJson {
+    pub path: String,
+    pub count: u32,
 }
 
 #[cfg(test)]

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -830,4 +830,46 @@ mod tests {
         assert!(ctx.contains("fix auth bug"));
         assert!(ctx.contains("src/auth/mod.rs"));
     }
+
+    #[test]
+    fn test_session_json_schema_validation() {
+        let mut state = SessionState::new();
+        state.session_id = "test-session".to_string();
+        state.inferred_task = Some("compile code".to_string());
+        state.add_hot_file("src/main.rs");
+        state.add_error("E0308: mismatched types");
+
+        let json_struct = super::SessionJson {
+            version: "1".to_string(),
+            session_id: state.session_id.clone(),
+            agent_id: "test-agent".to_string(),
+            project_path: "/test/project".to_string(),
+            task: state.inferred_task.clone(),
+            domain: state.inferred_domain.clone(),
+            estimated_tokens: state.estimated_current_tokens,
+            command_count: state.command_count,
+            session_age_seconds: 120,
+            active_errors: state.active_errors.clone(),
+            hot_files: state
+                .hot_files
+                .iter()
+                .map(|(k, v)| super::HotFileJson {
+                    path: k.clone(),
+                    count: *v,
+                })
+                .collect(),
+            recent_commands: state.last_commands.clone(),
+            tokens_saved: state.estimated_tokens_saved(),
+            context_pressure: state.context_pressure.to_string(),
+            should_warn: false,
+        };
+
+        let json_str = serde_json::to_string(&json_struct).unwrap();
+        assert!(json_str.contains("\"version\":\"1\""));
+        assert!(json_str.contains("\"session_id\":\"test-session\""));
+        assert!(json_str.contains("\"agent_id\":\"test-agent\""));
+        assert!(json_str.contains("\"context_pressure\":\"Normal\""));
+        assert!(json_str.contains("\"should_warn\":false"));
+        assert!(json_str.contains("\"active_errors\":[\"E0308: mismatched types\"]"));
+    }
 }

--- a/src/cli/stats.rs
+++ b/src/cli/stats.rs
@@ -1144,4 +1144,34 @@ mod tests {
         assert_eq!(format_number(1000), "1,000");
         assert_eq!(format_number(1247000), "1,247,000");
     }
+
+    #[test]
+    fn test_stats_json_schema_validation() {
+        let json_struct = StatsJson {
+            version: "1".to_string(),
+            generated_at: 1234567890,
+            periods: vec![StatsPeriod {
+                label: "All Time".to_string(),
+                commands: 10,
+                input_tokens: 10000,
+                output_tokens: 1000,
+                savings_pct: 90.0,
+                usd_saved: 1.5,
+                measurement_method: "test".to_string(),
+            }],
+            commands: vec![],
+            agents: vec![],
+            rewind: RewindStat {
+                archived: 100,
+                retrieved: 5,
+            },
+            avg_latency_ms: 15.5,
+        };
+
+        let json_str = serde_json::to_string(&json_struct).unwrap();
+        assert!(json_str.contains("\"version\":\"1\""));
+        assert!(json_str.contains("\"generated_at\":1234567890"));
+        assert!(json_str.contains("\"savings_pct\":90.0"));
+        assert!(json_str.contains("\"avg_latency_ms\":15.5"));
+    }
 }

--- a/src/cli/stats.rs
+++ b/src/cli/stats.rs
@@ -855,6 +855,50 @@ fn run_detail(args: &[String], store: &Store) -> Result<()> {
 
 // ─── JSON Mode: Machine-Readable ────────────────────────
 
+#[derive(serde::Serialize)]
+pub struct StatsJson {
+    pub version: String,
+    pub generated_at: i64,
+    pub periods: Vec<StatsPeriod>,
+    pub commands: Vec<CommandStat>,
+    pub agents: Vec<AgentStat>,
+    pub rewind: RewindStat,
+    pub avg_latency_ms: f64,
+}
+
+#[derive(serde::Serialize)]
+pub struct StatsPeriod {
+    pub label: String,
+    pub commands: u64,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub savings_pct: f64,
+    pub usd_saved: f64,
+    pub measurement_method: String,
+}
+
+#[derive(serde::Serialize)]
+pub struct CommandStat {
+    pub command: String,
+    pub count: u64,
+    pub savings_pct: f64,
+    pub tokens_saved: u64,
+}
+
+#[derive(serde::Serialize)]
+pub struct AgentStat {
+    pub agent: String,
+    pub agent_id: String,
+    pub count: u64,
+    pub savings_pct: f64,
+}
+
+#[derive(serde::Serialize)]
+pub struct RewindStat {
+    pub archived: u64,
+    pub retrieved: u64,
+}
+
 fn run_json(store: &Store) -> Result<()> {
     let periods = store.multi_period_stats()?;
     let top_commands = get_top_commands(store, 0, 100);
@@ -867,7 +911,7 @@ fn run_json(store: &Store) -> Result<()> {
         0.0
     };
 
-    let periods_json: Vec<serde_json::Value> = periods
+    let periods_json: Vec<StatsPeriod> = periods
         .iter()
         .map(
             |(label, count, input, output, raw_tokens, filtered_tokens)| {
@@ -882,32 +926,34 @@ fn run_json(store: &Store) -> Result<()> {
                 let tokens_saved = raw_tokens.saturating_sub(*filtered_tokens);
                 let usd_saved =
                     (tokens_saved as f64 / 1_000_000.0) * crate::guard::config::get_input_cost();
-                serde_json::json!({
-                    "label": label.to_lowercase().replace(' ', "_"),
-                    "commands": count,
-                    "input_tokens": raw_tokens,
-                    "output_tokens": filtered_tokens,
-                    "savings_pct": savings_pct,
-                    "usd_saved": (usd_saved * 100.0).round() / 100.0,
-                    "measurement_method": if *raw_tokens > 0 { "actual" } else { "estimated" },
-                })
+                StatsPeriod {
+                    label: label.to_lowercase().replace(' ', "_"),
+                    commands: *count,
+                    input_tokens: *raw_tokens,
+                    output_tokens: *filtered_tokens,
+                    savings_pct,
+                    usd_saved: (usd_saved * 100.0).round() / 100.0,
+                    measurement_method: if *raw_tokens > 0 {
+                        "actual".to_string()
+                    } else {
+                        "estimated".to_string()
+                    },
+                }
             },
         )
         .collect();
 
-    let commands_json: Vec<serde_json::Value> = top_commands
+    let commands_json: Vec<CommandStat> = top_commands
         .iter()
-        .map(|(cmd, count, pct, tokens_saved)| {
-            serde_json::json!({
-                "command": cmd,
-                "count": count,
-                "savings_pct": pct,
-                "tokens_saved": tokens_saved,
-            })
+        .map(|(cmd, count, pct, tokens_saved)| CommandStat {
+            command: cmd.clone(),
+            count: *count,
+            savings_pct: *pct,
+            tokens_saved: *tokens_saved,
         })
         .collect();
 
-    let agent_json: Vec<serde_json::Value> = store
+    let agent_json: Vec<AgentStat> = store
         .get_agent_breakdown(0)
         .unwrap_or_default()
         .iter()
@@ -917,25 +963,27 @@ fn run_json(store: &Store) -> Result<()> {
             } else {
                 0.0
             };
-            serde_json::json!({
-                "agent": agent_display_name(agent_id),
-                "agent_id": agent_id,
-                "count": count,
-                "savings_pct": savings,
-            })
+            AgentStat {
+                agent: agent_display_name(agent_id).to_string(),
+                agent_id: agent_id.clone(),
+                count: *count,
+                savings_pct: savings,
+            }
         })
         .collect();
 
-    let output = serde_json::json!({
-        "periods": periods_json,
-        "commands": commands_json,
-        "agents": agent_json,
-        "rewind": {
-            "archived": rewind_stored,
-            "retrieved": rewind_retrieved,
+    let output = StatsJson {
+        version: "1".to_string(),
+        generated_at: chrono::Utc::now().timestamp(),
+        periods: periods_json,
+        commands: commands_json,
+        agents: agent_json,
+        rewind: RewindStat {
+            archived: rewind_stored,
+            retrieved: rewind_retrieved,
         },
-        "avg_latency_ms": (avg_latency * 10.0).round() / 10.0,
-    });
+        avg_latency_ms: (avg_latency * 10.0).round() / 10.0,
+    };
 
     println!("{}", serde_json::to_string_pretty(&output)?);
     Ok(())

--- a/src/cli/version.rs
+++ b/src/cli/version.rs
@@ -30,6 +30,27 @@ pub fn run_version(args: &[String]) {
         };
         println!("{}", serde_json::to_string_pretty(&output).unwrap());
     } else {
-        println!("omni {}", version_str);
+        println!("OMNI v{}", version_str);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::VersionJson;
+
+    #[test]
+    fn test_version_json_schema_validation() {
+        let json_struct = VersionJson {
+            version: "0.5.9".to_string(),
+            build_date: "2026-06-05".to_string(),
+            git_hash: "abc1234".to_string(),
+            features: vec!["hermes".to_string(), "mcp".to_string()],
+        };
+
+        let json_str = serde_json::to_string(&json_struct).unwrap();
+        assert!(json_str.contains("\"version\":\"0.5.9\""));
+        assert!(json_str.contains("\"build_date\":\"2026-06-05\""));
+        assert!(json_str.contains("\"git_hash\":\"abc1234\""));
+        assert!(json_str.contains("\"features\":[\"hermes\",\"mcp\"]"));
     }
 }

--- a/src/cli/version.rs
+++ b/src/cli/version.rs
@@ -1,0 +1,35 @@
+use serde::Serialize;
+
+#[derive(Serialize)]
+pub struct VersionJson {
+    pub version: String,
+    pub build_date: String,
+    pub git_hash: String,
+    pub features: Vec<String>,
+}
+
+pub fn run_version(args: &[String]) {
+    let json_flag = args.iter().any(|a| a == "--json");
+    let version_str = env!("CARGO_PKG_VERSION").to_string();
+
+    if json_flag {
+        let output = VersionJson {
+            version: version_str,
+            build_date: option_env!("OMNI_BUILD_DATE")
+                .unwrap_or("unknown")
+                .to_string(),
+            git_hash: option_env!("OMNI_GIT_HASH")
+                .unwrap_or("unknown")
+                .to_string(),
+            features: vec![
+                "hermes".to_string(),
+                "mcp".to_string(),
+                "engram".to_string(),
+                "handoff".to_string(),
+            ],
+        };
+        println!("{}", serde_json::to_string_pretty(&output).unwrap());
+    } else {
+        println!("omni {}", version_str);
+    }
+}

--- a/src/guard/config.rs
+++ b/src/guard/config.rs
@@ -111,12 +111,20 @@ pub struct OmniConfig {
 
 impl OmniConfig {
     pub fn for_agent(&self, agent_id: &str) -> AgentConfig {
-        self.agents
-            .as_ref()
-            .and_then(|a| a.get(agent_id))
-            .cloned()
-            .or_else(|| self.global.clone())
-            .unwrap_or_default()
+        // Priority: explicit per-agent config > Hermes defaults > global > generic defaults
+        if let Some(agent_cfg) = self.agents.as_ref().and_then(|a| a.get(agent_id)) {
+            return agent_cfg.clone();
+        }
+
+        // Hermes-optimized defaults when no explicit config exists
+        if crate::agents::hermes::is_hermes_agent(agent_id) {
+            return self
+                .global
+                .clone()
+                .unwrap_or_else(crate::agents::hermes::hermes_default_config);
+        }
+
+        self.global.clone().unwrap_or_default()
     }
 }
 

--- a/src/hooks/pipe.rs
+++ b/src/hooks/pipe.rs
@@ -618,6 +618,25 @@ fn emit_output<W: Write, E: Write>(
         return Ok(());
     }
 
+    if std::env::var("OMNI_OUTPUT_JSON").is_ok() {
+        let tokens_saved = if result.input_text.len() > result.best_output().len() {
+            (result.input_text.len() - result.best_output().len()) / 4
+        } else {
+            0
+        };
+        let json_meta = serde_json::json!({
+            "route": result.route.to_string(),
+            "hash": result.rewind_hash,
+            "tokens_saved": tokens_saved
+        });
+        writeln!(
+            error,
+            "{}",
+            serde_json::to_string(&json_meta).unwrap_or_default()
+        )?;
+        return Ok(());
+    }
+
     let elapsed = result.start_time.elapsed().as_millis();
     let reduction = if !result.input_text.is_empty() {
         100.0 * (1.0 - result.best_output().len() as f64 / result.input_text.len() as f64)

--- a/src/main.rs
+++ b/src/main.rs
@@ -227,7 +227,7 @@ fn main() {
 
             match cmd {
                 "version" | "-v" | "--version" => {
-                    println!("omni {}", env!("CARGO_PKG_VERSION"));
+                    cli::version::run_version(&args);
                 }
 
                 "help" | "-h" | "--help" => {
@@ -265,7 +265,7 @@ fn main() {
                     }
                 },
 
-                "session" => match Store::open() {
+                "session" | "sessions" => match Store::open() {
                     Ok(store) => {
                         let store_arc = Arc::new(store);
                         if let Err(e) = cli::session::run_session(&args, store_arc) {
@@ -275,6 +275,34 @@ fn main() {
                     }
                     Err(e) => {
                         eprintln!("[omni] Cannot open database for session: {}", e);
+                        std::process::exit(1);
+                    }
+                },
+
+                "engram" | "engrams" => match Store::open() {
+                    Ok(store) => {
+                        let store_arc = Arc::new(store);
+                        if let Err(e) = cli::engram::run_engram(&args, store_arc) {
+                            eprintln!("[omni] Engram error: {}", e);
+                            std::process::exit(1);
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!("[omni] Cannot open database for engrams: {}", e);
+                        std::process::exit(1);
+                    }
+                },
+
+                "handoff" => match Store::open() {
+                    Ok(store) => {
+                        let store_arc = Arc::new(store);
+                        if let Err(e) = cli::handoff::run_handoff(&args, store_arc) {
+                            eprintln!("[omni] Handoff error: {}", e);
+                            std::process::exit(1);
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!("[omni] Cannot open database for handoff: {}", e);
                         std::process::exit(1);
                     }
                 },

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -269,28 +269,57 @@ impl OmniServer {
         description = "Show the top recurring issues and error patterns across the entire project"
     )]
     pub async fn omni_insight(&self) -> String {
+        let mut report = String::new();
+
+        // Proactive: Context Pressure Notification (Item 10)
+        if let Ok(s) = self.session.lock() {
+            if let Some(warning) = s.pressure_warning() {
+                report.push_str(&warning);
+                report.push_str("\n\n");
+            }
+
+            // Surface active errors for quick awareness
+            if !s.active_errors.is_empty() {
+                report.push_str(&format!(
+                    "⚠ Active errors ({}): {}\n\n",
+                    s.active_errors.len(),
+                    s.active_errors
+                        .first()
+                        .map(|e| e[..e.len().min(80)].to_string())
+                        .unwrap_or_default()
+                ));
+            }
+        }
+
         let patterns = self.store.get_top_insights(5);
-        if patterns.is_empty() {
+        if patterns.is_empty() && report.is_empty() {
             return "No recurring issues detected yet.".to_string();
         }
 
-        let mut report = format!("Top {} recurring issues:\n\n", patterns.len());
-        for (i, p) in patterns.iter().enumerate() {
-            report.push_str(&format!(
-                "[{}] Tool: {} | Seen {}x | Status: {}\n",
-                i + 1,
-                p.tool_family,
-                p.occurrence_count,
-                if p.was_resolved { "RESOLVED" } else { "ACTIVE" }
-            ));
-            let mut pattern_preview = p.pattern_text.replace('\n', " ");
-            if pattern_preview.len() > 100 {
-                pattern_preview.truncate(97);
-                pattern_preview.push_str("...");
+        if !patterns.is_empty() {
+            report.push_str(&format!("Top {} recurring issues:\n\n", patterns.len()));
+            for (i, p) in patterns.iter().enumerate() {
+                report.push_str(&format!(
+                    "[{}] Tool: {} | Seen {}x | Status: {}\n",
+                    i + 1,
+                    p.tool_family,
+                    p.occurrence_count,
+                    if p.was_resolved { "RESOLVED" } else { "ACTIVE" }
+                ));
+                let mut pattern_preview = p.pattern_text.replace('\n', " ");
+                if pattern_preview.len() > 100 {
+                    pattern_preview.truncate(97);
+                    pattern_preview.push_str("...");
+                }
+                report.push_str(&format!("  Pattern: {}\n\n", pattern_preview));
             }
-            report.push_str(&format!("  Pattern: {}\n\n", pattern_preview));
         }
-        report
+
+        if report.is_empty() {
+            "No recurring issues detected yet.".to_string()
+        } else {
+            report
+        }
     }
 
     #[tool(

--- a/tests/hook_e2e.rs
+++ b/tests/hook_e2e.rs
@@ -328,8 +328,8 @@ fn test_cli_version() {
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        stdout.contains("omni"),
-        "Version output should contain 'omni'"
+        stdout.contains("OMNI"),
+        "Version output should contain 'OMNI'"
     );
 }
 

--- a/tests/smoke_test.sh
+++ b/tests/smoke_test.sh
@@ -200,6 +200,57 @@ else
 fi
 TOTAL=$((TOTAL + 1))
 
+# ─── 11. JSON Contracts (Hermes Integration) ─────────────
+echo "▸ Scenario 11: JSON Contracts"
+
+# Test version --json
+VERSION_JSON=$("$OMNI" version --json 2>&1 || true)
+if echo "$VERSION_JSON" | python3 -c 'import sys,json; json.load(sys.stdin)' 2>/dev/null; then
+    echo "  ✓ version --json is valid JSON"
+    PASS=$((PASS + 1))
+else
+    echo "  ✗ version --json is NOT valid JSON"
+    FAIL=$((FAIL + 1))
+fi
+TOTAL=$((TOTAL + 1))
+check "version json has git_hash" "$VERSION_JSON" "git_hash"
+
+# Test stats --json
+STATS_JSON=$("$OMNI" stats --json 2>&1 || true)
+if echo "$STATS_JSON" | python3 -c 'import sys,json; json.load(sys.stdin)' 2>/dev/null; then
+    echo "  ✓ stats --json is valid JSON"
+    PASS=$((PASS + 1))
+else
+    echo "  ✗ stats --json is NOT valid JSON"
+    FAIL=$((FAIL + 1))
+fi
+TOTAL=$((TOTAL + 1))
+check "stats json has avg_latency_ms" "$STATS_JSON" "avg_latency_ms"
+
+# Test session --json
+SESSION_JSON=$("$OMNI" session --json 2>&1 || true)
+if echo "$SESSION_JSON" | python3 -c 'import sys,json; json.load(sys.stdin)' 2>/dev/null; then
+    echo "  ✓ session --json is valid JSON"
+    PASS=$((PASS + 1))
+else
+    echo "  ✗ session --json is NOT valid JSON"
+    FAIL=$((FAIL + 1))
+fi
+TOTAL=$((TOTAL + 1))
+check "session json has context_pressure" "$SESSION_JSON" "context_pressure"
+
+# Test handoff --json
+HANDOFF_JSON=$("$OMNI" handoff --json 2>&1 || true)
+if echo "$HANDOFF_JSON" | python3 -c 'import sys,json; json.load(sys.stdin)' 2>/dev/null; then
+    echo "  ✓ handoff --json is valid JSON"
+    PASS=$((PASS + 1))
+else
+    echo "  ✗ handoff --json is NOT valid JSON"
+    FAIL=$((FAIL + 1))
+fi
+TOTAL=$((TOTAL + 1))
+check "handoff json has markdown_export" "$HANDOFF_JSON" "markdown_export"
+
 # ─── Results ─────────────────────────────────────────────
 echo ""
 echo "═══════════════════════════════════════════"


### PR DESCRIPTION
<!-- AI-PR-DESCRIPTION-START -->
## PR Auto Describe


## Summary
This PR adds **Hermes agent integration**, **machine-readable JSON output** for all major CLI commands, and two new commands (`omni engram`, `omni handoff`). Build scripts now inject git hash and build date for better traceability.

---

## Key Changes

- **Hermes Agent Support**: Detection, config defaults, command patterns; `is_hermes_agent()` helper
- **JSON Output Modes**: `--json` flag added to `version`, `session`, `stats`, `doctor`, `handoff` with typed structs
- **New CLI Commands**: `omni engram` (list subtask digests), `omni handoff` (export session state)
- **Build Integration**: `build.rs` injects `OMNI_GIT_HASH` and `OMNI_BUILD_DATE` at compile time
- **MCP Enhancements**: `omni_insight` now proactively surfaces context pressure warnings
- **README**: Updated feature descriptions for MCP, multi-agent, context pressure, session handoffs

---

## Detailed Breakdown

### CLI & Commands
| File | Change |
|------|--------|
| `src/cli/version.rs` | New module; `version --json` outputs typed `VersionJson` with git_hash, build_date, features |
| `src/cli/engram.rs` | New module; `omni engram list --json` exports subtask digests |
| `src/cli/handoff.rs` | New module; `omni handoff --json` exports session context as markdown |
| `src/cli/session.rs` | Added `session --json` with `SessionJson` struct; added `--json` alias |
| `src/cli/stats.rs` | Replaced `serde_json::json!` macros with typed structs (`StatsJson`, `StatsPeriod`, `CommandStat`, `AgentStat`, `RewindStat`) |
| `src/cli/doctor.rs` | Added `doctor --json` with `DoctorJson`/`DoctorCheck` structs; `doctor --fix` auto-creates `~/.omni/` |
| `src/cli/mod.rs` | Added `engram`, `handoff`, `version` module exports |
| `src/main.rs` | Registered `session|sessions`, `engram|engrams`, `handoff`, `version` commands; delegated to new modules |

### Agent Integration
| File | Change |
|------|--------|
| `src/agents/hermes.rs` | Added `hermes_default_config()`, `hermes_command_patterns()`, `is_hermes_agent()` with tests |
| `src/guard/config.rs` | `for_agent()` now checks Hermes identity before falling back to global config |

### MCP Server
| File | Change |
|------|--------|
| `src/mcp/server.rs` | `omni_insight` now includes proactive context pressure warnings and active error summaries |

### Build & Hooks
| File | Change |
|------|--------|
| `build.rs` | New file; runs `git rev-parse` and `date` to inject `OMNI_GIT_HASH`, `OMNI_BUILD_DATE` |
| `src/hooks/pipe.rs` | Added `OMNI_OUTPUT_JSON` env var for structured metadata output |

### Documentation
| File | Change |
|------|--------|
| `README.md` | Updated MCP server description, added "Token Traffic Light" / proactive context pressure, expanded multi-agent / session handoff sections |

### Tests
| File | Change |
|------|--------|
| `tests/hook_e2e.rs` | Updated version assertion from lowercase `omni` to uppercase `OMNI` |
| `tests/smoke_test.sh` | Added Scenario 11: JSON contract validation for `version`, `stats`, `session`, `handoff` commands |

---

## Breaking Changes
- `omni session` now accepts `session` or `sessions` (plural alias)
- `omni version` output changed from `"omni X.Y.Z"` to `"OMNI vX.Y.Z"` (caps + `v` prefix)
- `stats --json` schema changed from anonymous `serde_json::Value` arrays to typed structs; top-level now includes `version`, `generated_at`, `avg_latency_ms`

_Last updated: 2026-06-05 03:11:57_
<!-- AI-PR-DESCRIPTION-END -->