### PR TITLE
fix(pipeline): gate structured output out of the lossy path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+
+### Fixed
+- **Format-safe compression (data integrity)**: The pipeline had no format awareness, so collapse squashed the repeated lines of structured output into `[N similar lines collapsed]` and left the payload unparseable — breaking any downstream `jq` / `json.load` / `kubectl apply`. A JSON dashboard piped through the hook came out with 14 collapse markers and failed `jq` outright. A new format sniffer (`pipeline::format`) now gates both choke points (`hooks::post_tool`, `hooks::pipe`): JSON, NDJSON, YAML, TSV, and CSV pass through byte-for-byte at zero marker cost, while plain text still compresses as before.
+
 ## [0.6.1] - 2026-06-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,9 +423,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/src/hooks/normalize.rs
+++ b/src/hooks/normalize.rs
@@ -151,7 +151,8 @@ fn normalize_claude_code(input: &str, agent_id: String) -> Option<NormalizedInpu
     let response = parsed.tool_response.as_ref()?;
     let content = if let Some(ref c) = response.content {
         extract_value_content(c)?
-    } else if let Some(ref stdout) = response.stdout {
+    } else {
+        let stdout = response.stdout.as_ref()?;
         if stdout.is_empty() {
             return None;
         }
@@ -163,8 +164,6 @@ fn normalize_claude_code(input: &str, agent_id: String) -> Option<NormalizedInpu
             s.push_str(stderr);
         }
         s
-    } else {
-        return None;
     };
 
     let command = parsed
@@ -226,11 +225,7 @@ fn normalize_pi(input: &str, agent_id: String) -> Option<NormalizedInput> {
     let response = parsed.tool_response.as_ref()?;
 
     // Extract content from "result" field (string or object with nested fields)
-    let content = if let Some(ref r) = response.result {
-        extract_value_content(r)?
-    } else {
-        return None;
-    };
+    let content = extract_value_content(response.result.as_ref()?)?;
 
     if content.is_empty() {
         return None;

--- a/src/hooks/pipe.rs
+++ b/src/hooks/pipe.rs
@@ -119,6 +119,25 @@ pub fn run_inner<R: Read, W: Write, E: Write>(
         return Ok(());
     }
 
+    // Phase 2.5: Format-safe gate. Structured payloads are machine-read downstream
+    // (`jq`, `json.load`, `kubectl apply`); collapse and the distillers would leave
+    // them unparseable. Emit the input verbatim, byte for byte.
+    if let Some(kind) = crate::pipeline::format::sniff(&input_text) {
+        output.write_all(input_text.as_bytes())?;
+        output.flush()?;
+        if let Some(s) = &store {
+            s.record_passthrough(
+                &format!(
+                    "{} [{}]",
+                    command_to_use.unwrap_or(""),
+                    crate::pipeline::format::passthrough_reason(kind)
+                ),
+                input_text.len(),
+            );
+        }
+        return Ok(());
+    }
+
     // Phase 3: Transcript Begin
     let project_path = std::env::current_dir()
         .map(|p| p.to_string_lossy().to_string())

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -1,5 +1,5 @@
 use crate::pipeline::toml_filter;
-use crate::pipeline::{DistillResult, Route, SessionState, collapse, scorer};
+use crate::pipeline::{DistillResult, Route, SessionState, collapse, format, scorer};
 use crate::store::sqlite::Store;
 use serde::Serialize;
 use std::sync::{Arc, Mutex};
@@ -32,6 +32,23 @@ pub fn process_payload(
     let normalized = crate::hooks::normalize::normalize(input_str)?;
 
     if crate::guard::env::is_passthrough() {
+        return None;
+    }
+
+    // Format-safe gate: structured payloads are parsed by whatever reads them next,
+    // so every lossy stage below — including the >2MB head/tail trim — would corrupt
+    // them. Emit nothing: the host keeps the original bytes at zero marker cost.
+    if let Some(kind) = format::sniff(&normalized.content) {
+        if let Some(ref s) = store {
+            s.record_passthrough(
+                &format!(
+                    "{} [{}]",
+                    normalized.command,
+                    format::passthrough_reason(kind)
+                ),
+                normalized.content.len(),
+            );
+        }
         return None;
     }
 

--- a/src/pipeline/format.rs
+++ b/src/pipeline/format.rs
@@ -1,0 +1,341 @@
+//! Format sniffer — detects structured, machine-read payloads.
+//!
+//! Collapse and the distillers are lossy: they are safe on human-facing free text
+//! but they corrupt anything a later step parses (`jq`, `json.load`, `kubectl apply`).
+//! The sniffer is the gate that keeps those payloads out of the lossy path.
+//!
+//! Design principle: when a payload is *plausibly* structured, say so — a missed
+//! compression is cheap, a corrupted payload is not. Detection is still positive
+//! (a signal must be present), because treating unknown text as structured would
+//! disable compression everywhere.
+
+use std::fmt;
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+/// Above this size a full `serde_json` parse would blow the pipeline's latency
+/// budget, so bracket-shape alone decides.
+const MAX_PARSE_BYTES: usize = 1_000_000;
+
+/// Number of NDJSON lines actually parsed before trusting the rest.
+const NDJSON_SAMPLE_LINES: usize = 50;
+
+/// Minimum rows before a consistent delimiter count means anything.
+const MIN_DELIMITED_LINES: usize = 3;
+
+/// A structured payload kind. Every variant must survive the pipeline verbatim.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Structured {
+    Json,
+    Ndjson,
+    Yaml,
+    Tsv,
+    Csv,
+}
+
+impl Structured {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Structured::Json => "json",
+            Structured::Ndjson => "ndjson",
+            Structured::Yaml => "yaml",
+            Structured::Tsv => "tsv",
+            Structured::Csv => "csv",
+        }
+    }
+}
+
+impl fmt::Display for Structured {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+/// Label recorded on the passthrough event when the gate fires.
+pub fn passthrough_reason(kind: Structured) -> String {
+    format!("structured:{}", kind)
+}
+
+/// Classify `input`. `None` means plain text — safe to compress.
+pub fn sniff(input: &str) -> Option<Structured> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    // NDJSON sits between the two JSON checks: a `{…}\n{…}` stream is bracketed like
+    // a JSON document but only parses line by line.
+    sniff_json(trimmed)
+        .or_else(|| sniff_ndjson(trimmed))
+        .or_else(|| sniff_json_shaped(trimmed))
+        .or_else(|| sniff_yaml(trimmed))
+        .or_else(|| sniff_delimited(trimmed))
+}
+
+/// True when `input` must not be compressed.
+pub fn is_structured(input: &str) -> bool {
+    sniff(input).is_some()
+}
+
+/// Definitive JSON: a whole document that parses (or is too big to parse in budget).
+fn sniff_json(trimmed: &str) -> Option<Structured> {
+    if !is_bracketed(trimmed) {
+        return None;
+    }
+
+    // Too large to parse in budget: bracket shape is the only evidence we can
+    // afford, and it is enough to stay off the lossy path.
+    if trimmed.len() > MAX_PARSE_BYTES {
+        return Some(Structured::Json);
+    }
+
+    serde_json::from_str::<serde_json::Value>(trimmed)
+        .ok()
+        .map(|_| Structured::Json)
+}
+
+/// Bracketed but unparseable — truncated or comment-bearing JSON. Unsure →
+/// structured: compression cannot repair it, but it can make it worse.
+fn sniff_json_shaped(trimmed: &str) -> Option<Structured> {
+    if is_bracketed(trimmed) && has_json_field_syntax(trimmed) {
+        return Some(Structured::Json);
+    }
+    None
+}
+
+fn is_bracketed(trimmed: &str) -> bool {
+    let (Some(first), Some(last)) = (
+        trimmed.as_bytes().first().copied(),
+        trimmed.as_bytes().last().copied(),
+    ) else {
+        return false;
+    };
+    (first == b'{' && last == b'}') || (first == b'[' && last == b']')
+}
+
+/// Looks for `"key":` — the one bit of syntax free text almost never carries.
+fn has_json_field_syntax(text: &str) -> bool {
+    static JSON_FIELD: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r#""[^"]*"\s*:"#).expect("valid json field regex"));
+    JSON_FIELD.is_match(text)
+}
+
+fn sniff_ndjson(trimmed: &str) -> Option<Structured> {
+    let lines: Vec<&str> = non_empty_lines(trimmed);
+    if lines.len() < 2 {
+        return None;
+    }
+    if !lines
+        .iter()
+        .all(|l| l.starts_with('{') || l.starts_with('['))
+    {
+        return None;
+    }
+    // Parsing every line of a huge stream is not worth the latency; a sample that
+    // holds is strong enough evidence.
+    if lines
+        .iter()
+        .take(NDJSON_SAMPLE_LINES)
+        .all(|l| serde_json::from_str::<serde_json::Value>(l).is_ok())
+    {
+        return Some(Structured::Ndjson);
+    }
+    None
+}
+
+fn sniff_yaml(trimmed: &str) -> Option<Structured> {
+    let lines: Vec<&str> = trimmed.lines().filter(|l| !l.trim().is_empty()).collect();
+    if lines.is_empty() {
+        return None;
+    }
+
+    // A leading document marker is unambiguous.
+    let first = lines[0].trim_end();
+    if first == "---" || first.starts_with("--- ") {
+        return Some(Structured::Yaml);
+    }
+
+    if lines.len() < 2 {
+        return None;
+    }
+
+    // Otherwise every line must be YAML-shaped, and the document must show real
+    // structure (nesting or a list). Free-text logs fail the first test: their
+    // lines carry no `key:` at all.
+    if !lines.iter().all(|l| is_yaml_shaped(l)) {
+        return None;
+    }
+    let has_structure = lines
+        .iter()
+        .any(|l| l.starts_with(' ') || l.trim_start().starts_with("- "));
+    if !has_structure {
+        return None;
+    }
+
+    Some(Structured::Yaml)
+}
+
+fn is_yaml_shaped(line: &str) -> bool {
+    static YAML_KEY: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r#"^\s*(?:"[^"]*"|'[^']*'|[A-Za-z_][A-Za-z0-9_.\-/]*)\s*:(?:\s.*|)$"#)
+            .expect("valid yaml key regex")
+    });
+
+    let trimmed = line.trim();
+    if trimmed.starts_with('#') || trimmed == "---" || trimmed == "..." {
+        return true;
+    }
+    if trimmed == "-" || trimmed.starts_with("- ") {
+        return true;
+    }
+    YAML_KEY.is_match(line)
+}
+
+fn sniff_delimited(trimmed: &str) -> Option<Structured> {
+    let lines = non_empty_lines(trimmed);
+    if lines.len() < MIN_DELIMITED_LINES {
+        return None;
+    }
+
+    for (delim, kind) in [('\t', Structured::Tsv), (',', Structured::Csv)] {
+        let expected = lines[0].matches(delim).count();
+        if expected == 0 {
+            continue;
+        }
+        if lines.iter().all(|l| l.matches(delim).count() == expected) {
+            return Some(kind);
+        }
+    }
+
+    None
+}
+
+fn non_empty_lines(text: &str) -> Vec<&str> {
+    text.lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_json_object() {
+        assert_eq!(sniff(r#"{"a": 1, "b": [2, 3]}"#), Some(Structured::Json));
+    }
+
+    #[test]
+    fn detects_json_array_of_similar_objects() {
+        // The live repro: `az ... -o json` shaped output that collapse used to squash.
+        let items: Vec<String> = (0..20)
+            .map(|i| format!(r#"{{"name": "vm-{i}", "location": "eastus", "id": {i}}}"#))
+            .collect();
+        let payload = format!("[\n  {}\n]", items.join(",\n  "));
+        assert_eq!(sniff(&payload), Some(Structured::Json));
+    }
+
+    #[test]
+    fn detects_pretty_printed_json_with_newlines() {
+        let payload = "{\n  \"kind\": \"List\",\n  \"items\": [\n    {\"n\": 1}\n  ]\n}";
+        assert_eq!(sniff(payload), Some(Structured::Json));
+    }
+
+    #[test]
+    fn treats_truncated_json_as_structured() {
+        // Unsure → structured. Compressing a truncated payload cannot help it.
+        let payload = r#"{"items": [{"name": "a"}, {"name": "b"#;
+        assert_eq!(sniff(payload), None, "unbracketed tail is not JSON-shaped");
+
+        let bracketed = r#"{"items": [{"name": "a"}, {"name": }"#;
+        assert_eq!(sniff(bracketed), Some(Structured::Json));
+    }
+
+    #[test]
+    fn detects_ndjson_stream() {
+        let payload =
+            "{\"ts\": 1, \"msg\": \"a\"}\n{\"ts\": 2, \"msg\": \"b\"}\n{\"ts\": 3, \"msg\": \"c\"}";
+        assert_eq!(sniff(payload), Some(Structured::Ndjson));
+    }
+
+    #[test]
+    fn detects_yaml_with_document_marker() {
+        let payload = "---\napiVersion: v1\nkind: ConfigMap\ndata:\n  key: value\n";
+        assert_eq!(sniff(payload), Some(Structured::Yaml));
+    }
+
+    #[test]
+    fn detects_yaml_without_document_marker() {
+        let payload = "apiVersion: apps/v1\nkind: Deployment\nspec:\n  replicas: 3\n";
+        assert_eq!(sniff(payload), Some(Structured::Yaml));
+    }
+
+    #[test]
+    fn detects_tsv_table() {
+        let payload = "name\tstatus\tage\npod-a\tRunning\t1d\npod-b\tRunning\t2d\n";
+        assert_eq!(sniff(payload), Some(Structured::Tsv));
+    }
+
+    #[test]
+    fn detects_csv_table() {
+        let payload = "name,status,age\npod-a,Running,1d\npod-b,Running,2d\n";
+        assert_eq!(sniff(payload), Some(Structured::Csv));
+    }
+
+    #[test]
+    fn treats_build_log_as_plain_text() {
+        let payload = "   Compiling serde v1.0.203\n   Compiling omni v0.6.1\n\
+                       error[E0308]: mismatched types\n  --> src/main.rs:3:5\n   |\n\
+                       3  |     let x: i32 = \"s\";\n   |            ---   ^^^ expected i32\n\
+                       error: could not compile `omni` due to 1 previous error\n";
+        assert_eq!(sniff(payload), None);
+    }
+
+    #[test]
+    fn treats_log_lines_with_colons_as_plain_text() {
+        // `level: message` looks superficially like YAML — it must not gate.
+        let payload = "INFO: starting server\nWARN: cache miss\nERROR: connection refused\n";
+        assert_eq!(sniff(payload), None);
+    }
+
+    #[test]
+    fn treats_git_status_as_plain_text() {
+        let payload = "On branch main\nChanges not staged for commit:\n  \
+                       modified:   src/main.rs\n  modified:   src/lib.rs\n";
+        assert_eq!(sniff(payload), None);
+    }
+
+    #[test]
+    fn treats_empty_input_as_plain_text() {
+        assert_eq!(sniff(""), None);
+        assert_eq!(sniff("   \n\n  "), None);
+    }
+
+    #[test]
+    fn treats_prose_as_plain_text() {
+        let payload = "The quick brown fox jumps over the lazy dog.\n\
+                       Pack my box with five dozen liquor jugs.\n";
+        assert_eq!(sniff(payload), None);
+    }
+
+    #[test]
+    fn survives_binary_noise_without_panicking() {
+        let payload = "\u{0}\u{1}\u{2}garbage\u{7f}\u{fffd}{[}]";
+        let _ = sniff(payload);
+    }
+
+    #[test]
+    fn oversized_bracketed_payload_short_circuits_to_json() {
+        let filler = "x".repeat(MAX_PARSE_BYTES + 1);
+        let payload = format!("{{{}}}", filler);
+        assert_eq!(sniff(&payload), Some(Structured::Json));
+    }
+
+    #[test]
+    fn reason_label_names_the_kind() {
+        assert_eq!(passthrough_reason(Structured::Json), "structured:json");
+        assert_eq!(passthrough_reason(Structured::Yaml), "structured:yaml");
+    }
+}

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -1,5 +1,6 @@
 pub mod analyzer;
 pub mod collapse;
+pub mod format;
 pub mod registry;
 pub mod scorer;
 pub mod semantic;

--- a/tests/fixtures/az_vm_list.json
+++ b/tests/fixtures/az_vm_list.json
@@ -1,0 +1,102 @@
+[
+  {
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-prod/providers/Microsoft.Compute/virtualMachines/vm-web-01",
+    "location": "southeastasia",
+    "name": "vm-web-01",
+    "powerState": "VM running",
+    "provisioningState": "Succeeded",
+    "resourceGroup": "rg-prod",
+    "tags": { "env": "prod", "team": "platform" },
+    "vmSize": "Standard_D2s_v3"
+  },
+  {
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-prod/providers/Microsoft.Compute/virtualMachines/vm-web-02",
+    "location": "southeastasia",
+    "name": "vm-web-02",
+    "powerState": "VM running",
+    "provisioningState": "Succeeded",
+    "resourceGroup": "rg-prod",
+    "tags": { "env": "prod", "team": "platform" },
+    "vmSize": "Standard_D2s_v3"
+  },
+  {
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-prod/providers/Microsoft.Compute/virtualMachines/vm-web-03",
+    "location": "southeastasia",
+    "name": "vm-web-03",
+    "powerState": "VM running",
+    "provisioningState": "Succeeded",
+    "resourceGroup": "rg-prod",
+    "tags": { "env": "prod", "team": "platform" },
+    "vmSize": "Standard_D2s_v3"
+  },
+  {
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-prod/providers/Microsoft.Compute/virtualMachines/vm-api-01",
+    "location": "southeastasia",
+    "name": "vm-api-01",
+    "powerState": "VM running",
+    "provisioningState": "Succeeded",
+    "resourceGroup": "rg-prod",
+    "tags": { "env": "prod", "team": "backend" },
+    "vmSize": "Standard_D4s_v3"
+  },
+  {
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-prod/providers/Microsoft.Compute/virtualMachines/vm-api-02",
+    "location": "southeastasia",
+    "name": "vm-api-02",
+    "powerState": "VM running",
+    "provisioningState": "Succeeded",
+    "resourceGroup": "rg-prod",
+    "tags": { "env": "prod", "team": "backend" },
+    "vmSize": "Standard_D4s_v3"
+  },
+  {
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-prod/providers/Microsoft.Compute/virtualMachines/vm-api-03",
+    "location": "southeastasia",
+    "name": "vm-api-03",
+    "powerState": "VM deallocated",
+    "provisioningState": "Succeeded",
+    "resourceGroup": "rg-prod",
+    "tags": { "env": "prod", "team": "backend" },
+    "vmSize": "Standard_D4s_v3"
+  },
+  {
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-staging/providers/Microsoft.Compute/virtualMachines/vm-web-01",
+    "location": "southeastasia",
+    "name": "vm-web-01",
+    "powerState": "VM running",
+    "provisioningState": "Succeeded",
+    "resourceGroup": "rg-staging",
+    "tags": { "env": "staging", "team": "platform" },
+    "vmSize": "Standard_B2s"
+  },
+  {
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-staging/providers/Microsoft.Compute/virtualMachines/vm-api-01",
+    "location": "southeastasia",
+    "name": "vm-api-01",
+    "powerState": "VM running",
+    "provisioningState": "Succeeded",
+    "resourceGroup": "rg-staging",
+    "tags": { "env": "staging", "team": "backend" },
+    "vmSize": "Standard_B2s"
+  },
+  {
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-staging/providers/Microsoft.Compute/virtualMachines/vm-worker-01",
+    "location": "southeastasia",
+    "name": "vm-worker-01",
+    "powerState": "VM running",
+    "provisioningState": "Succeeded",
+    "resourceGroup": "rg-staging",
+    "tags": { "env": "staging", "team": "data" },
+    "vmSize": "Standard_B2s"
+  },
+  {
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-dev/providers/Microsoft.Compute/virtualMachines/vm-sandbox-01",
+    "location": "southeastasia",
+    "name": "vm-sandbox-01",
+    "powerState": "VM deallocated",
+    "provisioningState": "Succeeded",
+    "resourceGroup": "rg-dev",
+    "tags": { "env": "dev", "team": "platform" },
+    "vmSize": "Standard_B1s"
+  }
+]

--- a/tests/fixtures/grafana_dashboard.json
+++ b/tests/fixtures/grafana_dashboard.json
@@ -1,0 +1,127 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "axisLabel": "", "drawStyle": "line", "fillOpacity": 10 },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "targets": [
+        {
+          "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"prod\"}[5m])) by (pod)",
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "title": "CPU usage by pod",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "axisLabel": "", "drawStyle": "line", "fillOpacity": 10 },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "id": 2,
+      "targets": [
+        {
+          "expr": "sum(container_memory_working_set_bytes{namespace=\"prod\"}) by (pod)",
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Memory working set by pod",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "id": 3,
+      "targets": [
+        {
+          "expr": "sum(kube_pod_container_status_restarts_total{namespace=\"prod\"}) by (pod)",
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Container restarts",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "id": 4,
+      "targets": [
+        {
+          "expr": "probe_success{job=\"blackbox\"}",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Blackbox probe success",
+      "type": "stat"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["kubernetes", "prod"],
+  "templating": { "list": [] },
+  "time": { "from": "now-6h", "to": "now" },
+  "timezone": "browser",
+  "title": "Prod / Kubernetes overview",
+  "uid": "prod-k8s-overview",
+  "version": 7
+}

--- a/tests/format_safe.rs
+++ b/tests/format_safe.rs
@@ -1,0 +1,219 @@
+//! Format-safe gate — structured payloads must leave the hooks byte-for-byte intact.
+//!
+//! Regression cover for the live repro: `az … -o json` and `git show <dashboard>.json`
+//! had their repeated lines squashed into `[N similar lines collapsed]`, so the payload
+//! no longer parsed and every downstream `jq` / `json.load` / `kubectl apply` broke.
+
+use std::path::Path;
+
+use omni::hooks::{pipe, post_tool};
+use serde_json::Value;
+
+fn fixture(name: &str) -> String {
+    let path = Path::new("tests").join("fixtures").join(name);
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+/// Run input through the pipe hook and return stdout.
+fn pipe_through(input: &str, command: &str) -> String {
+    let mut out = Vec::new();
+    let mut err = Vec::new();
+    pipe::run_inner(
+        input.as_bytes(),
+        &mut out,
+        &mut err,
+        None,
+        None,
+        Some(command),
+    )
+    .expect("pipe hook must not fail");
+    String::from_utf8(out).expect("pipe output must stay valid UTF-8")
+}
+
+/// Build a Claude Code PostToolUse payload around a tool's raw output.
+fn bash_payload(command: &str, content: &str) -> String {
+    serde_json::json!({
+        "tool_name": "Bash",
+        "tool_input": { "command": command },
+        "tool_response": { "content": content },
+    })
+    .to_string()
+}
+
+#[test]
+fn az_json_output_survives_pipe_byte_for_byte() {
+    // Arrange
+    let raw = fixture("az_vm_list.json");
+
+    // Act
+    let out = pipe_through(&raw, "az vm list -o json");
+
+    // Assert
+    assert_eq!(out, raw, "structured output must pass through unmodified");
+    assert_eq!(
+        serde_json::from_str::<Value>(&out).expect("output must still parse"),
+        serde_json::from_str::<Value>(&raw).expect("fixture must parse"),
+        "output must parse to the same value"
+    );
+}
+
+#[test]
+fn json_dashboard_survives_pipe_byte_for_byte() {
+    // The `git show` repro: a large JSON dashboard piped through the hook.
+    let raw = fixture("grafana_dashboard.json");
+
+    let out = pipe_through(&raw, "git show HEAD:dashboards/prod-k8s-overview.json");
+
+    assert_eq!(out, raw);
+    assert_eq!(
+        serde_json::from_str::<Value>(&out).expect("dashboard must still parse"),
+        serde_json::from_str::<Value>(&raw).expect("fixture must parse")
+    );
+}
+
+#[test]
+fn json_array_of_similar_objects_is_not_collapsed() {
+    // 20 look-alike lines is exactly what collapse used to squash.
+    let raw = format!(
+        "[\n{}\n]",
+        (0..20)
+            .map(|i| format!(r#"  {{"name": "pod-{i}", "status": "Running", "restarts": 0}}"#))
+            .collect::<Vec<_>>()
+            .join(",\n")
+    );
+
+    let out = pipe_through(&raw, "kubectl get pods -o json");
+
+    assert!(
+        !out.contains("collapsed"),
+        "collapse marker must never appear in structured output: {out}"
+    );
+    assert_eq!(
+        serde_json::from_str::<Value>(&out).expect("output must still parse"),
+        serde_json::from_str::<Value>(&raw).expect("input must parse")
+    );
+}
+
+#[test]
+fn ndjson_log_survives_pipe_byte_for_byte() {
+    let raw = (0..30)
+        .map(|i| format!(r#"{{"ts": {i}, "level": "info", "msg": "request served"}}"#))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let out = pipe_through(&raw, "kubectl logs deploy/api");
+
+    assert_eq!(out, raw);
+    for line in out.lines() {
+        serde_json::from_str::<Value>(line).expect("every NDJSON line must still parse");
+    }
+}
+
+#[test]
+fn yaml_manifest_survives_pipe_byte_for_byte() {
+    let raw = "---\n\
+               apiVersion: apps/v1\n\
+               kind: Deployment\n\
+               metadata:\n  \
+                 name: api\n  \
+                 namespace: prod\n\
+               spec:\n  \
+                 replicas: 3\n  \
+                 template:\n    \
+                   spec:\n      \
+                     containers:\n        \
+                       - name: api\n          \
+                         image: registry.example.com/api:1.2.3\n";
+
+    let out = pipe_through(raw, "kubectl get deploy api -o yaml");
+
+    assert_eq!(out, raw);
+}
+
+#[test]
+fn post_tool_hook_leaves_structured_output_untouched() {
+    // `None` means "no rewrite" — the host keeps the original bytes at zero marker cost.
+    let raw = fixture("az_vm_list.json");
+    let payload = bash_payload("az vm list -o json", &raw);
+
+    let out = post_tool::process_payload(&payload, None, None);
+
+    assert!(
+        out.is_none(),
+        "structured output must not be rewritten, got: {out:?}"
+    );
+}
+
+#[test]
+fn post_tool_hook_leaves_json_dashboard_untouched() {
+    let raw = fixture("grafana_dashboard.json");
+    let payload = bash_payload("git show HEAD:dashboards/prod-k8s-overview.json", &raw);
+
+    assert!(post_tool::process_payload(&payload, None, None).is_none());
+}
+
+#[test]
+fn chatty_build_log_still_compresses_through_pipe() {
+    // The gate must not over-trigger: plain text is still the pipeline's job.
+    let raw = fixture("heavy_noise.txt");
+
+    let out = pipe_through(&raw, "docker build .");
+
+    assert!(
+        out.len() < raw.len(),
+        "text build log must still compress: {} → {} bytes",
+        raw.len(),
+        out.len()
+    );
+}
+
+#[test]
+fn git_diff_still_compresses_through_pipe() {
+    let raw = fixture("git_diff_multi_file.txt");
+
+    let out = pipe_through(&raw, "git diff");
+
+    assert!(
+        out.len() < raw.len(),
+        "git diff must still compress: {} → {} bytes",
+        raw.len(),
+        out.len()
+    );
+}
+
+#[test]
+fn space_aligned_table_still_compresses_through_pipe() {
+    // `kubectl get pods` is column-aligned with spaces, not tabs — the delimited
+    // sniffer must not mistake it for TSV and gate it.
+    let raw = fixture("kubectl_pods_mixed.txt");
+
+    let out = pipe_through(&raw, "kubectl get pods");
+
+    assert!(
+        out.len() < raw.len(),
+        "space-aligned table must still compress: {} → {} bytes",
+        raw.len(),
+        out.len()
+    );
+}
+
+#[test]
+fn post_tool_hook_still_distills_text_build_log() {
+    let raw = fixture("cargo_build_errors.txt");
+    let payload = bash_payload("cargo build", &raw);
+
+    assert!(
+        post_tool::process_payload(&payload, None, None).is_some(),
+        "text build log must still be distilled"
+    );
+}
+
+#[test]
+fn malformed_json_passes_through_without_panicking() {
+    // Unsure → structured. A truncated payload cannot be helped by compression.
+    let raw = r#"{"items": [{"name": "a"}, {"name": "b"}, {"name": }"#;
+
+    let out = pipe_through(raw, "az vm list -o json");
+
+    assert_eq!(out, raw);
+}

--- a/tests/savings_assertions.rs
+++ b/tests/savings_assertions.rs
@@ -221,3 +221,41 @@ fn test_omni_stats_shows_command_not_content_type() {
     );
     assert_eq!(*count, 1);
 }
+
+/// Structured payloads are the one case where 0% savings is the correct answer:
+/// they are parsed downstream, so the pipeline must hand them back untouched.
+#[test]
+fn structured_output_reports_zero_savings_and_preserves_bytes() {
+    use omni::hooks::pipe;
+
+    const STRUCTURED: &[(&str, &str)] = &[
+        ("tests/fixtures/az_vm_list.json", "az vm list -o json"),
+        (
+            "tests/fixtures/grafana_dashboard.json",
+            "git show HEAD:dashboard.json",
+        ),
+    ];
+
+    for (path, command) in STRUCTURED {
+        let raw = std::fs::read_to_string(path).unwrap_or_else(|e| panic!("read {path}: {e}"));
+
+        let mut out = Vec::new();
+        pipe::run_inner(
+            raw.as_bytes(),
+            &mut out,
+            std::io::sink(),
+            None,
+            None,
+            Some(command),
+        )
+        .expect("pipe hook must not fail");
+        let out = String::from_utf8(out).expect("output must stay valid UTF-8");
+
+        let savings_pct = 100.0 * (1.0 - out.len() as f64 / raw.len() as f64);
+        assert_eq!(
+            savings_pct, 0.0,
+            "{path} must report 0% savings, got {savings_pct:.1}%"
+        );
+        assert_eq!(out, raw, "{path} must be byte-preserving");
+    }
+}


### PR DESCRIPTION
## The bug

Collapse had no format awareness. Any output with ≥10 lines and ≥3 look-alike lines got squashed into `[N similar lines collapsed]` — including `az … -o json` arrays and JSON dashboards. The payload no longer parsed, so every downstream `jq` / `json.load` / `kubectl apply` broke.

This is silent corruption of machine-read data, which is worse than zero compression. It's why the workflow needed a bypass rule in the first place.

**Verified on the live repro.** Piping `tests/fixtures/grafana_dashboard.json` through the hook on `main`:

```
collapse markers injected: 14
jq verdict:                PARSE FAILED — payload corrupted
3484B → 2830B  (of "savings" that destroyed the payload)
```

After this change: byte-identical, and `jq` parses it to the same value.

## The fix

New sniffer `src/pipeline/format.rs` classifies JSON / NDJSON / YAML / TSV / CSV, gating both choke points:

- `post_tool::process_payload` — returns `None`, so the host keeps the original bytes at **zero marker cost**
- `pipe::run_inner` — emits the input verbatim, before the TOML filters and collapse

Structured input is recorded as a `structured:<kind>` passthrough event for the Phase 2 accounting work.

In `post_tool` the gate sits ahead of the whole tool-routing match rather than in the `_ =>` arm the spec suggested. The >2MB head/tail trim above it also mangles structured payloads, and the corruption in the live repro came through the **Bash** arm — gating only `_ =>` would have missed the actual bug.

### Detection philosophy

Detection stays **positive** (a signal must be present), because treating unknown text as structured would disable compression everywhere. Within that, ambiguity resolves toward structured, per the spec's principle — a missed compression is cheap, a corrupted payload is not:

- bracketed-but-unparseable JSON (truncated / comment-bearing) → gated
- payloads too large to parse inside the latency budget → gated on bracket shape alone

No new dependencies: YAML uses a conservative shape check rather than pulling in `serde_yaml`.

## Text is untouched

The sniffer returns `None` on every text fixture. I confirmed this empirically by re-running the pipe path with the gate stashed out — output is **byte-for-byte identical to the pre-gate baseline** on every text fixture.

Tests cover the no-over-trigger direction with pairings that genuinely compress: `docker build` on a noisy log (9207B → 5783B), git diff (44.6%), and a space-aligned `kubectl` table (proving the TSV sniffer doesn't mistake space alignment for tabs).

## One thing worth knowing

The YAML sniffer requires *every* line to be YAML-shaped, so a manifest using block scalars (`key: |`) **without** a leading `---` is treated as text and compressed. Doc-marker YAML — the common `kubectl -o yaml` case — is covered. Tightening it further trades against text compression, so I left it; worth revisiting if it shows up in practice.

## Scope

Phase 1 of `docs/specs/2026-07-16-format-safe-compression.md` only. Phase 2 (honest net accounting) and Phase 3 (scope-to-where-it-pays) are **not** in this PR. While measuring, I confirmed Phase 2's premise: the pipe path already nets ~0% on most text fixtures (`cargo build` 3220B → 3220B, `cargo test` 16515B → 16515B) because `MIN_REDUCTION_PCT` returns the input whenever the distiller doesn't beat it. Those numbers are recorded in `docs/specs/RESUME.md` as the Phase 2 starting point.

## Gates

- `cargo test` — green (384 lib + 12 new format-safe + 1 savings case)
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt` — applied

<!-- AI-PR-DESCRIPTION-START -->
## PR Auto Describe


## Summary
Fixes a critical data integrity bug where structured output (JSON/YAML/NDJSON/CSV/TSV) was corrupted by the collapse compression, leaving payloads unparseable by downstream tools (`jq`, `json.load`, `kubectl apply`). Introduces a format sniffer that gates structured payloads through both `hooks::post_tool` and `hooks::pipe` at zero marker cost.

---

## Key Changes

| Area | Change |
|------|--------|
| **New module** | `pipeline/format.rs` — format sniffer (JSON, NDJSON, YAML, TSV, CSV) |
| **Pipe hook** | Phase 2.5 gate: structured payloads pass through byte-for-byte |
| **Post-tool hook** | Early exit with `None` for structured payloads (host keeps original bytes) |
| **normalize.rs** | Fixed stdout extraction in `claude_code` and `pi` format handlers |
| **Tests** | 15 new tests covering passthrough, compression still works on plain text |
| **Fixtures** | `az_vm_list.json`, `grafana_dashboard.json` for regression cover |

---

## Detailed Breakdown

### `src/pipeline/format.rs` (new)
- `sniff(&str) → Option<Structured>` — detects format; `None` = plain text (safe to compress)
- **JSON**: bracket shape + optional `serde_json` parse; falls back to `{"field":}` regex for truncated docs
- **NDJSON**: ≥2 lines starting with `{` or `[`; validates 50-line sample
- **YAML**: `---` marker or all-lines YAML-shaped + real structure (nesting or list)
- **TSV/CSV**: ≥3 non-empty lines, consistent delimiter count across all rows
- **Oversized payloads** (>1MB): bracket shape alone decides (parse budget)
- Design principle: false positives are cheap; false negatives corrupt data

### `src/hooks/pipe.rs`
- Added Phase 2.5 after read/check, before transcript/collapse
- Structured input → `output.write_all()` verbatim, records `passthrough` event, returns

### `src/hooks/post_tool.rs`
- Early return `None` for structured payloads (signal to host: keep original bytes)

### `src/hooks/normalize.rs`
- `claude_code`: collapsed `if let Some(ref stdout) / else { None }` into `let stdout = response.stdout.as_ref()?`
- `pi`: simplified `extract_value_content(response.result.as_ref()?)?` (was `if/else None`)

### `Cargo.lock`
- `crossbeam-epoch` 0.9.18 → 0.9.20 (checksum updated)

---

## Notes
- Compression still works on plain text (build logs, git diffs, space-aligned tables) — confirmed by tests.
- `git diff` and `kubectl get pods` (space-aligned, not TSV) are correctly NOT gated.
- Truncated/uncertain JSON is gated (bracket-shaped with `"key":` syntax) — compression cannot fix it but can make it worse.

---

## Breaking Changes
None. This is a pure bug fix; structured payloads are now correctly preserved.

_Last updated: 2026-07-16 09:20:53_
<!-- AI-PR-DESCRIPTION-END -->