### PR TITLE
chore(ci): pin the Rust toolchain to 1.97.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,18 @@
+# Pin the toolchain so CI is reproducible.
+#
+# .github/workflows/ci.yml uses `dtolnay/rust-toolchain@stable`, which tracks
+# whatever stable shipped most recently. That turned CI red on code nobody had
+# touched: rustc 1.97.0 landed 2026-07-07 with new clippy lints, and the next run
+# after main's last green build (2026-06-24) failed on pre-existing code.
+#
+# rustup reads this file in preference to the workflow's `rustup default stable`,
+# so CI needs no change — cargo picks this toolchain up automatically.
+#
+# Caveat: this only binds rustup-managed toolchains. A cargo installed from a
+# distro package or Homebrew ignores this file, and will keep drifting from CI.
+#
+# To bump: raise `channel`, run `make ci`, and fix any new lints in the same commit.
+[toolchain]
+channel = "1.97.0"
+components = ["rustfmt", "clippy"]
+profile = "minimal"


### PR DESCRIPTION
## Why

CI installs whatever stable shipped most recently (`dtolnay/rust-toolchain@stable`), so a new Rust release can turn it red with **no change to the code**.

That is not hypothetical — it just happened:

| | |
|---|---|
| main's last green CI run | 2026-06-24 |
| rustc 1.97.0 released | **2026-07-07** |
| next run (PR #100) | ❌ `make ci` — 2 new clippy lints in `src/hooks/normalize.rs`, a file untouched since before that branch |

`main` itself would fail CI today if re-run. The failure surfaced on an unrelated PR, where it cost time to diagnose and had to be fixed in-scope just to get a green tick.

## What

Pin the toolchain in `rust-toolchain.toml`:

```toml
[toolchain]
channel = "1.97.0"
components = ["rustfmt", "clippy"]
profile = "minimal"
```

A CI run is now reproducible, and a toolchain upgrade lands as its own reviewable commit — with any new lints fixed alongside it — instead of ambushing whoever opens the next PR.

## No workflow change needed

`ci.yml` keeps using `dtolnay/rust-toolchain@stable`. I checked the action's source rather than assuming: it ends with `rustup default <toolchain>` and never sets `RUSTUP_TOOLCHAIN`. In rustup's precedence order a `rust-toolchain.toml` **outranks** `rustup default`, so this file wins and cargo auto-installs the pinned toolchain plus its components.

## Caveat worth knowing

This only binds **rustup-managed** toolchains. A cargo installed from Homebrew or a distro package ignores `rust-toolchain.toml` entirely and will keep drifting from CI — which is exactly how the lints reached CI unnoticed (local clippy 1.94 vs CI 1.97). Getting real local/CI parity means installing rustup; the pin alone won't do it.

## Merge order

Stacked on #100, which contains the `normalize.rs` lint fix — without it, pinning 1.97 makes CI red on the pre-existing lints. Merge **#100 first**; GitHub will retarget this to `main` automatically.

## Bumping later

Raise `channel`, run `make ci`, fix any new lints in the same commit.

<!-- AI-PR-DESCRIPTION-START -->
## PR Auto Describe


## Summary
Added `rust-toolchain.toml` pinning Rust to `1.97.0` for reproducible CI. Resolves clippy lint failures introduced in newer stable without code changes. Cargo automatically picks up the pinned toolchain in CI.

---

## Key Changes
- **Toolchain pinning**: Added `rust-toolchain.toml` with pinned channel `1.97.0`
- **CI stabilization**: Eliminates CI breakage from new clippy lints in unreleased Rust versions

---

## Detailed Breakdown
- New `rust-toolchain.toml` file with `channel = "1.97.0"`, `minimal` profile, and `rustfmt`, `clippy` components
- rustup reads this file automatically; CI workflow (`dtolnay/rust-toolchain@stable`) remains unchanged
- Bump process: raise channel, run `make ci`, fix any new lints in same commit

---

## Notes
- Only affects rustup-managed toolchains; distro/Homebrew-installed Rust ignores this file
- Rationale: CI was failing on pre-existing code due to new clippy lints in `rustc 1.97.0` (2026-07-07) after main's last green build (2026-06-24)

---

## Breaking Changes
None.

_Last updated: 2026-07-16 09:42:53_
<!-- AI-PR-DESCRIPTION-END -->