### PR TITLE
test(perf): bound the latency guards catastrophically, not tightly

### DIFF
--- a/tests/performance_benchmarks.rs
+++ b/tests/performance_benchmarks.rs
@@ -1,9 +1,26 @@
+//! Guards against pathological slowdowns — a hang, a deadlock, an accidental
+//! O(n²). Not benchmarks: these run under `cargo test` on shared CI runners,
+//! where wall-clock time measures the runner's load as much as our code.
+//!
+//! So every bound here is **catastrophic-only**: orders of magnitude above the
+//! design target named in each test. A tight bound cannot tell "the code got
+//! slower" from "the runner was busy" — `bench_handoff_export_latency` proved
+//! it, failing at 100ms on Windows and passing on a rerun of the same commit,
+//! reddening an unrelated PR.
+//!
+//! Real performance tracking lives in `benches/pipeline.rs` (criterion,
+//! `cargo bench`), which measures against a baseline instead of a magic number.
+
 use omni::cli::handoff::run_handoff;
 use omni::pipeline::scorer;
 use omni::store::sqlite::Store;
 use std::sync::Arc;
 use std::time::Instant;
 use tempfile::tempdir;
+
+/// Upper bound for every timing assertion here. Anything this slow is broken,
+/// not merely unlucky — these operations are all designed to run in ~milliseconds.
+const CATASTROPHIC_MS: u128 = 2000;
 
 #[test]
 fn bench_distillation_latency() {
@@ -13,8 +30,11 @@ fn bench_distillation_latency() {
     omni::distillers::distill_with_command(&segments, &input, "ls", None);
     let elapsed = start.elapsed();
 
-    // Latency should be < 2000ms (to account for unoptimized debug builds in CI)
-    assert!(elapsed.as_millis() < 2000, "Distillation latency too high");
+    // Design target: well under a second, even in an unoptimized debug build.
+    assert!(
+        elapsed.as_millis() < CATASTROPHIC_MS,
+        "Distillation latency too high: {elapsed:?}"
+    );
 }
 
 #[test]
@@ -30,8 +50,13 @@ fn bench_handoff_export_latency() {
     let _ = run_handoff(&["--json".to_string()], store);
     let elapsed = start.elapsed();
 
-    // Handoff should be < 50ms
-    assert!(elapsed.as_millis() < 100, "Handoff latency too high");
+    // Design target: < 50ms. Bounded catastrophically because this one does
+    // real SQLite and tempdir I/O, which is exactly what a loaded CI runner
+    // stalls on — the source of the original flake.
+    assert!(
+        elapsed.as_millis() < CATASTROPHIC_MS,
+        "Handoff latency too high: {elapsed:?}"
+    );
 }
 
 #[test]
@@ -45,8 +70,11 @@ fn bench_pressure_calculation_latency() {
     }
     let elapsed = start.elapsed();
 
-    // Pressure recalc < 100ms
-    assert!(elapsed.as_millis() < 100, "Pressure latency too high");
+    // Design target: 100 in-memory recalcs in < 1ms.
+    assert!(
+        elapsed.as_millis() < CATASTROPHIC_MS,
+        "Pressure latency too high: {elapsed:?}"
+    );
 }
 
 #[test]
@@ -60,5 +88,9 @@ fn bench_environment_sanitization_latency() {
     let _sanitized = omni::guard::env::sanitize_vars(malicious_env);
     let elapsed = start.elapsed();
 
-    assert!(elapsed.as_millis() < 50, "Security scan too slow");
+    // Design target: 1000 vars sanitized in a few ms.
+    assert!(
+        elapsed.as_millis() < CATASTROPHIC_MS,
+        "Security scan too slow: {elapsed:?}"
+    );
 }


### PR DESCRIPTION
## The flake, caught in the act

`bench_handoff_export_latency` asserted a **100ms wall-clock bound** around real SQLite + tempdir I/O. It failed on `windows-latest` and reddened **#101** — a PR whose entire diff was one file (`rust-toolchain.toml`) that cannot affect runtime timing.

Proof it was the runner and not the code:

| run | commit | result |
|---|---|---|
| first | `cae79ba` | ❌ `Handoff latency too high` |
| rerun, **same commit** | `cae79ba` | ✅ pass |

Both compiled with rustc 1.97.0. Same code, same compiler, opposite results.

## Why not just raise that one threshold

A wall-clock assert on a shared CI runner cannot distinguish *"the code got slower"* from *"the runner was busy"*. Any bound tight enough to catch a real regression will eventually fail on an unrelated PR. All four guards in this file have that defect — only one had fired yet, so fixing just the one that fired would be whack-a-mole.

## What changed

Every guard is now bounded at **2000ms** — the precedent `bench_distillation_latency` already set ("to account for unoptimized debug builds in CI") — with each design target kept in a comment:

| test | design target | bound |
|---|---|---|
| `bench_distillation_latency` | sub-second | 2000ms |
| `bench_handoff_export_latency` | < 50ms | 2000ms |
| `bench_pressure_calculation_latency` | 100 recalcs < 1ms | 2000ms |
| `bench_environment_sanitization_latency` | 1000 vars in a few ms | 2000ms |

These operations are designed to run in milliseconds, so 2000ms still catches what this file is actually for: a hang, a deadlock, an accidental O(n²).

Assertions now report the measured duration (`"Handoff latency too high: 3.011615084s"`) instead of just complaining.

## The bound still bites

Verified rather than assumed — injecting a 3s stall into the handoff path:

```
Handoff latency too high: 3.011615084s
test result: FAILED. 0 passed; 1 failed
```

## The tradeoff, stated plainly

This **does** trade away fine-grained regression detection: a 50ms → 500ms regression would now pass. That is deliberate. The alternative is a signal that fires randomly on innocent PRs, which trains everyone to hit rerun — worse than no signal, because it burns trust in CI.

Real performance tracking already exists in `benches/pipeline.rs` (criterion), which compares against a baseline instead of a magic number. `make ci` runs `cargo test`, never `cargo bench` — so if you want per-commit perf tracking, wiring criterion into CI is the way to get it honestly. Not in this PR.

<!-- AI-PR-DESCRIPTION-START -->
## PR Auto Describe


## Summary
Refactored performance regression tests to use catastrophic-only thresholds (2000ms) instead of tight bounds, eliminating CI flakiness. Added module docs explaining these are not benchmarks but guards against pathological slowdowns. Improved error messages with actual elapsed times.

## Key Changes
- **Catastrophic-only thresholds**: All 4 timing tests now use `CATASTROPHIC_MS = 2000` instead of varying tight bounds (50-2000ms)
- **Module documentation**: Added docs explaining these tests guard against hang/deadlock/O(n²), not incremental regressions
- **Better diagnostics**: All assertions now include `{elapsed:?}` in failure messages

## Detailed Breakdown
- `bench_distillation_latency`: Bound 2000→CATASTROPHIC; design target "well under a second" documented
- `bench_handoff_export_latency`: Bound 100→CATASTROPHIC; explains SQLite/tempdir I/O stalls on loaded runners (original flake source)
- `bench_pressure_calculation_latency`: Bound 100→CATASTROPHIC; design target documented as 100 in-memory recalcs in <1ms
- `bench_environment_sanitization_latency`: Bound 50→CATASTROPHIC; design target documented as 1000 vars in a few ms
- Added `CATASTROPHIC_MS: u128 = 2000` constant for all assertions

## Notes
Real performance tracking lives in `benches/pipeline.rs` (criterion) which measures against baselines rather than magic numbers. This change fixes the `bench_handoff_export_latency` flake that failed at 100ms on Windows CI but passed on reruns.

## Breaking Changes
None.

_Last updated: 2026-07-16 10:34:02_
<!-- AI-PR-DESCRIPTION-END -->