### PR TITLE
fix(cloud): fingerprint pod tables by READY+RESTARTS, resolve columns from header

### DIFF
--- a/src/distillers/cloud.rs
+++ b/src/distillers/cloud.rs
@@ -27,6 +27,11 @@ impl Distiller for CloudDistiller {
             distill_helm(input)
         } else if input.contains("aws ") {
             distill_aws(segments, input)
+        } else if is_resource_table(input) {
+            // A columnar listing we have no distiller for (`kubectl get pvc|pv|
+            // ns|certificates …`). The fallback would keep 20 lines and drop the
+            // rest with no marker, so hand back the payload untouched.
+            input.to_string()
         } else {
             distill_fallback(segments)
         }
@@ -37,10 +42,33 @@ impl Distiller for CloudDistiller {
 // Detection helpers
 // ---------------------------------------------------------------------------
 
+/// A pod table is fingerprinted by `READY` + `RESTARTS`, which no other
+/// `kubectl get` resource prints. `NAMESPACE NAME STATUS` is *not* a
+/// fingerprint — it is the common prefix of nearly every `-A` listing (pvc, pv,
+/// namespaces, certificates, …), and matching on it routed those into the pod
+/// distiller, which then reported healthy objects as errors.
 fn is_kubectl_table(input: &str) -> bool {
-    input.lines().any(|l| {
-        (l.contains("READY") && l.contains("STATUS") && l.contains("RESTARTS"))
-            || (l.contains("NAMESPACE") && l.contains("NAME") && l.contains("STATUS"))
+    input.lines().any(is_pod_header)
+}
+
+fn is_pod_header(line: &str) -> bool {
+    line.contains("NAME")
+        && line.contains("READY")
+        && line.contains("STATUS")
+        && line.contains("RESTARTS")
+}
+
+/// Any tabular listing with a `NAME` column and an otherwise all-caps header.
+/// Used only to refuse: we can recognise the shape without knowing the schema.
+fn is_resource_table(input: &str) -> bool {
+    input.lines().take(5).any(|l| {
+        let cols: Vec<&str> = l.split_whitespace().collect();
+        cols.len() >= 3
+            && cols.contains(&"NAME")
+            && cols.iter().all(|c| {
+                c.chars()
+                    .all(|ch| ch.is_ascii_uppercase() || ch == '-' || ch == '_')
+            })
     })
 }
 
@@ -119,41 +147,96 @@ fn is_noise(line: &str) -> bool {
 // kubectl table (NAME READY STATUS RESTARTS AGE)
 // ---------------------------------------------------------------------------
 
+/// Pod phases/reasons that mean "not healthy yet, but not broken".
+const POD_PENDING: &[&str] = &[
+    "Pending",
+    "ContainerCreating",
+    "PodInitializing",
+    "Terminating",
+];
+
+/// Pod phases/reasons that mean "broken". Anything outside these three lists is
+/// counted as `unknown`, never as an error — a status this distiller has never
+/// heard of is not evidence of a failure.
+const POD_FAILED: &[&str] = &[
+    "CrashLoopBackOff",
+    "Error",
+    "Failed",
+    "ImagePullBackOff",
+    "ErrImagePull",
+    "OOMKilled",
+    "Evicted",
+    "CreateContainerConfigError",
+    "CreateContainerError",
+    "InvalidImageName",
+    "RunContainerError",
+    "NodeAffinity",
+    "Unknown",
+];
+
 fn distill_kubectl(input: &str) -> String {
+    // Resolve NAME/STATUS from the header instead of assuming column 0 and 2:
+    // `kubectl get pods -A` prefixes a NAMESPACE column, which shifted every
+    // lookup by one and made READY ("1/1") read as the status.
+    let Some((header_idx, header)) = input.lines().enumerate().find(|(_, l)| is_pod_header(l))
+    else {
+        return input.to_string();
+    };
+    let cols: Vec<&str> = header.split_whitespace().collect();
+    let (Some(name_idx), Some(status_idx)) = (
+        cols.iter().position(|c| *c == "NAME"),
+        cols.iter().position(|c| *c == "STATUS"),
+    ) else {
+        return input.to_string();
+    };
+
     let mut running = 0u32;
     let mut pending = 0u32;
     let mut failed = 0u32;
+    let mut unknown = 0u32;
     let mut total = 0u32;
     let mut problems: Vec<String> = Vec::new();
 
-    for line in input.lines().skip(1) {
+    for line in input.lines().skip(header_idx + 1) {
         let trimmed = line.trim();
         if trimmed.is_empty() {
             continue;
         }
-        total += 1;
         let parts: Vec<&str> = trimmed.split_whitespace().collect();
-        if parts.len() >= 3 {
-            let name = parts[0];
-            let status = parts[2];
-            match status {
-                "Running" | "Completed" | "Succeeded" => running += 1,
-                "Pending" | "ContainerCreating" | "Init:0/1" => {
-                    pending += 1;
-                    problems.push(format!("{} ({})", name, status));
-                }
-                _ => {
-                    failed += 1;
-                    problems.push(format!("{} ({})", name, status));
-                }
-            }
+        // A row that does not reach the STATUS column is not a row we can read.
+        if parts.len() <= status_idx {
+            continue;
         }
+        total += 1;
+        let name = parts[name_idx];
+        let status = parts[status_idx];
+        if matches!(status, "Running" | "Completed" | "Succeeded") {
+            running += 1;
+        } else if POD_PENDING.contains(&status) || status.starts_with("Init:") {
+            pending += 1;
+            problems.push(format!("{} ({})", name, status));
+        } else if POD_FAILED.contains(&status) {
+            failed += 1;
+            problems.push(format!("{} ({})", name, status));
+        } else {
+            unknown += 1;
+            problems.push(format!("{} ({})", name, status));
+        }
+    }
+
+    // Nothing parsed means the fingerprint matched something that only looks
+    // like a pod table. Hand back the payload rather than summarise a guess.
+    if total == 0 {
+        return input.to_string();
     }
 
     let mut out = format!(
         "k8s: {} pods | {} running, {} pending, {} error",
         total, running, pending, failed
     );
+    if unknown > 0 {
+        out.push_str(&format!(", {} unknown", unknown));
+    }
 
     if !problems.is_empty() {
         out.push_str("\nProblems: ");
@@ -585,4 +668,69 @@ fn distill_fallback(segments: &[OutputSegment]) -> String {
     }
 
     out.trim().to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// From issue #105: `kubectl get pvc -A` matched the pod fingerprint and
+    /// every healthy `Bound` claim was reported as an error.
+    const PVC_TABLE: &str = "\
+NAMESPACE    NAME                      STATUS   VOLUME         CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+datasource   qdrant-storage-qdrant-0   Bound    pvc-0a75d858   5Gi        RWO            default        2y
+consul       data-consul-0             Bound    pvc-1b86e969   10Gi       RWO            default        2y";
+
+    const PODS_ALL_NAMESPACES: &str = "\
+NAMESPACE   NAME                     READY   STATUS             RESTARTS   AGE
+default     api-7fb96c846b-f4jnm     1/1     Running            0          5d
+kube-系统   auth-5d4f6c8b99-abc12    0/1     CrashLoopBackOff   15         2h";
+
+    fn distill(input: &str) -> String {
+        CloudDistiller.distill(&[], input, None)
+    }
+
+    #[test]
+    fn passes_non_pod_resource_tables_through_untouched() {
+        assert_eq!(distill(PVC_TABLE), PVC_TABLE);
+    }
+
+    #[test]
+    fn does_not_fingerprint_namespace_name_status_as_pods() {
+        assert!(!is_kubectl_table(PVC_TABLE));
+    }
+
+    #[test]
+    fn resolves_columns_from_header_when_namespace_is_present() {
+        let out = distill(PODS_ALL_NAMESPACES);
+        assert!(
+            out.starts_with("k8s: 2 pods | 1 running, 0 pending, 1 error"),
+            "{out}"
+        );
+        // The name column, not the namespace column.
+        assert!(
+            out.contains("auth-5d4f6c8b99-abc12 (CrashLoopBackOff)"),
+            "{out}"
+        );
+    }
+
+    #[test]
+    fn counts_unrecognised_status_as_unknown_not_error() {
+        let input = "\
+NAME    READY   STATUS        RESTARTS   AGE
+web-0   1/1     SomeNewPhase  0          5d";
+        let out = distill(input);
+        assert!(out.contains("0 error"), "{out}");
+        assert!(out.contains("1 unknown"), "{out}");
+    }
+
+    #[test]
+    fn returns_input_when_pod_table_has_no_rows() {
+        let input = "NAME   READY   STATUS   RESTARTS   AGE\n";
+        assert_eq!(distill(input), input);
+    }
 }


### PR DESCRIPTION
Fixes #105.

## The bug

`CloudDistiller` treated any table containing `NAMESPACE` + `NAME` + `STATUS` as
a pod table. That is not a fingerprint of anything — it is the common prefix of
most `kubectl get <resource> -A` output. `kubectl get pvc -A` matched it, routed
into `distill_kubectl`, and every healthy `Bound` claim fell into the catch-all
arm and was reported as an error.

Reproduced against the unfixed distiller, byte-for-byte with the report:

```
k8s: 35 pods | 0 running, 0 pending, 35 error
Problems: consul (Bound), consul (Bound), consul (Bound), consul (Bound), consul (Bound) +30 more
```

Three falsehoods: they are PVCs not pods, `Bound` is the healthy terminal phase
so the true error count is zero, and the names shown are namespaces.

## Changes

**1. `is_kubectl_table` requires `READY` + `RESTARTS`** — columns no other
`kubectl get` resource prints. `kubectl get pods -A` still matches.

**2. `distill_kubectl` resolves `NAME`/`STATUS` from the header** instead of
assuming columns 0 and 2. This was a *second, unreported instance of the same
bug*: `kubectl get pods -A` also carries a `NAMESPACE` column, so `parts[2]` read
`READY` (`"1/1"`) as the status and reported every healthy pod as an error too.
Tightening the fingerprint alone would not have fixed that.

A status outside the known lists now counts as `unknown`, never `error` — an
unrecognised status is not evidence of a failure. A header missing either column,
or zero parseable rows, returns the input untouched.

**3. Unhandled columnar listings pass through** rather than reaching
`distill_fallback`, which kept 20 lines and dropped the rest with no marker.
Without this, `pvc`/`pv`/`ns` would still lose 15 of 35 rows silently.

## Verification

- Reproduced the reported bytes against unfixed `cloud.rs`, confirmed the same
  input now returns the table verbatim — the regression test fails without the
  fix.
- 5 new unit tests in `cloud.rs` covering: PVC passthrough, the fingerprint
  itself, `-A` column resolution, unknown-status handling, and a header-only
  table.
- Existing kubectl snapshots unchanged — the non-`-A` fixtures resolve to the
  same indices the old code hardcoded.

## Caveats

**Gates ran on rustc 1.94.0, not the pinned 1.97.0** (no rustup on the dev box,
so `rust-toolchain.toml` is ignored there). `cargo fmt --check`, `clippy -D
warnings` and 398 tests pass locally, but clippy is release-sensitive — CI is the
real answer.

**This fix may be unreachable through the hook path.** See #110: TOML-first
dispatch in `post_tool.rs` lets `signals/tools/kubectl.toml` shadow
`CloudDistiller` for every `kubectl get`. The code here is wrong today and
correct after, which stands on its own — but expect no behavior change in live
sessions until #110 is resolved.

Also filed while investigating: #111 (silent `max_lines` truncation) and #112
(root cause of the `kubectl exec` → `docker logs` misroute noted in #105).

<!-- AI-PR-DESCRIPTION-START -->
## PR Auto Describe


## Summary
Fixed a bug where `kubectl get` tabular output (PVC, PV, namespaces, etc.) was incorrectly matched as pod tables and healthy resources reported as errors. Pod tables with `-A` (all namespaces) were also misparsed due to fixed column assumptions. Added `is_resource_table()` to pass unknown columnar output through unchanged, and made `distill_kubectl` resolve column indices from headers dynamically.

## Key Changes
- **Stricter pod fingerprinting**: `NAMESPACE NAME STATUS` alone no longer triggers pod detection; requires `READY` + `RESTARTS`
- **New resource table passthrough**: Unrecognized tabular listings are returned unchanged instead of misprocessed
- **Dynamic column resolution**: Parse header to locate NAME/STATUS columns rather than assuming fixed positions (fixes `-A` output)
- **Explicit status categorization**: `POD_PENDING`, `POD_FAILED` constants; unknown statuses counted separately instead of as errors

## Detailed Breakdown
- Added `is_resource_table()` — detects columnar tables by `NAME` column + all-caps headers, triggers passthrough
- Added `is_pod_header()` — requires NAME, READY, STATUS, RESTARTS (was: any 3 of NAMESPACE, NAME, STATUS)
- `distill_kubectl` now finds column indices from header row, skips `header_idx + 1` rows
- Added `POD_PENDING` (`Pending`, `ContainerCreating`, `PodInitializing`, `Terminating`) and `POD_FAILED` arrays
- Init container statuses (`Init:*`) now treated as pending, not errors
- Unknown statuses increment `unknown` counter rather than `failed`
- Empty pod row result returns input unchanged
- Added 5 test cases covering PVC passthrough, `-A` namespace resolution, unknown status handling, and empty table edge case

## Breaking Changes
None. Output format change only: `k8s: N pods | ...` now includes `, X unknown` suffix when applicable.

_Last updated: 2026-07-20 10:29:07_
<!-- AI-PR-DESCRIPTION-END -->