### PR TITLE
fix(hooks): make weak TOML filters fall through to the distiller in post_tool

### DIFF
--- a/src/guard/limits.rs
+++ b/src/guard/limits.rs
@@ -1,6 +1,17 @@
 pub const MAX_INPUT: usize = 16 * 1024 * 1024; // 16MB
 pub const WARN_INPUT: usize = 1024 * 1024; // 1MB
 
+/// Output must be under this percentage of the input to count as a real
+/// reduction. Anything above it is not compression worth taking — e.g. a TOML
+/// filter that strips a few lines does not get to short-circuit a distiller
+/// that would summarise the same input.
+pub const MIN_REDUCTION_PCT: usize = 95;
+
+/// True when `output` compressed `input` enough to be worth keeping.
+pub fn beats_guardrail(output_len: usize, input_len: usize) -> bool {
+    output_len < input_len * MIN_REDUCTION_PCT / 100
+}
+
 pub enum InputCheck {
     Ok,
     Warn,

--- a/src/hooks/pipe.rs
+++ b/src/hooks/pipe.rs
@@ -9,7 +9,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 /// Guardrail: only emit distilled output if it's at least this much smaller than input
-const MIN_REDUCTION_PCT: usize = 95; // e.g., if output is 96% of input, just return original input
+use crate::guard::limits::MIN_REDUCTION_PCT;
 
 /// Maximum output size before truncation to prevent overwhelming context windows
 pub const MAX_OUTPUT_BYTES: usize = 50_000;
@@ -385,7 +385,7 @@ fn distill(
     // through; a filter that earns its match still wins, user filters included.
     let toml_hit = matched_toml.and_then(|f| {
         let out = f.apply(&input_text);
-        (out.len() < input_text.len() * MIN_REDUCTION_PCT / 100).then_some((out, f.name))
+        crate::guard::limits::beats_guardrail(out.len(), input_text.len()).then_some((out, f.name))
     });
 
     let (output, filter_name, rewind_hash, kept_count, dropped_count, collapse_savings, route) =

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -192,11 +192,22 @@ pub fn process_payload(
         toml_filters.iter().find(|f| f.matches(clean_command))
     };
 
+    // A TOML filter only gets to short-circuit the distiller if it actually beat
+    // the guardrail — the same rule `hooks::pipe` already applies. Without it the
+    // broad `sys_*_domain` filters win the `find()` race for cargo, npm, docker,
+    // kubectl and terraform while stripping only a few lines, shadowing the
+    // distiller that would have summarised the same input. Weak filter, fall
+    // through; a filter that earns its match still wins, user filters included.
+    let toml_hit = toml_match.and_then(|f| {
+        let out = f.apply(&content);
+        crate::guard::limits::beats_guardrail(out.len(), content.len())
+            .then(|| (out, f.name.clone()))
+    });
+
     let session_guard = session.as_ref().and_then(|l| l.lock().ok());
     let mut collapse_savings_data = None;
-    let (final_out, filter_name) = if let Some(filter) = toml_match {
-        let output = filter.apply(&content);
-        (output, filter.name.clone())
+    let (final_out, filter_name) = if let Some((output, name)) = toml_hit {
+        (output, name)
     } else {
         // Pure Command Architecture: Resolve profile once
         let profile = crate::pipeline::registry::resolve_profile_for_chain(clean_command);


### PR DESCRIPTION
Refs #110. **Draft — blocked by #116.** Do not merge yet; the reason is below and
it is the interesting part.

## What this does

`hooks::pipe` already refuses to let a TOML filter short-circuit the distiller
unless it beats `MIN_REDUCTION_PCT`, and its comment (`pipe.rs:380-385`) names
the exact failure. `hooks::post_tool` — the PostToolUse path agents actually run
— never got that guard. This ports it.

1. `guard::limits` gains `MIN_REDUCTION_PCT` and `beats_guardrail()`, moved out of
   `hooks::pipe` so both hook paths share one definition (CLAUDE.md SSOT).
2. `post_tool` applies the same gate.

## Blast radius is wider than the kubectl case I filed

Selection is `Vec::find()` over an alphabetically-ordered embed list, so the three
broad `signals/domains/*.toml` filters sit ahead of every tool-specific filter and
swallow **cargo, npm, yarn, pnpm, bun, gradle, mvn, cmake, make, dotnet, docker,
kubectl, terraform, ansible, helm, aws, gcloud, az, pytest, jest, vitest, go test,
rspec, phpunit** before anything else is consulted. Each shadows a real distiller.
Most of `signals/tools/` never fires at all.

Measured on a 35-row pod table: **88.7% via the distiller, ~0% via the filter that
beat it to the match.**

Also found: `TomlFilter::priority` — the field that exists precisely to resolve
this ordering — is parsed, stored, and read by nothing. Not fixed here; it needs
its own ticket and a decision about whether ordering or a strength test should
win.

## Why it is a draft

With the guard in place, the kubectl path reaches the distiller for the first
time — and immediately produces, from a 35-pod table:

```
k8s: 2 pods | 0 running, 0 pending, 2 error
Problems: [5 (lines), [30 (lines)
```

`collapse` runs before `distill`, so the distiller parses OMNI's own
`[30 similar lines collapsed]` markers as pod rows. `[5` is a pod name; `lines`
is its status. That is **#116**, which this guard is what uncovered.

Merging this before #116 would trade an honest passthrough for a confident false
claim — the exact defect class the changelog keeps recording. #116 also has to
land before #113 (the #105 kubectl fix), or that fix lands on a pipeline feeding
it marker text.

Suggested order: **#116 → this → #113.**

## Verification

- `cargo fmt`, `clippy -D warnings`, 398 tests pass — on **rustc 1.94.0, not the
  pinned 1.97.0** (no rustup locally), so CI is the real answer on clippy.
- Before/after measured through `omni --post-hook` with a 35-row pod table:
  filter path ~0% reduction, distiller path 88.7%.
- No test added yet. It goes in once #116 settles what the distiller is supposed
  to receive — a regression test written against the current marker-fed behaviour
  would encode the bug.

<!-- AI-PR-DESCRIPTION-START -->
## PR Auto Describe


## Summary
Centralized the compression guardrail logic into a shared `beats_guardrail()` utility in `guard/limits.rs`, replacing scattered inline calculations. Applied the same guardrail rule to TOML filter short-circuiting in `post_tool.rs`, preventing weak filters from shadowing the distiller without earning their output reduction.

## Key Changes
- **Centralized guardrail**: `MIN_REDUCTION_PCT` (95%) and `beats_guardrail()` moved to `src/guard/limits.rs`
- **Enforced guardrail on TOML filters**: `post_tool.rs` now requires filters to beat the 95% threshold, not just match
- **Removed inline duplication**: `pipe.rs` now imports and uses the shared utility

## Detailed Breakdown
- **src/guard/limits.rs**: New module exposing `MIN_REDUCTION_PCT` constant and `beats_guardrail(output_len, input_len) -> bool` helper
- **src/hooks/pipe.rs**: Removed local `MIN_REDUCTION_PCT` constant; imports from `guard::limits` and calls `beats_guardrail()` in TOML filter evaluation
- **src/hooks/post_tool.rs**: TOML filters now wrapped in guardrail check before winning the short-circuit race. Without this, broad `sys_*_domain` filters (cargo, npm, docker, kubectl, terraform) that strip only a few lines were shadowing the distiller. Filter still wins if it earns the match by actually compressing ≥95%.

## Notes
No functional breakage for end users. TOML filters that don't meaningfully compress will now fall through to the distiller instead of short-circuiting.

## Breaking Changes
None.

_Last updated: 2026-07-20 13:05:07_
<!-- AI-PR-DESCRIPTION-END -->