### PR TITLE
fix(hooks): pass failed commands through verbatim, never distill a non-zero exit into success

### DIFF
--- a/src/hooks/normalize.rs
+++ b/src/hooks/normalize.rs
@@ -24,6 +24,7 @@ pub struct NormalizedInput {
     pub command: String,   // command yang dieksekusi
     pub content: String,   // output dari tool
     pub agent_id: String,  // untuk session isolation
+    pub failed: bool,      // command exited non-zero / agent signalled an error (#120)
 }
 
 /// Detect agent format dari raw JSON string
@@ -179,6 +180,11 @@ fn normalize_claude_code(input: &str, agent_id: String) -> Option<NormalizedInpu
         command,
         content,
         agent_id,
+        // Claude Code sends a failed command as a bare `tool_response` string
+        // ("Error: Exit code N…"), which never matches ClaudeToolResponse, so
+        // parsing bails to None (passthrough) before reaching here. Reaching this
+        // point means the tool_response object parsed, i.e. the command succeeded.
+        failed: false,
     })
 }
 
@@ -213,7 +219,6 @@ fn normalize_pi(input: &str, agent_id: String) -> Option<NormalizedInput> {
     #[derive(Deserialize)]
     struct PiToolResponse {
         result: Option<Value>,
-        #[allow(dead_code)]
         #[serde(default)]
         #[serde(rename = "isError")]
         is_error: bool,
@@ -249,6 +254,7 @@ fn normalize_pi(input: &str, agent_id: String) -> Option<NormalizedInput> {
         command,
         content,
         agent_id,
+        failed: response.is_error,
     })
 }
 
@@ -306,6 +312,7 @@ fn normalize_opencode(input: &str, agent_id: String) -> Option<NormalizedInput> 
         command: parsed.command.unwrap_or_default(),
         content,
         agent_id,
+        failed: false, // OpenCode payload carries no exit/error signal
     })
 }
 
@@ -375,6 +382,7 @@ fn normalize_vscode_continue(input: &str, agent_id: String) -> Option<Normalized
         command,
         content,
         agent_id,
+        failed: false, // Continue.dev payload carries no exit/error signal
     })
 }
 
@@ -389,6 +397,7 @@ fn normalize_codex(input: &str, agent_id: String) -> Option<NormalizedInput> {
         output: Option<String>,
         stdout: Option<String>,
         stderr: Option<String>,
+        exit_code: Option<i64>,
     }
 
     let parsed: CodexInput = serde_json::from_str(input).ok()?;
@@ -413,6 +422,7 @@ fn normalize_codex(input: &str, agent_id: String) -> Option<NormalizedInput> {
         command: parsed.command.unwrap_or_default(),
         content,
         agent_id,
+        failed: parsed.exit_code.is_some_and(|c| c != 0),
     })
 }
 
@@ -430,6 +440,7 @@ fn normalize_aider(input: &str, agent_id: String) -> Option<NormalizedInput> {
         command,
         content: input.to_string(),
         agent_id,
+        failed: false, // Aider pipes raw stdout only; no exit signal available
     })
 }
 
@@ -444,13 +455,15 @@ fn normalize_generic_mcp(input: &str, agent_id: String) -> Option<NormalizedInpu
     #[derive(Deserialize)]
     struct McpResultContent {
         content: Option<Value>,
+        #[serde(default)]
+        #[serde(rename = "isError")]
+        is_error: bool,
     }
 
     let parsed: McpResult = serde_json::from_str(input).ok()?;
-    let content = parsed
-        .result
-        .and_then(|r| r.content)
-        .and_then(|c| extract_value_content(&c))?;
+    let result = parsed.result?;
+    let failed = result.is_error;
+    let content = result.content.and_then(|c| extract_value_content(&c))?;
 
     if content.is_empty() {
         return None;
@@ -465,6 +478,7 @@ fn normalize_generic_mcp(input: &str, agent_id: String) -> Option<NormalizedInpu
         command,
         content,
         agent_id,
+        failed,
     })
 }
 

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -31,6 +31,14 @@ pub fn process_payload(
 ) -> Option<String> {
     let normalized = crate::hooks::normalize::normalize(input_str)?;
 
+    // #120: a command that exited non-zero passes through verbatim — never distilled.
+    // Distillation must never turn a failed command into output that reads as success
+    // (a fabricated success terminates investigation; a fabricated error only costs a
+    // retry). Emit nothing: the host keeps the original bytes at zero marker cost.
+    if normalized.failed {
+        return None;
+    }
+
     if crate::guard::env::is_passthrough() {
         return None;
     }
@@ -1128,5 +1136,84 @@ mod tests {
         });
         let out = process_payload(&input.to_string(), None, None);
         assert!(out.is_none(), "Edit tool should still return None");
+    }
+
+    // ── #120: failed commands pass through verbatim, never distilled ──────
+
+    /// Distillable output that a passing command WOULD get summarised, but the
+    /// non-zero exit must force passthrough (None).
+    fn distillable_noise() -> String {
+        std::fs::read_to_string("tests/fixtures/heavy_noise.txt")
+            .expect("heavy_noise fixture missing")
+    }
+
+    #[test]
+    fn codex_nonzero_exit_passes_through() {
+        let input = serde_json::json!({
+            "action": "run",
+            "command": "docker build .",
+            "result": distillable_noise(),
+            "exit_code": 1,
+        });
+        let out = process_payload(&input.to_string(), None, None);
+        assert!(
+            out.is_none(),
+            "a failed command must pass through verbatim, not be distilled"
+        );
+    }
+
+    #[test]
+    fn codex_zero_exit_still_distills() {
+        // Guards the guard: a successful command with the same output is still distilled.
+        let input = serde_json::json!({
+            "action": "run",
+            "command": "docker build .",
+            "result": distillable_noise(),
+            "exit_code": 0,
+        });
+        let out = process_payload(&input.to_string(), None, None);
+        assert!(
+            out.is_some(),
+            "a successful command must still be distilled"
+        );
+    }
+
+    #[test]
+    fn pi_error_passes_through() {
+        let input = serde_json::json!({
+            "toolName": "Bash",
+            "command": "vault kv list apps/x",
+            "toolResponse": { "result": distillable_noise(), "isError": true },
+        });
+        let out = process_payload(&input.to_string(), None, None);
+        assert!(out.is_none(), "Pi isError=true must pass through verbatim");
+    }
+
+    #[test]
+    fn mcp_error_passes_through() {
+        let input = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": { "content": distillable_noise(), "isError": true },
+        });
+        let out = process_payload(&input.to_string(), None, None);
+        assert!(out.is_none(), "MCP isError=true must pass through verbatim");
+    }
+
+    #[test]
+    fn claude_code_failure_string_passes_through() {
+        // Claude Code sends a failed command as a bare `tool_response` STRING, which
+        // must never be parsed into a success summary. Locks in the passthrough so a
+        // future, more-lenient parser can't silently reintroduce the fabrication.
+        let input = serde_json::json!({
+            "tool_name": "Bash",
+            "tool_input": {"command": "vault kv list apps/x"},
+            "tool_response": "Error: Exit code 2\nGet \"https://vault/…\": i/o timeout",
+        });
+        let out = process_payload(&input.to_string(), None, None);
+        assert!(
+            out.is_none(),
+            "Claude Code failure string must pass through verbatim"
+        );
     }
 }


### PR DESCRIPTION
Closes #120

## Problem

A command that **failed** could be distilled into output that reads as success. That is the worst failure mode: a fabricated success terminates investigation, while a fabricated error only costs a retry. In the filed case a `vault` call that failed `exit=2` on a network timeout surfaced a clean, plausible, fictional `["n8n"]`.

Root cause (code-visible, not the unreproducible `["n8n"]` itself): OMNI's `normalize` layer **parsed each agent's failure signal and threw it away**.

| agent | failure signal | state before |
|---|---|---|
| Codex CLI | `exit_code` | never read into `CodexInput` |
| Pi | `toolResponse.isError` | `#[allow(dead_code)]` |
| Generic MCP | `result.isError` | in a doc comment, never deserialized |
| Claude Code | `tool_response` is a bare string `"Error: Exit code N…"` | parse-failed to `None` (safe by accident) |

So failed commands from Codex/Pi/MCP ran the full distiller.

## Fix

The invariant from the issue: **a non-zero exit passes through verbatim, never distilled.** Implemented at the one place format knowledge already lives:

- `NormalizedInput` gains `failed`, set from each agent's own signal (`exit_code != 0`, `isError`).
- One guard in `post_tool::process_payload`: `if normalized.failed { return None }` — passthrough, host keeps the raw bytes at **zero** marker cost.
- No `is_command_error` text heuristic: the guard keys on exit status only, so a *successful* build log full of the word "error" still distills. Net savings on passing commands are untouched.

Claude Code needs no code change (its failure string already passes through); a regression test locks that in so a future lenient parser can't silently reintroduce the fabrication.

## Verified end-to-end (real binary, `omni --hook`)

| input | before | after |
|---|---|---|
| `docker build` **exit_code 1**, 9207 B | distilled → 6090 B | **0 B → passthrough** (host keeps raw) |
| `docker build` **exit_code 0**, 9207 B | distilled → 6090 B | distilled → 6090 B (unchanged) |

Teeth: disabling the guard turns the Codex/Pi/MCP tests red; restoring it makes them green.

Gates: `cargo fmt` / `clippy -D warnings` / `cargo test` (1027 passed, 0 failed) — run on local Homebrew **1.94.0**, not CI's pinned 1.97.0, so CI clippy is the source of truth.

## Out of scope (follow-up)

The `omni exec`/`pipe.rs` path reads piped stdout only and never sees the child exit code; hardening it needs `exec.rs` to capture and forward the code — a separate change, not this one.

<!-- AI-PR-DESCRIPTION-START -->
## PR Auto Describe


## Summary

Added `failed` field to `NormalizedInput` to track non-zero command exits or error signals per-agent. Failed commands now pass through verbatim instead of being distilled — preventing fabricated success summaries that would terminate investigation early. Fixes #120 with full test coverage across all affected parsers.

## Key Changes

- **New field**: `NormalizedInput.failed: bool` tracks command failure per agent format
- **Passthrough guard**: `process_payload` returns `None` (verbatim pass) when `failed == true`
- **Per-agent parsing**: exit codes / `isError` flags wired into `failed` where available
- **Tests**: 5 new cases covering Codex, Pi, MCP, and Claude Code failure paths

## Detailed Breakdown

- **`normalize_claude_code`**: always sets `failed: false` — failures arrive as bare strings, not objects, so never reach the normalizer
- **`normalize_pi`**: reads `isError` boolean into `failed`
- **`normalize_opencode` / `normalize_vscode_continue` / `normalize_aider`**: set `failed: false` — no exit/error signal in payload
- **`normalize_codex`**: reads `exit_code` field; `failed = exit_code.is_some_and(|c| c != 0)`
- **`normalize_generic_mcp`**: reads `isError` from `McpResultContent` into `failed`
- **`process_payload`**: early return `None` when `normalized.failed` — host keeps original bytes; no risk of a distilled success hiding a real failure

## Notes

- Design decision: "fabricated success terminates investigation; fabricated error only costs a retry" — skewed toward preserving fidelity of failed commands.
- Claude Code bare-string failures already passthrough via passthrough guard; the `failed: false` here documents intent and guards future parser changes.

## Breaking Changes

None.

_Last updated: 2026-07-21 00:51:52_
<!-- AI-PR-DESCRIPTION-END -->