### PR TITLE
fix(exec): pass a failed command's stdout through verbatim on `omni exec`, never distill it

### DIFF
--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -1,8 +1,9 @@
 use anyhow::Result;
+use std::io::{Read, Write};
 use std::process::{Command, Stdio};
 use std::sync::{Arc, Mutex};
 
-use crate::hooks::pipe::run_inner;
+use crate::hooks::pipe::{run_inner, stream_filter_for};
 use crate::pipeline::SessionState;
 use crate::store::sqlite::Store;
 
@@ -76,22 +77,50 @@ pub fn run_exec(
         (c, full_cmd)
     };
 
-    let child_stdout = child.stdout.take().expect("Failed to open stdout");
+    let mut child_stdout = child.stdout.take().expect("Failed to open stdout");
 
-    let stdout = std::io::stdout().lock();
-    let stderr = std::io::stderr().lock();
-
-    // Pipe the stdout of the child process through OMNI's pipeline
-    run_inner(
-        child_stdout,
-        stdout,
-        stderr,
-        store.clone(),
-        session.clone(),
-        Some(&cmd_name),
-    )?;
-
-    let status = child.wait()?;
+    let status = if stream_filter_for(&cmd_name).is_some() {
+        // Stream-mode command: distilled output is emitted line-by-line as it
+        // arrives, before the exit code is known, so the exit-code gate below
+        // cannot apply. Keep the live-streaming behavior.
+        let stdout = std::io::stdout().lock();
+        let stderr = std::io::stderr().lock();
+        run_inner(
+            child_stdout,
+            stdout,
+            stderr,
+            store.clone(),
+            session.clone(),
+            Some(&cmd_name),
+        )?;
+        child.wait()?
+    } else {
+        // Buffered path: drain stdout first (draining before wait() avoids the
+        // classic full-pipe deadlock), then gate on the real exit code. #122: a
+        // command that exited non-zero passes its stdout through verbatim and is
+        // never distilled — distillation must not turn a failure into output that
+        // reads as success.
+        let mut buf = Vec::new();
+        child_stdout.read_to_end(&mut buf)?;
+        let status = child.wait()?;
+        if status.success() {
+            let stdout = std::io::stdout().lock();
+            let stderr = std::io::stderr().lock();
+            run_inner(
+                std::io::Cursor::new(&buf),
+                stdout,
+                stderr,
+                store.clone(),
+                session.clone(),
+                Some(&cmd_name),
+            )?;
+        } else {
+            let mut stdout = std::io::stdout().lock();
+            stdout.write_all(&buf)?;
+            stdout.flush()?;
+        }
+        status
+    };
 
     if !status.success() {
         if let (Some(sess), Some(st)) = (&session, &store) {

--- a/src/hooks/pipe.rs
+++ b/src/hooks/pipe.rs
@@ -56,6 +56,18 @@ impl PipelineResult {
     }
 }
 
+/// The stream-mode TOML filter that governs `cmd`, if any. Stream-mode filters
+/// emit distilled output line-by-line as it arrives — before a wrapped command's
+/// exit code is known — so callers that gate on exit status (`omni exec`, #122)
+/// must treat a stream-mode command as un-gateable and keep it streaming.
+/// Semantics match Phase 0.5: the first filter that matches, and only if it is
+/// stream-mode.
+pub fn stream_filter_for(cmd: &str) -> Option<toml_filter::TomlFilter> {
+    let filters = toml_filter::load_all_filters();
+    let f = filters.iter().find(|filter| filter.matches(cmd))?;
+    f.stream_mode.then(|| f.clone())
+}
+
 pub fn run_inner<R: Read, W: Write, E: Write>(
     input: R,
     mut output: W,
@@ -75,17 +87,7 @@ pub fn run_inner<R: Read, W: Write, E: Write>(
         .map(|c| c.strip_prefix("omni exec ").unwrap_or(c));
 
     // Phase 0.5: Streaming Distillation Check
-    let mut stream_filter = None;
-    if let Some(cmd) = command_to_use {
-        let filters = toml_filter::load_all_filters();
-        if let Some(f) = filters.iter().find(|filter| filter.matches(cmd))
-            && f.stream_mode
-        {
-            stream_filter = Some(f.clone());
-        }
-    }
-
-    if let Some(filter) = stream_filter {
+    if let Some(filter) = command_to_use.and_then(stream_filter_for) {
         return stream_distill(input, output, error, filter, store, session, command_to_use);
     }
 

--- a/tests/exec_fail_passthrough.rs
+++ b/tests/exec_fail_passthrough.rs
@@ -1,0 +1,65 @@
+//! #122: `omni exec` must pass a failed command's stdout through verbatim and
+//! never distill it — the same invariant #120 enforced on the hook path, applied
+//! where the exit code comes from the wrapped child rather than the agent JSON.
+//!
+//! Unix-only: the reproduction drives a POSIX `sh` loop. On Windows `omni exec`
+//! wraps commands in `cmd /C`, which does not speak this syntax; the gate itself
+//! is OS-agnostic (`cli::exec`), only the test's shell script is not.
+#![cfg(unix)]
+
+use std::process::Command;
+
+fn omni() -> String {
+    env!("CARGO_BIN_EXE_omni").to_string()
+}
+
+/// Run `omni exec <script>` with an isolated DB. The script is passed as a single
+/// argument on purpose: `omni exec` re-wraps a shell command in `sh -c`, so
+/// `omni exec sh -c '…'` would double-wrap and mangle the quotes.
+fn run_exec(script: &str) -> (String, i32) {
+    let db = tempfile::NamedTempFile::new().expect("temp db");
+    let out = Command::new(omni())
+        .arg("exec")
+        .arg(script)
+        .env("OMNI_DB_PATH", db.path())
+        .env("OMNI_QUIET", "1")
+        .output()
+        .expect("spawn omni exec");
+    (
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        out.status.code().unwrap_or(-1),
+    )
+}
+
+// 60 identical noisy lines: `collapse` folds them to one marker on a *successful*
+// run, so their survival is a direct signal that distillation was skipped.
+const NOISE_LOOP: &str = "i=0; while [ $i -lt 60 ]; do echo noise noise noise; i=$((i+1)); done;";
+
+#[test]
+fn failed_command_passes_through_verbatim() {
+    let (stdout, code) = run_exec(&format!("{NOISE_LOOP} exit 1"));
+
+    assert_eq!(code, 1, "the child's non-zero exit code must propagate");
+    assert_eq!(
+        stdout.lines().filter(|l| l.contains("noise")).count(),
+        60,
+        "a failed command must pass through verbatim, not be collapsed"
+    );
+    assert!(
+        !stdout.contains("collapsed"),
+        "a failed command must carry no distillation marker"
+    );
+}
+
+#[test]
+fn successful_command_is_still_distilled() {
+    // Guards the guard: the identical output with a zero exit is still distilled,
+    // so the fix did not simply disable `omni exec` distillation.
+    let (stdout, code) = run_exec(&format!("{NOISE_LOOP} exit 0"));
+
+    assert_eq!(code, 0);
+    assert!(
+        stdout.contains("collapsed"),
+        "a successful command should still be distilled"
+    );
+}


### PR DESCRIPTION
Closes #122

## Problem

#120 enforced *"a non-zero exit passes through verbatim, never distilled"* on the **hook** path, where the exit signal is in the agent JSON. `omni exec` had the same hole from a different cause: `cli::exec` streamed the child's stdout straight into `run_inner` (the distiller) and only called `child.wait()` **afterwards** — so by the time the exit code was known, the distilled output had already been written. A command that failed under `omni exec` still got distilled. That's the #120 vault case, one layer down, and `omni exec` is the repo's own reproduction harness.

## Why it couldn't be a one-liner

The child's exit code is only knowable **after** its stdout is fully drained — and draining before `wait()` is also what avoids the classic full-pipe deadlock. So exec now:

1. drains the child's stdout into a buffer,
2. `wait()`s for the real exit code,
3. gates: **non-zero → write stdout verbatim, skip distillation**; zero → distil exactly as before (the buffer is replayed through `run_inner`, so the pipeline is unchanged).

**Stream-mode commands** (`docker`/`npm`/`bun`, via `stream_mode` TOML filters) emit distilled output line-by-line *before* the exit code exists, so the gate cannot apply — they keep streaming. The stream-filter lookup Phase 0.5 did inline is factored into `pipe::stream_filter_for` so exec and the pipeline agree on which commands stream (SSOT).

## Verified end-to-end (real binary)

60 identical noise lines:

| exit | before | after |
|---|---|---|
| **1** | distilled → `[60 similar lines collapsed]` | **60 lines verbatim**, exit 1 propagated |
| **0** | distilled → 1 marker | distilled → 1 marker (unchanged) |

Teeth: forcing the success branch turns `failed_command_passes_through_verbatim` red; restoring it green. New `tests/exec_fail_passthrough.rs` (unix-gated — the repro drives POSIX `sh`; the gate itself is OS-agnostic).

Gates: `cargo fmt` / `clippy -D warnings` / `cargo test` (1029 passed, 0 failed) on local Homebrew **1.94.0**, not CI's pinned 1.97.0 — CI is the source of truth for clippy.

## Noted, not fixed here

`omni exec sh -c '…'` double-wraps (exec re-prepends `sh -c`, mangling quotes) — a pre-existing exec quoting quirk, also glimpsed in #120's "not reported" notes. Separate issue if it's worth filing.

<!-- AI-PR-DESCRIPTION-START -->
## PR Auto Describe


## Summary
Fixes #122: `omni exec` now gates distillation on the wrapped command's exit code. Failed commands pass stdout verbatim (no distillation); successful commands are distilled as before. Stream-mode filters remain un-gated for live output. Also extracts `stream_filter_for` into a reusable helper in `hooks/pipe.rs`.

## Key Changes
- **exec.rs**: Conditional distillation based on `stream_filter_for()` — buffered path drains stdout first, gates `run_inner()` on `status.success()`, else writes raw bytes
- **pipe.rs**: Extract `stream_filter_for(cmd) -> Option<TomlFilter>` as public reusable function; simplify `run_inner` to use it
- **New test**: `exec_fail_passthrough.rs` verifies #122 invariant (failed=verbatim, success=distilled)

## Detailed Breakdown
- **Exit-code gating (#122)**: Previously all `omni exec` output was piped through distillation. Now non-zero exit skips `run_inner` entirely; stdout is written raw to stdout
- **Buffering order**: Draining `child_stdout` before `wait()` avoids classic full-pipe deadlock; `Cursor::new(&buf)` feeds buffered bytes to distillation when applicable
- **Stream-mode unchanged**: Commands matched by a stream-mode filter still emit live output before exit code is known (un-gateable by design)
- **Minor refactor**: `stream_filter_for` replaces inline filter lookup in `run_inner`; matches existing Phase 0.5 semantics

## Notes
- Test is Unix-only due to shell script syntax; the core fix is OS-agnostic

## Breaking Changes
None.

_Last updated: 2026-07-21 01:48:49_
<!-- AI-PR-DESCRIPTION-END -->