### PR TITLE
fix(deps): clear brace-expansion DoS by bumping pi-coding-agent to 0.81.0

### DIFF
--- a/plugins/pi/package-lock.json
+++ b/plugins/pi/package-lock.json
@@ -8,22 +8,22 @@
       "name": "@fajarhide/omni-pi",
       "version": "0.6.0",
       "devDependencies": {
-        "@earendil-works/pi-coding-agent": "^0.79.8",
+        "@earendil-works/pi-coding-agent": "^0.81.0",
         "@types/node": "^22.0.0",
         "typescript": "^5.0.0"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.79.8",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.79.8.tgz",
-      "integrity": "sha512-wr9oTS/yrwURDXnYrONQgFgV7QDlwslXL/rvKU5X7TRtrGxIhippsRApXqYlRwSeMjb2YzgHMfZ/kAhOqrzoFQ==",
+      "version": "0.81.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.81.0.tgz",
+      "integrity": "sha512-2p0Dnx+3fkPLga8M82eg14ZYNLcFLhqxxKyVVfqUSIio9Xx4p7UjvJtopx/6PTeJKmdJl1/xOm/c02AFcJ+l/g==",
       "dev": true,
       "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.79.8",
-        "@earendil-works/pi-ai": "^0.79.8",
-        "@earendil-works/pi-tui": "^0.79.8",
+        "@earendil-works/pi-agent-core": "^0.81.0",
+        "@earendil-works/pi-ai": "^0.81.0",
+        "@earendil-works/pi-tui": "^0.81.0",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
@@ -513,12 +513,12 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.79.8",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.79.8.tgz",
+      "version": "0.81.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.81.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.79.8",
+        "@earendil-works/pi-ai": "^0.81.0",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -528,8 +528,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.79.8",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.79.8.tgz",
+      "version": "0.81.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.81.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -546,15 +546,15 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "./dist/cli.js"
+        "pi-ai": "dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.79.8",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.79.8.tgz",
+      "version": "0.81.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.81.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -669,9 +669,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -689,9 +686,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -709,9 +703,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -729,9 +720,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -749,9 +737,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1120,9 +1105,9 @@
       "license": "MIT"
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1987,9 +1972,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.19.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.18.tgz",
-      "integrity": "sha512-9v00a+dn2yWVsYDEunWC4g/TcRKVq3r8N5FuZp7u0SGrPvdN9c2yXI9bBuf5Fl0hNCb+QTIePTn5pJs2pwBOQQ==",
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/plugins/pi/package.json
+++ b/plugins/pi/package.json
@@ -16,7 +16,7 @@
     ]
   },
   "devDependencies": {
-    "@earendil-works/pi-coding-agent": "^0.79.8",
+    "@earendil-works/pi-coding-agent": "^0.81.0",
     "@types/node": "^22.0.0",
     "typescript": "^5.0.0"
   }


### PR DESCRIPTION
Closes #138

Dependabot #21: **brace-expansion 5.0.6** (high, DoS; fixed in 5.0.7), transitive under `@earendil-works/pi-coding-agent` in `plugins/pi`.

## Why the obvious fix doesn't work

A consumer override —

```json
"overrides": { "brace-expansion": ">=5.0.7" }
```

— is **ignored**. `@earendil-works/pi-coding-agent` ships its own `npm-shrinkwrap.json` pinning `brace-expansion@5.0.6`, and a dependency's shrinkwrap wins over a consumer override. Verified: brace-expansion stayed 5.0.6 after the override on both `npm install --package-lock-only` and a full `npm install`.

## The fix

The lever is the parent. **pi-coding-agent 0.81.0**'s shrinkwrap ships `brace-expansion@5.0.7`, so bump the devDependency `^0.79.8 → ^0.81.0` and regenerate the lockfile.

## Verified

```
brace-expansion → 5.0.7
npm audit       → high gone (1 moderate remains, see below)
npx tsc --noEmit → exit 0   # pi extension still compiles against the SDK bump
```

`node_modules` is gitignored and not committed. Only `package.json` (+1 minor bump) and `package-lock.json` change.

## Out of scope

A **moderate protobufjs** DoS remains in 0.81.0's shrinkwrap — a different advisory this bump doesn't clear (an override can't touch it for the same shrinkwrap reason). Filed as **#139**. It's dev-only transitive (`dev: true`, the `pi` plugin's tooling, not the core Rust binary).

<!-- AI-PR-DESCRIPTION-START -->
## PR Auto Describe


## Summary
Updated `@earendil-works/pi-coding-agent` dependency from `^0.79.8` to `^0.81.0` in the Pi plugin, including its transitive dependencies (`pi-agent-core`, `pi-ai`, `pi-tui`). Also updated `@types/node` to `22.20.1` and `brace-expansion` to `5.0.7`.

---

## Key Changes
- **Dependency bump**: `@earendil-works/pi-coding-agent` `^0.79.8` → `^0.81.0`
- **Transitive deps**: All `pi-*` packages updated from `0.79.8` to `0.81.0`
- **Dev deps**: `@types/node` `22.19.18` → `22.20.1`

---

## Detailed Breakdown
| Package | Old Version | New Version |
|---------|-------------|-------------|
| `@earendil-works/pi-coding-agent` | 0.79.8 | **0.81.0** |
| `@earendil-works/pi-agent-core` | 0.79.8 | **0.81.0** |
| `@earendil-works/pi-ai` | 0.79.8 | **0.81.0** |
| `@earendil-works/pi-tui` | 0.79.8 | **0.81.0** |
| `@types/node` | 22.19.18 | **22.20.1** |
| `brace-expansion` | 5.0.6 | **5.0.7** |

- Removed `libc` constraints from optional platform-specific binaries in photon-node package (standardization change)
- Minor lockfile formatting update (trailing newline added to `package.json`)

---

## Notes
Minor version updates with no API changes expected. Verify plugin functionality remains intact if any behavioral changes in the upstream `pi-coding-agent` were introduced between `0.79.8` and `0.81.0`.

---

## Breaking Changes
None detected.

_Last updated: 2026-07-21 15:29:58_
<!-- AI-PR-DESCRIPTION-END -->