### PR TITLE
fix(jsts): stop vitest claiming ✓ 0/0 passed when it parsed no tests

### DIFF
--- a/src/distillers/jsts.rs
+++ b/src/distillers/jsts.rs
@@ -245,7 +245,16 @@ fn distill_vitest(input: &str) -> String {
     }
 
     if failed_tests == 0 && failed_details.is_empty() {
-        return format!("vitest: ✓ {}/{} passed", passed_tests, total_tests);
+        // Zero-state guard (#143): only claim a clean run if we actually parsed a
+        // vitest signal (a "Tests …" summary or at least one ✓ line). Otherwise a
+        // misdetected input (e.g. a `VITE v` dev server, #115) would become a
+        // false `vitest: ✓ 0/0 passed`. No signal → pass the input through.
+        let parsed = has_summary || passed_tests > 0;
+        return super::require_parsed(
+            parsed,
+            input,
+            format!("vitest: ✓ {}/{} passed", passed_tests, total_tests),
+        );
     }
 
     // Deduplicate failed_details

--- a/src/distillers/mod.rs
+++ b/src/distillers/mod.rs
@@ -395,7 +395,10 @@ mod tests {
             "zero-parse produced a false success claim: {output:?}"
         );
         // The load-bearing signal (the bound port) survives.
-        assert!(output.contains(":8080"), "dev-server port was dropped: {output:?}");
+        assert!(
+            output.contains(":8080"),
+            "dev-server port was dropped: {output:?}"
+        );
     }
 
     #[test]

--- a/src/distillers/mod.rs
+++ b/src/distillers/mod.rs
@@ -161,6 +161,17 @@ fn should_passthrough_config_output(command: &str, input: &str) -> bool {
         || lower.ends_with(".json")
 }
 
+/// Zero-state guard: a distiller may emit a success/clean summary only if it
+/// positively parsed a recognized signal. With no evidence anything was parsed,
+/// fail open by returning the raw input unchanged — never a synthesized
+/// `✓`/"no errors"/"passed" string that is byte-identical to a real clean run.
+///
+/// This is the shared invariant behind #143: a misdetection upstream then
+/// degrades to passthrough instead of a confident false claim.
+pub(crate) fn require_parsed(parsed: bool, input: &str, summary: String) -> String {
+    if parsed { summary } else { input.to_string() }
+}
+
 /// Distill output based on command
 #[tracing::instrument(skip_all)]
 pub fn distill_with_command(
@@ -369,6 +380,22 @@ mod tests {
             extract_base_executable("env FOO=1 \"/path/to/git\" status"),
             "/path/to/git"
         );
+    }
+
+    #[test]
+    fn vitest_zero_parse_passes_through_instead_of_claiming_success() {
+        // #143 / #115: a Vite dev server (no tests) must never distill to a
+        // green `vitest: ✓ 0/0 passed`. With nothing parsed, fail open.
+        let input = include_str!("../../tests/fixtures/vite_dev_server.txt");
+        let segments = scorer::score_with_command(input, "vitest", None);
+        let output = distill_with_command(&segments, input, "vitest", None);
+
+        assert!(
+            !output.contains("0/0 passed"),
+            "zero-parse produced a false success claim: {output:?}"
+        );
+        // The load-bearing signal (the bound port) survives.
+        assert!(output.contains(":8080"), "dev-server port was dropped: {output:?}");
     }
 
     #[test]

--- a/tests/fixtures/vite_dev_server.txt
+++ b/tests/fixtures/vite_dev_server.txt
@@ -1,0 +1,6 @@
+
+  VITE v8.1.4  ready in 743 ms
+
+  ➜  Local:   http://localhost:8080/
+  ➜  Network: http://10.10.93.202:8080/
+  ➜  press h + enter to show help


### PR DESCRIPTION
## What

Reference implementation of the #143 **zero-state passthrough guard**, applied to the vitest path.

- New shared helper `require_parsed(parsed, input, summary)` in `src/distillers/mod.rs`: a distiller may emit a success string **only if it positively parsed a recognized signal**; otherwise it fails open and returns the input unchanged — never a synthesized green result.
- Wired into `distill_vitest`: `parsed = has_summary || passed_tests > 0`.

## Why

`is_vitest_output` matches `"VITE v"`, which a **Vite dev server** prints on startup (#115). So `npm run dev` was distilled to `vitest: ✓ 0/0 passed` — a false pass that also discarded the load-bearing bound port. With the guard, a zero-parse input passes through with `:8080` intact.

The guard fixes #115's **symptom at the root**: even though detection still misroutes the dev server into `distill_vitest`, the guard degrades it to passthrough instead of a false claim. Detection cleanup (`"VITE v"` → `"RUN v"`) is now optional polish, tracked separately if wanted.

## Verified

- New test `vitest_zero_parse_passes_through_instead_of_claiming_success` **proven to fail without the guard** (emits `vitest: ✓ 0/0 passed`) and pass with it.
- Full distiller suite **56/56 green**; `test_jsts_vitest` snapshot **unchanged** — legit vitest output parses a summary, so it's unaffected.
- Fixture `tests/fixtures/vite_dev_server.txt` is the real #115 scenario.
- Note: local runs were on Rust 1.94.0 (no rustup here); CI re-runs on the pinned 1.97.0.

Closes #115
Refs #143

<!-- AI-PR-DESCRIPTION-START -->
## PR Auto Describe


## Summary
Fix false positive `vitest: ✓ 0/0 passed` when vitest distiller receives non-test input (e.g., Vite dev server). Added a zero-state guard `require_parsed` that only emits success summaries when a recognized test signal was actually parsed; otherwise, raw input passes through unchanged.

## Key Changes
- **New utility**: `require_parsed(parsed, input, summary)` — emits `summary` only if `parsed` is true, else returns `input` unchanged
- **Vitest distiller**: Uses `require_parsed` to guard the zero-failure success path; requires either a "Tests …" summary line or at least one `✓` test line
- **Regression test** + fixture for Vite dev server output

## Detailed Breakdown
- `src/distillers/mod.rs`: Added `require_parsed` function (zero-state guard) and corresponding test verifying Vite dev server input does not become a false `0/0 passed` claim
- `src/distillers/jsts.rs`: Changed success path to `super::require_parsed(parsed, input, …)` where `parsed = has_summary || passed_tests > 0`; comments explain the invariant
- `tests/fixtures/vite_dev_server.txt`: New fixture covering the Vite dev server output that previously misdetected as vitest

## Notes
- The `parsed` condition intentionally requires a positive signal (summary line or any `✓` line); an empty run with no signals now passes through instead of claiming `0/0`.

## Breaking Changes
None.

_Last updated: 2026-07-21 17:18:21_
<!-- AI-PR-DESCRIPTION-END -->