### PR TITLE
chore(mcp): remove three stub tools that fabricated their output

### DIFF
--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -134,21 +134,6 @@ pub struct OmniSignalExtractParams {
     pub context: Option<String>,
 }
 
-#[derive(Deserialize, JsonSchema)]
-pub struct OmniGoalAlignmentParams {
-    pub goal: String,
-    pub last_n: usize,
-}
-
-#[derive(Deserialize, JsonSchema)]
-pub struct OmniNoiseProfileParams {}
-
-#[derive(Deserialize, JsonSchema)]
-pub struct OmniIterationSummaryParams {
-    pub iteration_start_command: u32,
-    pub iteration_end_command: u32,
-}
-
 // Automatically bind tool signatures
 #[tool_router(server_handler)]
 impl OmniServer {
@@ -1380,62 +1365,6 @@ impl OmniServer {
             "critical": critical,
             "important": important,
             "dropped_pct": dropped_pct
-        })
-        .to_string()
-    }
-
-    #[tool(
-        name = "omni_goal_alignment",
-        description = "Check if recent tool outputs aligned with stated goal"
-    )]
-    pub async fn omni_goal_alignment(&self, params: Parameters<OmniGoalAlignmentParams>) -> String {
-        let _goal = params.0.goal;
-        let _last_n = params.0.last_n.max(1);
-
-        // Since we don't have the session_id string here explicitly, we could just query globally or just return mock/best-effort
-        let progress_score = 0.5; // Stub for now
-
-        serde_json::json!({
-            "aligned": progress_score > 0.5,
-            "progress_score": progress_score,
-            "divergence_signals": ["Not implemented in MVP"]
-        })
-        .to_string()
-    }
-
-    #[tool(
-        name = "omni_noise_profile",
-        description = "Identify pattern noise mostly dropped in this session"
-    )]
-    pub async fn omni_noise_profile(&self, _params: Parameters<OmniNoiseProfileParams>) -> String {
-        let mut savings = std::collections::HashMap::new();
-        savings.insert("progress_bars", 15000);
-        savings.insert("debug_logs", 45000);
-
-        serde_json::json!({
-            "top_noise_patterns": [],
-            "savings_by_category": savings
-        })
-        .to_string()
-    }
-
-    #[tool(
-        name = "omni_iteration_summary",
-        description = "Compact summary of what happened in a loop iteration"
-    )]
-    pub async fn omni_iteration_summary(
-        &self,
-        params: Parameters<OmniIterationSummaryParams>,
-    ) -> String {
-        let start = params.0.iteration_start_command;
-        let end = params.0.iteration_end_command;
-
-        serde_json::json!({
-            "markdown_summary": format!("Iteration covers commands {} to {}.", start, end),
-            "json_summary": {
-                "commands_run": end.saturating_sub(start),
-                "errors_encountered": 0
-            }
         })
         .to_string()
     }


### PR DESCRIPTION
## What
Deletes three MCP tools from `src/mcp/server.rs` that returned hardcoded / stubbed data, plus their now-unused `Params` structs:

| tool | what it fabricated |
|---|---|
| `omni_goal_alignment` | `progress_score = 0.5 // Stub for now`, `"Not implemented in MVP"` |
| `omni_noise_profile` | hardcoded `progress_bars: 15000, debug_logs: 45000`, always-empty patterns; ignored the session |
| `omni_iteration_summary` | hardcoded `errors_encountered: 0` |

## Why
An agent that called one acted on a fabricated result — the exact false-claim defect #120/#143 fight, one level up in the MCP layer. None had a real caller (no agent template, test, or doc referenced them). Per #144 the surface is frozen and deletion is preferred; a false-claiming tool nobody calls is pure liability.

MCP tool count: **29 → 26** (satisfies #144 acceptance that the count goes down).

## Verified
- `cargo build` — clean
- `cargo clippy -- -D warnings` (clippy 0.1.94) — clean
- `cargo test` — 407 passed, 0 failed (redirected to file; not read through the hook)
- `grep` confirmed no references outside `server.rs`

Closes #146

<!-- AI-PR-DESCRIPTION-START -->
## PR Auto Describe


## Summary
Removed three stub tool implementations (`omni_goal_alignment`, `omni_noise_profile`, `omni_iteration_summary`) and their associated parameter structs. These were placeholder functions marked "Not implemented in MVP" or returning hardcoded mock data.

## Key Changes
- **Removed stubs**: Deleted 3 incomplete tool methods with placeholder logic
- **Removed params**: Deleted 3 unused parameter struct definitions

## Detailed Breakdown
- Removed `OmniGoalAlignmentParams`, `OmniNoiseProfileParams`, `OmniIterationSummaryParams` structs (lines 137–152)
- Removed `omni_goal_alignment()` — stub always returning `progress_score: 0.5`
- Removed `omni_noise_profile()` — stub returning empty patterns with hardcoded savings
- Removed `omni_iteration_summary()` — stub returning minimal command count

## Notes
All removed code contained explicit "stub for now" or "Not implemented in MVP" comments. Cleanup of unused dependencies not shown in this diff.

## Breaking Changes
None — these were internal tools not exposed in public API documentation.

_Last updated: 2026-07-21 17:48:16_
<!-- AI-PR-DESCRIPTION-END -->