### PR TITLE
docs(readme): lead with the moat — reversible + never-fabricates

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 <h1>OMNI</h1>
 <p align="center">
-    <em>Noise-canceling context and long-term memory for your AI agent. Stop paying Claude to read 10,000 lines of terminal noise like a headphone for AI agent</em>
+    <em>Noise-canceling context and long-term memory for your AI agent — <b>lossy, but always reversible, and it never fabricates a result.</b> Stop paying Claude to read 10,000 lines of terminal noise.</em>
 </p>
 
 [🇺🇸 English](README.md) | [🇯🇵 日本語](i18n/README-ja.md) | [🇨🇳 简体中文](i18n/README-zh.md) | [🇸🇦 العربية](i18n/README-ar.md) | [🇮🇩 Bahasa Indonesia](i18n/README-id.md) | [🇻🇳 Tiếng Việt](i18n/README-vi.md) | [🇰🇷 한국어](i18n/README-ko.md)
@@ -16,7 +16,7 @@
   [![Hits](https://hits.sh/github.com/fajarhide/omni.svg)](https://hits.sh/github.com/fajarhide/omni/)
 </br></br>
 <b>
-58.9% fewer tokens on a real command mix &middot; Cross-Session Memory &middot; Format-safe &middot; Fails open, never fabricates &middot; Numbers you can reproduce </b>
+58.9% fewer tokens on a real command mix &middot; Cross-Session Memory &middot; Format-safe &middot; Always reversible &middot; Fails open, never fabricates &middot; Numbers you can reproduce </b>
 
 </br></br>
 <img src="media/demo.gif" alt="OMNI distilling a noisy cargo test run down to the verdict, then omni stats" width="820" />
@@ -55,6 +55,20 @@ Real numbers, measured on `tests/fixtures/` and replayed traces — not aspirati
 | `docker build` (heavy cache noise) | 9.2 KB of layer hashes and progress bars | the build result, cache hits folded | **37%** |
 
 > **The honest caveat:** OMNI compresses *noisy successful* output. A command that **fails** is passed through **verbatim** — a hidden error is worse than an uncompressed one — and structured output (JSON/YAML/CSV) is never touched. It earns its keep on repetitive tool chatter and gets out of the way everywhere else.
+
+### Why you can trust a lossy tool
+
+Every other compressor asks you to *trust* that what it cut didn't matter. OMNI doesn't ask — it guarantees, and each guarantee is backed by code you can read:
+
+| Guarantee | How | Proof |
+|---|---|---|
+| **Get the original back, byte-for-byte** | everything cut is archived in a local SQLite **RewindStore** (SHA-256 → content); the agent gets a hash and calls `omni_retrieve` | [`How it works`](#how-it-works) |
+| **Never fabricates a result** | a distiller that parsed no signal returns the raw output, never a green `no errors` / `passed` string | [#143](https://github.com/fajarhide/omni/issues/143) |
+| **Failures are never masked** | a command that exits non-zero passes through verbatim | [#120](https://github.com/fajarhide/omni/issues/120) |
+| **Structured data is never touched** | JSON / YAML / NDJSON / CSV pass through byte-for-byte | `pipeline::format` |
+| **Numbers are measured, not aspirational** | 1,810 real traces replayed on the release binary — and 63.6% of calls net zero, which we publish too | [`Benchmarks`](#benchmarks) |
+
+That is the one thing a bigger compression number can't buy: **you can always recover the original, and it will never lie to your agent.**
 
 **Problem 2: Your agent forgets everything overnight**
 


### PR DESCRIPTION
## What
Sharpens the README hero around OMNI's real differentiator, and adds a compact **"Why you can trust a lossy tool"** guarantees table (each row links to the code that backs it: RewindStore, #143, #120, `pipeline::format`, the measured benchmark).

Three surgical edits:
- **Subtitle** now leads with *"lossy, but always reversible, and it never fabricates a result."*
- **Badge line** gains `Always reversible`.
- New **trust table** right after the honest caveat.

## Why
#131 made the README stop lying; this makes it **sell**. Competitors on `/topics/token-optimization` all lead with a bigger % (60–95%). OMNI's honest median is 58.9% (63.6% of calls net zero) — a headline war it can't win and shouldn't fight. The one claim rtk/headroom/MemOS can't copy is **earned honesty**: fully reversible + never-fabricate, now enforced end-to-end after #143.

## Guardrail honored
Framed as invariants OMNI *enforces and tests* (linked to #143/#120/`pipeline::format`), never as the "zero hallucination" claim #131 removed. No number OMNI can't support.

## Scope / i18n
English README is the source of truth and the positioning deliverable. Propagating the new hero + trust section into the six `i18n/README-*.md` (already divergent) is folded into **#132**, which owns i18n re-sync — rather than shipping five unverifiable translations of a trust claim.

Closes #147

<!-- AI-PR-DESCRIPTION-START -->
## PR Auto Describe


## Summary

Documentation refresh that clarifies OMNI's lossy-but-reversible design. New "Why you can trust a lossy tool" section adds a guarantees table explaining RewindStore recovery, no-fabrication policy, failure passthrough, and structured data protection.

---

## Key Changes

- **Updated tagline**: Now emphasizes "lossy, but always reversible, and it never fabricates a result"
- **Feature bullet added**: "Always reversible" to the header badges
- **New section**: "Why you can trust a lossy tool" with guarantees table (RewindStore, no fabrication, failure passthrough, structured data protection, measured benchmarks)

---

## Detailed Breakdown

| File | Change |
|------|--------|
| README.md | Tagline updated with reversibility + no-fabrication messaging |
| README.md | Header feature list expanded with "Always reversible" |
| README.md | New "Why you can trust a lossy tool" section with 5-row guarantees table (How + Proof columns) |

The new section links to specific issues (#143, #120) and internal docs (`pipeline::format`, `How it works`, `Benchmarks`) as proof for each guarantee.

---

## Notes

- No code changes — pure documentation
- Does not affect runtime behavior
- No API or interface changes

---

## Breaking Changes

None.

_Last updated: 2026-07-22 04:27:05_
<!-- AI-PR-DESCRIPTION-END -->