### PR TITLE
docs(how-to-use): fix drifted stats flags, document --rerun and [UNRELEASED]

### DIFF
--- a/docs/HOW_TO_USE.md
+++ b/docs/HOW_TO_USE.md
@@ -263,9 +263,11 @@ Run this any time to see how much OMNI has saved you.
 
 ```bash
 omni stats              # Last 30 days (default)
-omni stats --today      # Today only
-omni stats --week       # Last 7 days
-omni stats --month      # Last 30 days (explicit)
+omni stats --hour       # Last 60 minutes (-H)
+omni stats --today      # Today only (-d)
+omni stats --week       # Last 7 days (-w)
+omni stats --month      # Last 30 days, explicit (-m)
+omni stats --rerun      # Which distillers cost a re-run (see below)
 ```
 
 ### Example Output
@@ -781,6 +783,20 @@ omni doctor --fix   # Check AND auto-repair
 └─────────────────────────────────────────────────────────────────────────┘
 ```
 
+The binary-version check answers two separate questions. One is "is there a
+newer release than mine" — a GitHub lookup. The other, added in 0.6.4, is "does
+this build carry fixes that are in no release yet":
+
+```
+Binary:  omni v0.6.4 [LATEST]
+         [3 UNRELEASED] changes built into this binary are in no release — cut a tag
+```
+
+The second line only appears on a build made from a tree with pending changelog
+entries — a contributor's local build, not a released binary. It exists because
+a released version can still be `[LATEST]` while sitting on merged-but-unshipped
+fixes, which is exactly how six correctness fixes stayed invisible before 0.6.3.
+
 ### Auto-Fix Coverage
 
 When you run `omni doctor --fix`, OMNI will automatically repair:
@@ -922,20 +938,38 @@ omni init --uninstall  # Remove all OMNI components from Claude
 Token savings analytics dashboard.
 
 ```bash
-omni stats              # Last 30 days (default)
-omni stats --today      # Today only
-omni stats --week       # Last 7 days
-omni stats --month      # Last 30 days (explicit)
-omni stats --passthrough  # Show commands without filter coverage
-omni stats --session    # Session-level breakdown
+omni stats                # Last 30 days (default)
+omni stats --hour  / -H   # Last 60 minutes
+omni stats --today / -d   # Today only
+omni stats --week  / -w   # Last 7 days
+omni stats --month / -m   # Last 30 days (explicit)
+omni stats --detail       # Full breakdown: commands, routes, sessions, agents
+omni stats --all-commands # List every command, not just the top ones
+omni stats --project      # Breakdown per project path
+omni stats --context      # Context composition signals
+omni stats --rerun        # Which distillers cost a re-run
+omni stats --json         # Machine-readable
 ```
 
 **Output includes:**
 - Commands processed, input/output bytes, signal ratio
-- Estimated cost savings (@$3/1M tokens)
 - Per-filter breakdown with ASCII bar charts
-- Route distribution (Keep/Soft/Passthrough/Rewind)
+- Route distribution (Keep/Soft/Passthrough)
 - Session insights (hot files, accuracy signals)
+
+#### `--rerun`: the check reduction % cannot make
+
+Reduction percentage counts bytes removed, so a distiller that returned an empty
+string would score 100%. `--rerun` measures the thing reduction cannot see:
+**how often the agent had to run a command again** within five minutes of reading
+its distilled output. A high re-run rate means the distiller dropped something
+the agent needed, whatever its reduction says.
+
+`Passthrough` rows — where the agent read the raw output — are the control arm,
+so each filter is shown distilled-rate against raw-rate. Two guards keep the
+number honest: a filter whose two arms are very different sizes prints `n/a`
+(the delta would measure input size, not lost signal), and a filter needs enough
+runs on both arms before any delta is shown at all.
 
 ---
 
@@ -1168,7 +1202,7 @@ If you are using Claude Code, Cursor, or OpenClaw, the AI can independently call
 
 **DO:**
 - Run `omni doctor` after any system update or Claude Code upgrade
-- Check `omni stats --passthrough` to see which tools aren't being filtered yet (those are learning opportunities)
+- Check `omni stats --all-commands` to see which tools aren't being filtered yet (those are learning opportunities)
 - Pair with [Heimsense](https://github.com/fajarhide/heimsense) if using non-Anthropic models
 
 **DON'T:**


### PR DESCRIPTION
Closes #185

Documentation only — English `docs/HOW_TO_USE.md`. No measured number touched.

## The stale-flag half is the #151 defect in reverse

The stats reference listed two flags the binary rejects:

```
$ ./target/debug/omni stats --passthrough   → unknown flag, exit 1
$ ./target/debug/omni stats --session       → unknown flag, exit 1
```

Docs promising flags that do not exist — the mirror of #151, which was the
binary accepting flags it did not understand.

## What changed

**`omni stats`:**
- removed `--passthrough` and `--session` (both rejected by the binary)
- added the short forms `-H`/`-d`/`-w`/`-m` and `--hour` (#154), plus `--detail`,
  `--all-commands`, `--project`, `--context`
- added **`--rerun`** (#109), which had no documentation anywhere, with a short
  section explaining it measures re-runs — the signal reduction % cannot see —
  and naming the two guards so the `n/a` output is not read as a bug
- dropped "Estimated cost savings (@$3/1M tokens)" — `omni stats` no longer
  prints a cost figure, and a dollar number OMNI cannot compute is the
  `est_cost_usd` defect from 0.6.2

**`omni doctor`:**
- documented the `[N UNRELEASED]` line (#137) and the distinction it draws:
  "is there a newer release" vs "does this build carry fixes no release has",
  and that the second line only appears on a build from a tree with pending
  entries, not on a released binary

## Verified

- every flag the docs now show was run against the binary and is accepted; the
  two removed flags were confirmed rejected
- `tests/smoke_test.sh` — **31/31**
- code fences balanced (118)

## Deliberately out of scope

- **README benchmark numbers (#184)** — the 58.9% headline was measured on a
  pre-0.6.4 binary and needs re-running; untouched here.
- **i18n re-sync (#132)** — waits on that re-benchmark, so the translations are
  not rewritten around numbers about to change.
- The `Heimsense` referral at line 1206 is left as-is — whether that project is
  still current is the maintainer's call, not a flag-drift fix.

## Caveat on CI

Smoke test ran on **Rust 1.94.0** locally; the repo pins **1.97.0** and there is
no rustup here. This is a docs change with no Rust touched, so the risk is nil,
but the toolchain is stated for accuracy.

<!-- AI-PR-DESCRIPTION-START -->
## PR Auto Describe


## Summary

Document new `omni stats` options (`--hour/-H`, `--detail`, `--all-commands`, `--project`, `--context`, `--rerun`, `--json`). Added binary-version check section for detecting un-released changes in contributor builds. Documented `--rerun` metric and its relationship to reduction %.

---

## Key Changes

- **New `omni stats` flags**: `--hour/-H`, `--detail`, `--all-commands`, `--project`, `--context`, `--rerun`, `--json`
- **Binary-version check**: New section documenting the un-released-changes detection (0.6.4+)
- **Renamed flag**: `--passthrough` → `--all-commands`
- **Updated output docs**: Removed "Rewind" from route types, removed cost-savings line from output description

---

## Detailed Breakdown

### `omni stats` Flag Additions
| Flag | Short | Purpose |
|------|-------|---------|
| `--hour` | `-H` | Last 60 minutes |
| `--detail` | — | Full breakdown: commands, routes, sessions, agents |
| `--all-commands` | — | List every command, not just top ones |
| `--project` | — | Breakdown per project path |
| `--context` | — | Context composition signals |
| `--rerun` | — | Which distillers caused re-runs |
| `--json` | — | Machine-readable output |

### `--rerun` Metric Explanation Added
Reduction % measures bytes removed, so a distiller returning empty string scores 100%. The `--rerun` flag measures a different signal: how often the agent re-ran a command within 5 minutes of reading distilled output. High re-run rate = distiller dropped needed content. `Passthrough` rows serve as the control arm for comparison. Two guards prevent misleading numbers: size mismatches print `n/a`, and both arms need sufficient runs before delta is shown.

### Binary-Version Check Documentation
Added explanation that builds from trees with pending changelog entries display `[3 UNRELEASED]` message. This catches the case where a released version is `[LATEST]` while containing merged-but-unshipped fixes—addressing the issue where six correctness fixes stayed invisible before 0.6.3.

### Output Format Updates
- Removed "Estimated cost savings (@$3/1M tokens)"
- Removed "Rewind" from route distribution (now: Keep/Soft/Passthrough)
- Updated advice to recommend `omni stats --all-commands` instead of `--passthrough`

---

## Notes

Flag rename (`--passthrough` → `--all-commands`) is documentation-only; backend flag behavior unchanged.

---

## Breaking Changes

None.

_Last updated: 2026-07-23 17:44:56_
<!-- AI-PR-DESCRIPTION-END -->