### PR TITLE
docs(audit): where OMNI distillation helps an agent and where it drops the answer

### DIFF
--- a/docs/COMMAND_AUDIT.md
+++ b/docs/COMMAND_AUDIT.md
@@ -1,0 +1,96 @@
+# OMNI — Command Audit: where distillation helps an agent, and where it hurts
+
+Measured 2026-07-26 on the current build (main `12b1d28`). Each command's real
+output was piped through OMNI's pipe mode with an isolated `OMNI_DB_PATH` and a
+fresh session (no scorer history), then raw vs distilled bytes were compared and
+the distilled output was read in full to check whether the **answer** survived,
+not just whether bytes shrank.
+
+## The principle this surfaced
+
+OMNI earns its keep when a command's output is **`verdict + repeated noise`** — a
+build log, a test run, an infra plan. It drops the noise and keeps the signal, and
+the agent reads less while knowing the same thing.
+
+It **destroys the answer** when a command's output is a **list where every line is
+a distinct datum** — a file listing, a process table, a path enumeration. There is
+no noise to drop, so "compression" can only mean dropping items the agent asked
+for. High reduction on these commands is a red flag, not a win.
+
+> The rule that follows: distill `signal + noise`; pass through `a list of data`.
+
+## ✅ Genuine wins — distill these (noise dropped, answer kept)
+
+| Command | Input | Output | Saved | What survives |
+|---|---|---|---|---|
+| `terraform plan` | 916 B | 125 B | 86% | `+2 ~1 -1` summary **and every resource** (`+aws_instance.web`, `~…sg`, `-…old_worker`) |
+| `cargo test` | 16,515 B | 1,100 B | 93% | `490 passed; 10 failed` + each failing test |
+| `cargo build` | 3,220 B | 9 B | 99% | clean build → `Build: ok` (no error to lose) |
+| `docker build` | 309 B | 31 B | 89% | build status; errors kept on failure |
+| `npm run build` | 491 B | 60 B | 87% | build status |
+| `npm test` (vitest) | 392 B | 25 B | 93% | `✓ 16/17 ✗ 1` (minor: does not name the failing test) |
+| `docker build` (heavy noise) | 9,207 B | 5,783 B | 37% | the error inside a wall of progress lines |
+| `cargo build` (errors) | 317 B | 292 B | 7% | every error, little dropped — correct |
+
+These are OMNI's reason to exist. **The demo GIF and the marketing should lead
+with `cargo test` and `terraform plan`.**
+
+## ❌ Harms — these drop the answer (bugs)
+
+| Command | Input | Output | "Saved" | What is LOST |
+|---|---|---|---|---|
+| `ls -la` | 983 B | 55 B | 94% | every filename → replaced by a count (`ls: 16 items \| 13 files, 3 dirs`) |
+| `find` | 3,919 B | 636 B | 83% | 68 of 98 paths, `[Partial signal]` with no count — **#198** |
+| `git log` (verbose) | 17,703 B | 1,361 B | 92% | 10 of 12 commits, output cut mid-line — **#199** |
+| `wc -l` (many files) | 2,907 B | 916 B | 68% | most per-file counts |
+| `ps aux` | 148,556 B | 50,425 B | 66% | most processes (keeps top-by-CPU only; no count of the rest) |
+| `docker ps` | 862 B | 75 B | 91% | running containers' names/images/ports (keeps only the exited ones) |
+
+`ps aux` and `docker ps` are borderline — they surface the "interesting" rows
+(busy processes, failed containers) and drop the rest — but they drop them without
+a count, so a reader cannot tell a filtered view from a complete one.
+
+## ❌ Net-negative — OMNI *grows* the output
+
+| Command | Input | Output | Delta |
+|---|---|---|---|
+| `env` | 1,224 B | 1,838 B | **+50%** |
+| `df -h` | 953 B | 1,106 B | **+16%** |
+| `cargo tree` | 21,983 B | 22,324 B | **+1%** (should be a clean passthrough per #170) |
+
+Any command OMNI cannot shrink must be handed back byte-for-byte. Adding marker or
+annotation bytes to output it did not distill is a token cost with no benefit,
+paid on every turn once the context is cached.
+
+## ✅ Correct passthrough (working as intended)
+
+- `az vm list -o json` (3,969 B) → **0%**, byte-for-byte. The format-safe gate
+  (`pipeline::format::sniff`) recognises JSON and stands the lossy stages down.
+  This is the moat working.
+- `cat`, `head`, `ls -R`, `du`, small `go test` / `jest` / `semgrep` outputs —
+  passed through because they are structured, small, or have no noise to drop.
+- Modest lossless trims: `git diff` 44%, `eslint` 46%, `grep -rn` 20% (hoists the
+  repeated path, keeps every match), `git log --oneline` 19% (keeps every
+  subject), `pytest` 18%, `npm install` 19%, `kubectl get pods` 9% (small fixture;
+  a large pod table compresses more while keeping the statuses).
+
+## What this means
+
+1. **Scope OMNI to the commands it wins.** Enumeration commands (`ls`, `find`,
+   `tree`, `wc`, `ps`, `docker ps`, verbose `git log`) should keep every item with
+   a count, or pass through — never truncate to a shorter, plausible, incomplete
+   list. Tracked as an umbrella issue over #198 / #199.
+2. **The published savings figure is inflated** by the lossy truncation above. A
+   re-benchmark (#184) must count dropped list items as lost signal, not
+   compression, or the headline measures the bug.
+3. **Never grow.** `env` / `df` must pass through.
+
+## How to reproduce
+
+```
+OMNI_DB_PATH=$(mktemp -d)/d.db OMNI_QUIET=1 \
+  <command> | OMNI_CMD="<command>" ./target/debug/omni
+```
+
+Compare line/byte counts against the raw command, and **read the whole distilled
+output** — a byte count cannot tell a dropped item from removed noise.

--- a/docs/COMMAND_AUDIT.md
+++ b/docs/COMMAND_AUDIT.md
@@ -87,10 +87,6 @@ paid on every turn once the context is cached.
 
 ## How to reproduce
 
-```
-OMNI_DB_PATH=$(mktemp -d)/d.db OMNI_QUIET=1 \
-  <command> | OMNI_CMD="<command>" ./target/debug/omni
-```
 
 Compare line/byte counts against the raw command, and **read the whole distilled
 output** — a byte count cannot tell a dropped item from removed noise.


### PR DESCRIPTION
Adds `docs/COMMAND_AUDIT.md` — a measured audit of 35 agent-common commands through the current pipeline (main `12b1d28`), classifying each as a genuine win, a lossy harm, a net-negative grow, or a correct passthrough.

## The finding

OMNI splits cleanly:
- **Wins** on `verdict + noise` output — `cargo test` 93% (verdict + every failure), `terraform plan` 86% (summary + every resource), build logs 87–99%. Noise dropped, answer kept.
- **Harms** on `a list of data` output — `ls` (drops filenames), `find` (#198), verbose `git log` (#199), `wc`, `ps aux`, `docker ps` all drop items that are the answer. High reduction here is the defect.
- **Grows** `env` (+50%) and `df` (+16%) — should pass through.
- **Correct passthrough** on JSON (`az … -o json`, byte-for-byte via the format-safe gate) and small/structured output.

## Why merge it

- Names, in one place, which commands to showcase (cargo test, terraform plan) and which distillers over-reach.
- Backs the umbrella issue #200 (over #198 / #199) with the data.
- Documents that the #184 benchmark number is inflated by the lossy list-truncation, so the headline must be re-measured after the routing fix.

Docs only. Method and a reproduce-one-command snippet are in the file.

<!-- AI-PR-DESCRIPTION-START -->
## PR Auto Describe

## Summary

Added `docs/COMMAND_AUDIT.md` documenting OMNI's distillation behavior across 20+ commands. Identified three categories: commands where distillation correctly removes noise (cargo test, terraform plan), commands where it destroys answers by truncating enumeration lists (ls, find, ps aux), and commands where distillation inflates output size (env, df -h). Includes reproduction guidance and tracks issues #198/#199 (enumeration truncation) and #184 (re-benchmarking).

---

## Key Changes

- **New file**: `docs/COMMAND_AUDIT.md` — comprehensive command distillation audit with measured byte counts and pass/fail verdicts
- **Documents 3 behavior categories**: genuine wins (~10 commands), harmful truncations (~6 commands), net-negative growth (~3 commands)
- **Identifies 2 umbrella bugs**: enumeration command truncation (#198, #199)
- **Flags #184**: current savings metrics are inflated by counting dropped list items as compression

---

## Detailed Breakdown

| Category | Commands | Behavior |
|----------|----------|----------|
| ✅ Wins (86–99% savings, answer intact) | `terraform plan`, `cargo test`, `cargo build`, `docker build`, `npm run build`, `npm test` | Signal+noise pattern — distill correctly |
| ❌ Bugs (60–94% "savings", answer lost) | `ls -la`, `find`, `git log`, `wc -l`, `ps aux`, `docker ps` | List enumeration pattern — truncates items without count |
| ❌ Grows (net-negative) | `env`, `df -h`, `cargo tree` | OMNI adds bytes instead of removing any |

- **Correct passthrough** (0% change, byte-for-byte): `az vm list -o json` (JSON gate working), `cat`, `head`, `ls -R`, `du`, structured test output
- **Lossless trims** (keeps all data): `git diff` 44%, `eslint` 46%, `grep -rn` 20%, `git log --oneline` 19%, `pytest` 18%

---

## Notes

- Marketing/demo should lead with `cargo test` and `terraform plan` — these are OMNI's reason to exist
- Rule: distill `signal + noise`; pass through `a list of data`
- `ps aux` and `docker ps` are borderline — surface "interesting" rows but omit count, making filtered view indistinguishable from complete

---

## Breaking Changes

None — documentation-only addition.

_Last updated: 2026-07-26 02:50:37_
<!-- AI-PR-DESCRIPTION-END -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds `docs/COMMAND_AUDIT.md`, a measured audit of OMNI's distillation pipeline across 35 common agent commands, classifying outcomes into four categories: genuine wins, lossy harms, net-negative growth, and correct passthrough.

- **Wins documented**: `cargo test` (93%), `terraform plan` (86%), `docker build` (89%) — noise dropped, answer kept; recommended as primary demo/marketing material.
- **Harms documented**: `ls`, `find`, `git log`, `ps aux`, `docker ps` — lossy truncation drops list items the agent requested; tracked as umbrella over #198/#199.
- **Key gap**: The "How to reproduce" section exists as a heading but contains no command — the snippet was removed (in response to a prior review on env var placement) without a corrected replacement, leaving the audit non-reproducible.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Documentation-only change; no runtime code is modified. The one blocking issue is that the "How to reproduce" section heading was left empty after its command snippet was removed.

The audit tables and analysis are coherent and well-structured. The missing reproduction command is a real gap — the section promises a runnable snippet (the PR description explicitly says it is there), but the body was removed without a corrected replacement, making the audit non-reproducible by future contributors or reviewers. Adding the corrected command before merging would make this a clean 5.

**Files Needing Attention:** docs/COMMAND_AUDIT.md — the "How to reproduce" section needs a corrected command snippet restoring what was removed.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/COMMAND_AUDIT.md | New audit document classifying 35 commands across 4 distillation outcome categories; the "How to reproduce" section has its heading but the actual command snippet was removed, leaving the audit non-reproducible. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Command Output] --> B{format::sniff\nJSON / structured?}
    B -->|Yes| C[✅ Byte-for-byte passthrough\naz vm list -o json]
    B -->|No| D{Output type?}
    D -->|verdict + repeated noise\nbuild log / test run / infra plan| E[✅ Distill\ncargo test 93%\nterraform plan 86%\ndocker build 89%]
    D -->|list where every line\nis a distinct datum| F[❌ HARM — drops items\nls 94%, find 83%\ngit log 92%, docker ps 91%]
    D -->|unrecognised / no noise| G{Does OMNI shrink it?}
    G -->|Yes, lossless trim| H[✅ Modest trim\ngit diff 44%, eslint 46%\ngrep -rn 20%]
    G -->|No — output grows| I[❌ Net-negative\nenv +50%, df +16%\ncargo tree +1%]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Update docs/COMMAND\_AUDIT.md"](https://github.com/fajarhide/omni/commit/ee5854f244f904091082791c4343be41d750ac66) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47313999)</sub>

<!-- /greptile_comment -->