### PR TITLE
test(bench): reproducible net-savings replay over execution_traces (#184)

### DIFF
--- a/tests/bench_replay.rs
+++ b/tests/bench_replay.rs
@@ -37,7 +37,10 @@ fn base_command(cmd: &str) -> String {
 fn replay_execution_traces_net_savings() {
     // Resolve the corpus DB from the REAL home before we repoint HOME below.
     let db = std::env::var("OMNI_BENCH_DB").unwrap_or_else(|_| {
-        format!("{}/.omni/omni.db", std::env::var("HOME").unwrap_or_default())
+        format!(
+            "{}/.omni/omni.db",
+            std::env::var("HOME").unwrap_or_default()
+        )
     });
 
     // Match the method: no user config, no passthrough shortcut.
@@ -74,8 +77,14 @@ fn replay_execution_traces_net_savings() {
         let mut out = Vec::new();
         let mut err = std::io::sink();
         // None store + None session = fresh, deterministic, no persistence.
-        let _ =
-            omni::hooks::pipe::run_inner(Cursor::new(raw.as_bytes()), &mut out, &mut err, None, None, Some(cmd));
+        let _ = omni::hooks::pipe::run_inner(
+            Cursor::new(raw.as_bytes()),
+            &mut out,
+            &mut err,
+            None,
+            None,
+            Some(cmd),
+        );
 
         let (r, o) = (raw.len() as u64, out.len() as u64);
         n += 1;
@@ -99,15 +108,27 @@ fn replay_execution_traces_net_savings() {
     println!("corpus:            {n} traces from {db}");
     println!("bytes:             {raw_total} -> {out_total}");
     println!("NET SAVINGS:       {net:.1}%");
-    println!("saved nothing:     {:.1}% ({} passthrough + {} grew)", pct(unchanged + grew), unchanged, grew);
+    println!(
+        "saved nothing:     {:.1}% ({} passthrough + {} grew)",
+        pct(unchanged + grew),
+        unchanged,
+        grew
+    );
     println!("actually shrank:   {:.1}% ({shrank})", pct(shrank));
     println!("ADDED BYTES:       {grew} calls");
     println!("\ntop commands by input bytes:");
     let mut cmds: Vec<_> = per_cmd.into_iter().filter(|(k, _)| !k.is_empty()).collect();
     cmds.sort_by_key(|(_, v)| std::cmp::Reverse(v.1));
-    println!("{:<12} {:>7} {:>14} {:>14} {:>8}", "command", "calls", "input", "output", "saved");
+    println!(
+        "{:<12} {:>7} {:>14} {:>14} {:>8}",
+        "command", "calls", "input", "output", "saved"
+    );
     for (cmd, (calls, r, o)) in cmds.into_iter().take(15) {
-        let saved = if r > 0 { 100.0 * (r - o.min(r)) as f64 / r as f64 } else { 0.0 };
+        let saved = if r > 0 {
+            100.0 * (r - o.min(r)) as f64 / r as f64
+        } else {
+            0.0
+        };
         println!("{cmd:<12} {calls:>7} {r:>14} {o:>14} {saved:>7.1}%");
     }
     println!();

--- a/tests/bench_replay.rs
+++ b/tests/bench_replay.rs
@@ -1,0 +1,120 @@
+//! #184 — the reproducible net-savings benchmark.
+//!
+//! Replays every `execution_traces.raw_input` through the CURRENT pipeline and
+//! aggregates raw vs distilled bytes, so the published headline (docs/PERFOMANCE.md,
+//! README) can be re-measured on the shipped binary rather than trusted from a run
+//! nobody kept. This is the committed reproducer the README's "Numbers you can
+//! reproduce" promises.
+//!
+//! Ignored by default — it needs a populated trace DB. Run it explicitly:
+//!
+//!   OMNI_BENCH_DB=~/.omni/omni.db \
+//!     cargo test --release --test bench_replay -- --ignored --nocapture
+//!
+//! Faithfulness to docs/PERFOMANCE.md's method:
+//! - `session: None` + `store: None` → the scorer sees no history, i.e. the
+//!   "fresh HOME per invocation" the method requires (a warm DB is non-deterministic).
+//! - `HOME` is pointed at an empty temp dir so only the embedded signals load, not
+//!   whatever `~/.omni/signals` the measuring machine happens to carry.
+//! - `run_inner` is the same full pipeline (format gate → TOML → distill → guardrail)
+//!   the hook and `omni exec` run, so this measures what an agent actually receives.
+
+use std::collections::BTreeMap;
+use std::io::Cursor;
+
+fn base_command(cmd: &str) -> String {
+    cmd.split_whitespace()
+        .find(|t| !t.contains('=') && !t.starts_with('-'))
+        .unwrap_or("")
+        .rsplit('/')
+        .next()
+        .unwrap_or("")
+        .to_string()
+}
+
+#[test]
+#[ignore = "needs a populated trace DB; run with --ignored (see file header)"]
+fn replay_execution_traces_net_savings() {
+    // Resolve the corpus DB from the REAL home before we repoint HOME below.
+    let db = std::env::var("OMNI_BENCH_DB").unwrap_or_else(|_| {
+        format!("{}/.omni/omni.db", std::env::var("HOME").unwrap_or_default())
+    });
+
+    // Match the method: no user config, no passthrough shortcut.
+    let tmp_home = tempfile::tempdir().expect("temp home");
+    // SAFETY: single-threaded test; set before any pipeline call reads the env.
+    unsafe {
+        std::env::set_var("HOME", tmp_home.path());
+        std::env::remove_var("OMNI_PASSTHROUGH");
+    }
+
+    if !std::path::Path::new(&db).exists() {
+        eprintln!("SKIP: no trace DB at {db} (set OMNI_BENCH_DB)");
+        return;
+    }
+
+    let conn = rusqlite::Connection::open(&db).expect("open trace db");
+    let mut stmt = conn
+        .prepare("SELECT command, raw_input FROM execution_traces")
+        .expect("prepare");
+    let rows: Vec<(String, String)> = stmt
+        .query_map([], |r| Ok((r.get(0)?, r.get(1)?)))
+        .expect("query")
+        .filter_map(Result::ok)
+        .collect();
+
+    assert!(!rows.is_empty(), "trace DB has no rows to replay");
+
+    let (mut n, mut raw_total, mut out_total) = (0u64, 0u64, 0u64);
+    let (mut shrank, mut unchanged, mut grew) = (0u64, 0u64, 0u64);
+    // base command -> (calls, raw_bytes, out_bytes)
+    let mut per_cmd: BTreeMap<String, (u64, u64, u64)> = BTreeMap::new();
+
+    for (cmd, raw) in &rows {
+        let mut out = Vec::new();
+        let mut err = std::io::sink();
+        // None store + None session = fresh, deterministic, no persistence.
+        let _ =
+            omni::hooks::pipe::run_inner(Cursor::new(raw.as_bytes()), &mut out, &mut err, None, None, Some(cmd));
+
+        let (r, o) = (raw.len() as u64, out.len() as u64);
+        n += 1;
+        raw_total += r;
+        out_total += o;
+        match o.cmp(&r) {
+            std::cmp::Ordering::Less => shrank += 1,
+            std::cmp::Ordering::Equal => unchanged += 1,
+            std::cmp::Ordering::Greater => grew += 1,
+        }
+        let e = per_cmd.entry(base_command(cmd)).or_default();
+        e.0 += 1;
+        e.1 += r;
+        e.2 += o;
+    }
+
+    let net = 100.0 * (raw_total - out_total.min(raw_total)) as f64 / raw_total as f64;
+    let pct = |part: u64| 100.0 * part as f64 / n as f64;
+
+    println!("\n=== #184 net-savings replay (current pipeline) ===");
+    println!("corpus:            {n} traces from {db}");
+    println!("bytes:             {raw_total} -> {out_total}");
+    println!("NET SAVINGS:       {net:.1}%");
+    println!("saved nothing:     {:.1}% ({} passthrough + {} grew)", pct(unchanged + grew), unchanged, grew);
+    println!("actually shrank:   {:.1}% ({shrank})", pct(shrank));
+    println!("ADDED BYTES:       {grew} calls");
+    println!("\ntop commands by input bytes:");
+    let mut cmds: Vec<_> = per_cmd.into_iter().filter(|(k, _)| !k.is_empty()).collect();
+    cmds.sort_by_key(|(_, v)| std::cmp::Reverse(v.1));
+    println!("{:<12} {:>7} {:>14} {:>14} {:>8}", "command", "calls", "input", "output", "saved");
+    for (cmd, (calls, r, o)) in cmds.into_iter().take(15) {
+        let saved = if r > 0 { 100.0 * (r - o.min(r)) as f64 / r as f64 } else { 0.0 };
+        println!("{cmd:<12} {calls:>7} {r:>14} {o:>14} {saved:>7.1}%");
+    }
+    println!();
+
+    // The one invariant that must hold: OMNI never adds bytes across the corpus.
+    assert!(
+        out_total <= raw_total,
+        "OMNI added bytes across the corpus: {raw_total} -> {out_total}"
+    );
+}


### PR DESCRIPTION
Closes #184

Adds `tests/bench_replay.rs` — the committed reproducer for the published savings headline. There was none: the 58.9% in `docs/PERFOMANCE.md` came from an ad-hoc replay, while the README promises "Numbers you can reproduce."

## What it does
Replays every `execution_traces.raw_input` through the current pipeline (`hooks::pipe::run_inner` with a fresh session and no store) and aggregates raw vs distilled bytes. `#[ignore]`d — it needs a populated trace DB:

```
OMNI_BENCH_DB=~/.omni/omni.db cargo test --release --test bench_replay -- --ignored --nocapture
```

## Faithful to the documented method
- `session: None` + `store: None` → the scorer sees no history, i.e. the "fresh HOME per invocation" `docs/PERFOMANCE.md` requires (a warm DB is non-deterministic).
- Temp `HOME` so only embedded signals load, not the measuring machine's `~/.omni/signals`.
- Asserts the one hard invariant: **OMNI never adds bytes across the corpus**.

## Result and caveat
On the maintainer's 7,252-trace corpus it reports **84.5%** (0 calls grew). That figure is **inflated by lossy list-truncation** (#200, over #198/#199): `find`/`ls`/verbose `git log` etc. "compress" by dropping the answer, and this replay counts those dropped bytes as savings. So the headline is not updated here — it waits on the #200 routing fix, then a re-run of this tool. This PR ships the reproducer, not a new number.

<!-- AI-PR-DESCRIPTION-START -->
## PR Auto Describe

## Summary
New benchmark test `bench_replay.rs` replays stored execution traces through the current pipeline to verify net-savings claims. Runs only with `--ignored` flag and a populated `OMNI_BENCH_DB`. Provides per-command breakdown and enforces the invariant that OMNI never adds bytes.

---

## Key Changes
- **New benchmark test**: `tests/bench_replay.rs` — 141 lines
  - Replays `execution_traces` DB rows via `run_inner` (full pipeline)
  - Measures: raw bytes → distilled bytes, net savings %, per-command stats
  - Isolated: `session: None`, `store: None`, `HOME` pointed at empty temp dir
  - `#[ignore]` by default; run with `cargo test --release --test bench_replay -- --ignored --nocapture`

---

## Detailed Breakdown
- **Trace DB integration**: Reads `command` and `raw_input` from `execution_traces` table via `OMNI_BENCH_DB` (defaults to `~/.omni/omni.db`)
- **Pipeline fidelity**: Calls `omni::hooks::pipe::run_inner` with `None` session/store to match "fresh HOME per invocation" method
- **Output metrics**: Aggregates `raw_total`, `out_total`; categorizes calls into shrank/unchanged/grew
- **Assertion**: `out_total <= raw_total` — OMNI must never inflate bytes across corpus
- **Per-command table**: Top 15 commands by input bytes with calls, raw, out, and savings %

---

## Notes
- Typo in docs reference: `docs/PERFOMANCE.md` (missing 'R' in PERFORMANCE)
- Thread-safety note: `unsafe` block to set `HOME` before any pipeline calls; acceptable for single-threaded test

_Last updated: 2026-07-26 03:32:33_
<!-- AI-PR-DESCRIPTION-END -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds `tests/bench_replay.rs`, a reproducible benchmark that replays all `execution_traces.raw_input` rows through the current pipeline to verify and re-measure the net-savings headline from `docs/PERFOMANCE.md`. It is `#[ignore]`d by default and requires an external DB via `OMNI_BENCH_DB`.

- Replays every trace through `run_inner` with `session: None`, `store: None`, and a fresh temp `HOME` to match the documented \"fresh HOME per invocation\" measurement method.
- Aggregates raw vs. distilled bytes, prints a per-command breakdown (top 15 by input bytes), and asserts the corpus-wide invariant `out_total <= raw_total`.
- Discards `run_inner` errors silently (`let _ = ...`), meaning any failing trace contributes 0 output bytes and inflates the reported savings without any indication of the failure.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge as an infrastructure-only benchmark, but the measurement it produces is unreliable until erroring traces are handled explicitly.

The benchmark's core purpose is to produce an accurate, reproducible net-savings number. Discarding run_inner errors silently means any trace that fails at runtime contributes 0 output bytes, which counts as maximum savings. On a large corpus this could systematically overstate the headline figure with no indication in the output — directly undermining the reproducible promise the PR sets out to fulfill.

**Files Needing Attention:** tests/bench_replay.rs — specifically the discarded run_inner result and the env mutation ordering relative to the early-return DB check.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tests/bench_replay.rs | New benchmark replaying execution traces through the pipeline to measure net savings; discarded run_inner errors silently inflate the savings headline, and a couple of cross-platform path issues remain. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atests%2Fbench_replay.rs%3A80-87%0A**Silent%20errors%20inflate%20the%20savings%20metric**%0A%0A%60run_inner%60%20errors%20are%20silently%20discarded.%20When%20the%20call%20fails%2C%20%60out%60%20stays%20empty%20%280%20bytes%29%2C%20so%20the%20trace%20is%20counted%20as%20%22shrank%22%20with%20100%25%20savings%20%E2%80%94%20inflating%20%60net%60%20without%20any%20indication%20something%20went%20wrong.%20A%20corpus%20with%20even%20a%20few%20erroring%20traces%20will%20silently%20produce%20an%20optimistic%2C%20non-representative%20headline%20figure.%20At%20minimum%20the%20error%20count%20should%20be%20tracked%20and%20printed%3B%20ideally%20erroring%20traces%20should%20be%20excluded%20from%20the%20savings%20calculation.%0A%0A&repo=fajarhide%2Fomni&pr=202&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fajarhide%2Fomni%22%20on%20the%20existing%20branch%20%22test%2F184-bench-replay-runner%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22test%2F184-bench-replay-runner%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atests%2Fbench_replay.rs%3A80-87%0A**Silent%20errors%20inflate%20the%20savings%20metric**%0A%0A%60run_inner%60%20errors%20are%20silently%20discarded.%20When%20the%20call%20fails%2C%20%60out%60%20stays%20empty%20%280%20bytes%29%2C%20so%20the%20trace%20is%20counted%20as%20%22shrank%22%20with%20100%25%20savings%20%E2%80%94%20inflating%20%60net%60%20without%20any%20indication%20something%20went%20wrong.%20A%20corpus%20with%20even%20a%20few%20erroring%20traces%20will%20silently%20produce%20an%20optimistic%2C%20non-representative%20headline%20figure.%20At%20minimum%20the%20error%20count%20should%20be%20tracked%20and%20printed%3B%20ideally%20erroring%20traces%20should%20be%20excluded%20from%20the%20savings%20calculation.%0A%0A&repo=fajarhide%2Fomni&pr=202&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atests%2Fbench_replay.rs%3A80-87%0A**Silent%20errors%20inflate%20the%20savings%20metric**%0A%0A%60run_inner%60%20errors%20are%20silently%20discarded.%20When%20the%20call%20fails%2C%20%60out%60%20stays%20empty%20%280%20bytes%29%2C%20so%20the%20trace%20is%20counted%20as%20%22shrank%22%20with%20100%25%20savings%20%E2%80%94%20inflating%20%60net%60%20without%20any%20indication%20something%20went%20wrong.%20A%20corpus%20with%20even%20a%20few%20erroring%20traces%20will%20silently%20produce%20an%20optimistic%2C%20non-representative%20headline%20figure.%20At%20minimum%20the%20error%20count%20should%20be%20tracked%20and%20printed%3B%20ideally%20erroring%20traces%20should%20be%20excluded%20from%20the%20savings%20calculation.%0A%0A&pr=202&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fajarhide%2Fomni%22%20on%20the%20existing%20branch%20%22test%2F184-bench-replay-runner%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22test%2F184-bench-replay-runner%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atests%2Fbench_replay.rs%3A80-87%0A**Silent%20errors%20inflate%20the%20savings%20metric**%0A%0A%60run_inner%60%20errors%20are%20silently%20discarded.%20When%20the%20call%20fails%2C%20%60out%60%20stays%20empty%20%280%20bytes%29%2C%20so%20the%20trace%20is%20counted%20as%20%22shrank%22%20with%20100%25%20savings%20%E2%80%94%20inflating%20%60net%60%20without%20any%20indication%20something%20went%20wrong.%20A%20corpus%20with%20even%20a%20few%20erroring%20traces%20will%20silently%20produce%20an%20optimistic%2C%20non-representative%20headline%20figure.%20At%20minimum%20the%20error%20count%20should%20be%20tracked%20and%20printed%3B%20ideally%20erroring%20traces%20should%20be%20excluded%20from%20the%20savings%20calculation.%0A%0A&repo=fajarhide%2Fomni"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
tests/bench_replay.rs:80-87
**Silent errors inflate the savings metric**

`run_inner` errors are silently discarded. When the call fails, `out` stays empty (0 bytes), so the trace is counted as "shrank" with 100% savings — inflating `net` without any indication something went wrong. A corpus with even a few erroring traces will silently produce an optimistic, non-representative headline figure. At minimum the error count should be tracked and printed; ideally erroring traces should be excluded from the savings calculation.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["style(bench): rustfmt bench\_replay.rs"](https://github.com/fajarhide/omni/commit/617cca242063d94d9f6a6ec327db3ba2b191465d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47315056)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/weekndlabs/github/fajarhide/omni/-/custom-context?memory=1653942e-45b5-4251-8409-19e160d03e6e))

<!-- /greptile_comment -->