### PR TITLE
fix(review): git log body leak + standards fixes from #202/#203/#204 review

### DIFF
--- a/src/distillers/git.rs
+++ b/src/distillers/git.rs
@@ -193,6 +193,10 @@ fn distill_log(segments: &[OutputSegment], input: &str) -> String {
                 // Keep the line whole.
                 out.push_str(line);
                 out.push('\n');
+                // A verbose-log subject can itself start with a 7+ hex word
+                // (`a1b2c3d fix …`) and match here; clear the flag so the next
+                // body line is not then taken as the subject too (review of #204).
+                awaiting_subject = false;
             } else if line.starts_with("Author:")
                 || line.starts_with("Date:")
                 || line.starts_with("Merge:")
@@ -336,6 +340,28 @@ Date:   Sat Mar 18 10:00:00 2026 +0700
             out.lines().count(),
             3,
             "one line per commit expected: {out:?}"
+        );
+    }
+
+    /// Review of #204: a subject that itself starts with a 7+ hex word matches the
+    /// `--oneline` regex; that branch must clear `awaiting_subject` too, or the
+    /// next body line is appended as a second "subject".
+    #[test]
+    fn hex_looking_subject_does_not_leak_the_body() {
+        let input = "\
+commit 1111111aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+Author: A <a@x.com>
+Date:   Mon Mar 20 10:00:00 2026 +0700
+
+    abc1234 refactor the parser
+
+    this body line must not survive";
+        let out = distill_log(&one_segment(input), input);
+
+        assert!(out.contains("refactor the parser"), "subject lost: {out:?}");
+        assert!(
+            !out.contains("this body line must not survive"),
+            "body leaked as subject: {out:?}"
         );
     }
 }

--- a/src/distillers/mod.rs
+++ b/src/distillers/mod.rs
@@ -83,7 +83,11 @@ pub fn is_enumeration_command(command: &str) -> bool {
     matches!(
         base,
         "ls" | "tree" | "find" | "ps" | "df" | "du" | "stat" | "wc"
-    ) || (base.is_empty() && command.split_whitespace().next() == Some("env"))
+    )
+        // `extract_base_executable` strips a leading `env`/`command` wrapper, so
+        // bare `env` and `command env` both leave base empty — match on any `env`
+        // token in that case rather than only the first word (review of #203).
+        || (base.is_empty() && command.split_whitespace().any(|t| t == "env"))
 }
 
 fn looks_like_env_assignment(token: &str) -> bool {
@@ -753,13 +757,13 @@ mod tests {
             }
         };
     }
-    passthrough_test!(test_systemops_ls_passthrough, "ls_la_output.txt", "ls -l");
+    passthrough_test!(ls_passes_through_verbatim, "ls_la_output.txt", "ls -l");
     passthrough_test!(
-        test_systemops_find_passthrough,
+        find_passes_through_verbatim,
         "find_project_output.txt",
         "find ."
     );
-    passthrough_test!(test_systemops_env_passthrough, "env_output.txt", "env");
+    passthrough_test!(env_passes_through_verbatim, "env_output.txt", "env");
 
     snapshot_test!(test_jsts_vitest, "vitest_mixed.txt", "vitest");
     snapshot_test!(test_jsts_tsc, "tsc_errors.txt", "tsc");

--- a/src/distillers/mod.rs
+++ b/src/distillers/mod.rs
@@ -765,6 +765,19 @@ mod tests {
     );
     passthrough_test!(env_passes_through_verbatim, "env_output.txt", "env");
 
+    /// Review of #205: bare `env` and `command env` both leave `base` empty (the
+    /// wrapper is stripped), so the guard matches on any `env` token. Locks that
+    /// in — a narrowing back to "first word only" would silently drop `command
+    /// env` passthrough.
+    #[test]
+    fn treats_bare_and_wrapped_env_as_enumeration() {
+        assert!(is_enumeration_command("env"));
+        assert!(is_enumeration_command("command env"));
+        assert!(is_enumeration_command("ls -la"));
+        assert!(!is_enumeration_command("grep -r foo"));
+        assert!(!is_enumeration_command("echo hi"));
+    }
+
     snapshot_test!(test_jsts_vitest, "vitest_mixed.txt", "vitest");
     snapshot_test!(test_jsts_tsc, "tsc_errors.txt", "tsc");
     // #106: a composite `npm run <script>` (an `&&` chain) must NOT be claimed by a

--- a/tests/bench_replay.rs
+++ b/tests/bench_replay.rs
@@ -72,24 +72,36 @@ fn replay_execution_traces_net_savings() {
         .collect();
 
     assert!(!rows.is_empty(), "trace DB has no rows to replay");
+    assert!(
+        rows.iter().any(|(_, r)| !r.is_empty()),
+        "all trace rows have empty raw_input — nothing to measure"
+    );
 
     let (mut n, mut raw_total, mut out_total) = (0u64, 0u64, 0u64);
-    let (mut shrank, mut unchanged, mut grew) = (0u64, 0u64, 0u64);
+    let (mut shrank, mut unchanged, mut grew, mut errored) = (0u64, 0u64, 0u64, 0u64);
     // base command -> (calls, raw_bytes, out_bytes)
     let mut per_cmd: BTreeMap<String, (u64, u64, u64)> = BTreeMap::new();
 
     for (cmd, raw) in &rows {
         let mut out = Vec::new();
         let mut err = std::io::sink();
-        // None store + None session = fresh, deterministic, no persistence.
-        let _ = omni::hooks::pipe::run_inner(
+        // None store + None session = fresh, deterministic, no persistence. A
+        // failed replay would leave `out` empty and be counted as 100% savings,
+        // inflating the honest figure (review of #202) — exclude it entirely and
+        // report the count instead.
+        if omni::hooks::pipe::run_inner(
             Cursor::new(raw.as_bytes()),
             &mut out,
             &mut err,
             None,
             None,
             Some(cmd),
-        );
+        )
+        .is_err()
+        {
+            errored += 1;
+            continue;
+        }
 
         let (r, o) = (raw.len() as u64, out.len() as u64);
         n += 1;
@@ -106,11 +118,16 @@ fn replay_execution_traces_net_savings() {
         e.2 += o;
     }
 
-    let net = 100.0 * (raw_total - out_total.min(raw_total)) as f64 / raw_total as f64;
+    assert!(
+        n > 0,
+        "every replayed trace errored ({errored} of {})",
+        rows.len()
+    );
+    let net = 100.0 * (raw_total - out_total.min(raw_total)) as f64 / raw_total.max(1) as f64;
     let pct = |part: u64| 100.0 * part as f64 / n as f64;
 
     println!("\n=== #184 net-savings replay (current pipeline) ===");
-    println!("corpus:            {n} traces from {db}");
+    println!("corpus:            {n} traces from {db} ({errored} errored, excluded)");
     println!("bytes:             {raw_total} -> {out_total}");
     println!("NET SAVINGS:       {net:.1}%");
     println!(

--- a/tests/bench_replay.rs
+++ b/tests/bench_replay.rs
@@ -36,16 +36,21 @@ fn base_command(cmd: &str) -> String {
 #[ignore = "needs a populated trace DB; run with --ignored (see file header)"]
 fn replay_execution_traces_net_savings() {
     // Resolve the corpus DB from the REAL home before we repoint HOME below.
+    // Build the path with PathBuf, not a hardcoded `/` (CLAUDE.md cross-platform
+    // rule 1) — review of #202.
     let db = std::env::var("OMNI_BENCH_DB").unwrap_or_else(|_| {
-        format!(
-            "{}/.omni/omni.db",
-            std::env::var("HOME").unwrap_or_default()
-        )
+        std::path::PathBuf::from(std::env::var("HOME").unwrap_or_default())
+            .join(".omni")
+            .join("omni.db")
+            .to_string_lossy()
+            .into_owned()
     });
 
     // Match the method: no user config, no passthrough shortcut.
     let tmp_home = tempfile::tempdir().expect("temp home");
-    // SAFETY: single-threaded test; set before any pipeline call reads the env.
+    // SAFETY: this integration binary holds exactly one test, so no other test
+    // reads the environment concurrently while these mutations run (review of
+    // #202). If a second test is ever added here, serialize env access first.
     unsafe {
         std::env::set_var("HOME", tmp_home.path());
         std::env::remove_var("OMNI_PASSTHROUGH");


### PR DESCRIPTION
Follow-up to review comments that were merged past on green CI. All were valid.

**Correctness (#204):** a verbose-log subject that starts with a 7+ hex word (`abc1234 refactor …`) matches the `--oneline` regex; that branch did not clear `awaiting_subject`, so the next body line was appended as a second subject. Cleared it. Regression test added and proven to fail without the fix.

**Standards (#203):**
- Renamed the 3 passthrough tests off the forbidden `test_` prefix (CLAUDE.md).
- `command env` now counts as an enumeration too — base is empty for both bare `env` and `command env`, so match any `env` token, not only the first word.

**Cross-platform (#202):**
- Fallback DB path built with `PathBuf`, not a hardcoded `/` (rule 1).
- Corrected the overstated `SAFETY: single-threaded` comment: the binary holds one test.

Deferred: moving `is_enumeration_command` into `pipeline/registry.rs` (SSOT, #203 comment) — that belongs to the #194 registry migration, not a partial move here.

Local (Homebrew rust 1.94.0, not CI's 1.97.0): fmt, clippy `--all-targets -D warnings`, full suite (1,152 passed).

<!-- AI-PR-DESCRIPTION-START -->
## PR Auto Describe

## Summary
Bug fixes in git log distillation (hex-prefixed subjects no longer leak body lines as extra subjects), enumeration command detection (handles both bare `env` and `command env`), and benchmark replay accuracy (excludes failed replays from savings %, uses cross-platform path construction).

## Key Changes
- **git.rs**: Fixed `awaiting_subject` flag not cleared for verbose subjects starting with 7+ hex chars (#204)
- **mod.rs**: Fixed `is_enumeration_command` to match `env` at any position when `base` is empty (#203)
- **bench_replay.rs**: Cross-platform path construction, exclude errored replays from savings, guard against division by zero (#202)

## Detailed Breakdown
**src/distillers/git.rs**
- Added `awaiting_subject = false` in the verbose-log subject branch of `distill_log` to prevent next body line being appended as a spurious second subject
- New test `hex_looking_subject_does_not_leak_the_body` verifies commit with subject `abc1234 refactor the parser` and body line `this body line must not survive`

**src/distillers/mod.rs**
- Changed `is_enumeration_command` to use `command.split_whitespace().any(|t| t == "env")` instead of only checking first word when `base.is_empty()`
- This correctly handles both bare `env` and wrapper forms like `command env`
- Renamed 3 existing passthrough test functions to more descriptive names (`ls_passes_through_verbatim`, `find_passes_through_verbatim`, `env_passes_through_verbatim`)
- Added test `treats_bare_and_wrapped_env_as_enumeration` covering both cases plus `ls -la`, `grep`, `echo`

**tests/bench_replay.rs**
- Replaced hardcoded `format!("{HOME}/...")` with `PathBuf::from(HOME).join(".omni").join("omni.db")`
- Added validation: skip empty `raw_input` rows and count them in `errored`
- Failed `run_inner` calls now `continue` instead of inflating savings
- Added `n > 0` assertion after filtering
- Changed `raw_total as f64` denominator to `raw_total.max(1)` to prevent division by zero
- Updated printout to show `{errored} errored, excluded`

## Notes
Test renames in `mod.rs` are non-functional; no behavior changed.

## Breaking Changes
None.

_Last updated: 2026-07-26 04:42:42_
<!-- AI-PR-DESCRIPTION-END -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Targeted follow-up to three reviewed bugs: a verbose `git log` body-line leak when the commit subject starts with a hex-like word, `command env` not being recognised as an enumeration passthrough, and a benchmark that inflated savings figures by counting errored replays as 100% reduction.

- **git.rs**: `awaiting_subject` is now cleared in the `RE_GIT_LOG_HASH` branch so a subject like `abc1234 refactor …` (which matches the `--oneline` regex) does not leave the flag live and pull the next body line into the output.
- **mod.rs**: `is_enumeration_command` switches from `.next() == Some("env")` to `.any(|t| t == "env")`; since `extract_base_executable` strips both `env` and `command` wrappers, `base` is empty for both bare `env` and `command env`, and the new form catches both. Three passthrough test names are corrected from the forbidden `test_` prefix.
- **bench_replay.rs**: DB path built with `PathBuf::join` (CLAUDE.md cross-platform rule 1); errored replays are excluded from the savings total and counted separately; `raw_total.max(1)` guards the division.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

All three fixes are small, self-contained, and each is covered by a new regression test that would fail without the change.

The git.rs change adds a single flag-clear proven correct by the new test. The mod.rs change narrows env detection to cases where base is already empty, preventing false positives while capturing the missing command env form. The bench_replay changes improve accuracy without touching any production path.

**Files Needing Attention:** No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/distillers/git.rs | Adds `awaiting_subject = false` in the RE_GIT_LOG_HASH branch to prevent verbose-log body lines leaking as second subjects when the commit message starts with a hex-looking word; regression test added and confirmed. |
| src/distillers/mod.rs | Fixes `is_enumeration_command` to use `.any(|t| t == "env")` so `command env` is also recognized; three passthrough test names corrected off the forbidden `test_` prefix; new regression test covers the `command env` case. |
| tests/bench_replay.rs | Replaces hardcoded `/` path separator with `PathBuf::join`; skips errored traces from savings calculation; adds `raw_total.max(1)` division-by-zero guard and updates the SAFETY comment. |

</details>

<sub>Reviews (3): Last reviewed commit: ["test(distillers): cover command env pass..."](https://github.com/fajarhide/omni/commit/eb6c632193684d54079e5b658834c32d97b2ea22) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47320535)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/weekndlabs/github/fajarhide/omni/-/custom-context?memory=1653942e-45b5-4251-8409-19e160d03e6e))

<!-- /greptile_comment -->