### PR TITLE
fix(toml): fail open when batch filters strip every line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **A TOML filter could replace non-empty tool output with an empty string when its line rules removed every row (#224)**: `TomlFilter::apply` only handled an empty filtered result when the signal declared a `fallback_message`. Without one it returned `""`, so the post-hook wrote empty `stdout` over the host's real bytes and recorded the deletion as 100% compression. The mechanism is current but the reported trigger is deliberately synthetic: 200 `black --check` file rows reproduce it, while real Black output also prints a summary that survives the filter. Batch filtering now carries an explicit passthrough outcome: the post-hook declines its rewrite so the host keeps the original result, and the pipe path emits the input byte-for-byte; a configured fallback still wins. The distinction from `apply` is intentional because stream-mode filters call it once per line, where empty means "drop this noise line" rather than "drop the command result." Hook-level review caught that merely returning the input from `apply` was not enough: it failed the TOML size guard and fell through to `BuildDistiller`, changing the 200 rows into the fabricated `Build: ok`. Regression tests cover both hook paths, the all-stripped and configured-fallback outcomes, a surviving-signal counter-case, and unchanged stream suppression.
+
 ## [0.6.8] - 2026-07-29
 
 ### Fixed

--- a/src/hooks/pipe.rs
+++ b/src/hooks/pipe.rs
@@ -384,14 +384,20 @@ fn distill(
     // shadowed TestDistiller, cut 1%, and had that cut thrown away by best_output()
     // — reporting 0% on output the distiller reduces by 94%. Weak filter, fall
     // through; a filter that earns its match still wins, user filters included.
-    let toml_hit = matched_toml.and_then(|f| {
-        let out = f.apply(&input_text);
-        crate::guard::limits::beats_guardrail(out.len(), input_text.len()).then_some((out, f.name))
+    let toml_hit = matched_toml.and_then(|f| match f.apply_batch(&input_text) {
+        toml_filter::BatchFilterOutcome::Passthrough => {
+            Some((input_text.clone(), f.name, Route::Passthrough))
+        }
+        toml_filter::BatchFilterOutcome::Filtered(out) => crate::guard::limits::beats_guardrail(
+            out.len(),
+            input_text.len(),
+        )
+        .then_some((out, f.name, Route::Keep)),
     });
 
     let (output, filter_name, rewind_hash, kept_count, dropped_count, collapse_savings, route) =
-        if let Some((out, name)) = toml_hit {
-            (out, name, None, 0, 0, None, Route::Keep)
+        if let Some((out, name, route)) = toml_hit {
+            (out, name, None, 0, 0, None, route)
         } else {
             let cmd = command_name.unwrap_or("");
 
@@ -895,6 +901,30 @@ mod tests {
         let out_str = String::from_utf8(out).expect("must succeed");
 
         assert_eq!(out_str, input);
+    }
+
+    /// The pipe path shares batch TOML filtering with PostToolUse. When every
+    /// row is stripped and there is no explicit fallback, it must emit the
+    /// original bytes rather than falling through to another distiller.
+    #[test]
+    fn passes_through_a_batch_filter_that_removes_every_line() {
+        let input = "would reformat src/main.py\n\
+                     would reformat src/lib.py\n\
+                     would reformat tests/test_main.py\n";
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+
+        run_inner(
+            input.as_bytes(),
+            &mut out,
+            &mut err,
+            None,
+            None,
+            Some("black --check ."),
+        )
+        .expect("must succeed");
+
+        assert_eq!(String::from_utf8(out).expect("valid UTF-8"), input);
     }
 
     #[test]

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -345,11 +345,26 @@ pub fn process_payload(
     // for cargo, npm, docker, kubectl and terraform while stripping only a few
     // lines, shadowing the distiller that would have summarised the same input
     // (#110). Weak filter, fall through; a filter that earns its match still wins.
-    let toml_hit = toml_match.and_then(|f| {
-        let out = f.apply(&content);
-        crate::guard::limits::beats_guardrail(out.len(), content.len())
-            .then(|| (out, f.name.clone()))
-    });
+    let toml_hit = match toml_match {
+        Some(f) => match f.apply_batch(&content) {
+            toml_filter::BatchFilterOutcome::Passthrough => {
+                // The filter matched but produced no explicit zero-state.
+                // Returning `None` is the hook protocol's fail-open path: the
+                // host keeps its original bytes. Falling through here would
+                // hand the same payload to another distiller — `black` turned
+                // 200 all-stripped rows into the fabricated `Build: ok` (#224).
+                if let Some(ref s) = store {
+                    s.record_passthrough(clean_command, content.len());
+                }
+                return None;
+            }
+            toml_filter::BatchFilterOutcome::Filtered(out) => {
+                crate::guard::limits::beats_guardrail(out.len(), content.len())
+                    .then(|| (out, f.name.clone()))
+            }
+        },
+        None => None,
+    };
 
     let session_guard = session.as_ref().and_then(|l| l.lock().ok());
     let mut collapse_savings_data = None;
@@ -955,6 +970,62 @@ mod tests {
         assert_eq!(
             body, content,
             "bytes under a Passthrough banner must be what the command produced"
+        );
+    }
+
+    /// #224: the Black TOML filter stripped every row and returned an empty
+    /// string. The hook accepted it as 100% compression and replaced non-empty
+    /// stdout with nothing. A batch zero-state with no explicit fallback must
+    /// decline the rewrite so the host retains its original result.
+    #[test]
+    fn declines_a_batch_filter_that_removes_every_line() {
+        let content = (0..200)
+            .map(|i| format!("would reformat src/module_{i}.py"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let payload = json!({
+            "tool_name": "Bash",
+            "tool_input": {"command": "black --check ."},
+            "tool_response": bash_response(&content),
+        })
+        .to_string();
+
+        assert!(
+            process_payload(&payload, None, None).is_none(),
+            "the hook must decline instead of replacing stdout with an empty or fabricated result"
+        );
+    }
+
+    /// The counter-case: a Black summary is a real signal that survives the
+    /// line filter, so the TOML filter must still win rather than turning every
+    /// matching command into passthrough.
+    #[test]
+    fn still_applies_a_batch_filter_when_a_signal_survives() {
+        let mut content = String::new();
+        for i in 0..20 {
+            content.push_str(&format!("would reformat src/module_{i}.py\n"));
+        }
+        content.push_str("Oh no! 20 files would be reformatted.");
+        let payload = json!({
+            "tool_name": "Bash",
+            "tool_input": {"command": "black --check ."},
+            "tool_response": bash_response(&content),
+        })
+        .to_string();
+
+        let out = process_payload(&payload, None, None).expect("signal should be distilled");
+        let v: serde_json::Value = serde_json::from_str(&out).expect("valid hook json");
+        let stdout = v["hookSpecificOutput"]["updatedToolOutput"]["stdout"]
+            .as_str()
+            .expect("stdout is a string");
+
+        assert!(
+            stdout.contains("Oh no! 20 files would be reformatted."),
+            "the surviving signal was lost: {stdout}"
+        );
+        assert!(
+            !stdout.contains("would reformat src/module_"),
+            "configured noise rows survived: {stdout}"
         );
     }
 

--- a/src/pipeline/toml_filter.rs
+++ b/src/pipeline/toml_filter.rs
@@ -149,6 +149,12 @@ pub struct TomlFilter {
     pub stream_mode: bool,
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum BatchFilterOutcome {
+    Filtered(String),
+    Passthrough,
+}
+
 #[derive(Clone)]
 pub enum LineFilter {
     Strip(Vec<Regex>),
@@ -231,6 +237,22 @@ impl TomlFilter {
         let sample = self.apply(input);
         let ratio = 1.0 - (sample.len() as f32 / input.len().max(1) as f32);
         (ratio * self.confidence).clamp(0.0, 1.0)
+    }
+
+    /// Apply a filter to a complete command result.
+    ///
+    /// `apply` also serves stream-mode filters one line at a time, where an
+    /// empty string deliberately means "drop this noise line". At the batch
+    /// boundary the same empty string has different semantics: if the filter
+    /// has no explicit fallback, it recognised no usable zero-state and the
+    /// host must keep the original result (#224).
+    pub(crate) fn apply_batch(&self, input: &str) -> BatchFilterOutcome {
+        let output = self.apply(input);
+        if !input.is_empty() && output.trim().is_empty() && self.on_empty.is_none() {
+            BatchFilterOutcome::Passthrough
+        } else {
+            BatchFilterOutcome::Filtered(output)
+        }
     }
 
     pub fn apply(&self, input: &str) -> String {
@@ -958,10 +980,9 @@ mod tests {
         assert!(!report.warnings.is_empty());
     }
 
-    /// A filter that keeps `max_lines` and nothing else, for the #111 cases.
-    fn capped_filter(max: usize) -> TomlFilter {
+    fn test_filter() -> TomlFilter {
         TomlFilter {
-            name: "capped".to_string(),
+            name: "test".to_string(),
             description: None,
             confidence: 0.8,
             match_regex: Regex::new("").unwrap(),
@@ -969,7 +990,7 @@ mod tests {
             replace_rules: vec![],
             match_output: vec![],
             line_filter: LineFilter::None,
-            max_lines: Some(max),
+            max_lines: None,
             on_empty: None,
             project_types: None,
             inline_tests: vec![],
@@ -979,6 +1000,15 @@ mod tests {
             tool_family: None,
             priority: 100,
             stream_mode: false,
+        }
+    }
+
+    /// A filter that keeps `max_lines` and nothing else, for the #111 cases.
+    fn capped_filter(max: usize) -> TomlFilter {
+        TomlFilter {
+            name: "capped".to_string(),
+            max_lines: Some(max),
+            ..test_filter()
         }
     }
 
@@ -1015,6 +1045,81 @@ mod tests {
 
         assert_eq!(out, "pod-0 Running\npod-1 Running");
         assert!(!out.contains("omitted"), "nothing was dropped: {out}");
+    }
+
+    fn black_noise_filter(on_empty: Option<&str>) -> TomlFilter {
+        TomlFilter {
+            name: "black".to_string(),
+            line_filter: LineFilter::Strip(vec![
+                Regex::new(r"^would reformat ").unwrap(),
+                Regex::new(r"^reformatted ").unwrap(),
+            ]),
+            on_empty: on_empty.map(str::to_string),
+            ..test_filter()
+        }
+    }
+
+    /// #224: a filter that stripped every line returned an empty string when it
+    /// had no `fallback_message`, so the hook replaced non-empty tool output
+    /// with empty stdout and reported the deletion as 100% compression.
+    #[test]
+    fn requests_passthrough_when_line_filter_removes_every_line() {
+        // Arrange
+        let input = "would reformat src/main.py\nwould reformat src/lib.py\n";
+
+        // Act
+        let outcome = black_noise_filter(None).apply_batch(input);
+
+        // Assert
+        assert_eq!(
+            outcome,
+            BatchFilterOutcome::Passthrough,
+            "an unrecognised zero-state must fail open"
+        );
+    }
+
+    /// A `fallback_message` is an explicit zero-state chosen by the filter
+    /// author, so it still wins when every input line is filtered out.
+    #[test]
+    fn returns_configured_fallback_when_line_filter_removes_every_line() {
+        // Arrange
+        let input = "reformatted src/main.py\nreformatted src/lib.py\n";
+
+        // Act
+        let outcome = black_noise_filter(Some("black: files reformatted")).apply_batch(input);
+
+        // Assert
+        assert_eq!(
+            outcome,
+            BatchFilterOutcome::Filtered("black: files reformatted".to_string())
+        );
+    }
+
+    /// The guard is not a blanket passthrough: when a signal line survives, the
+    /// filter still removes its configured noise and returns the distilled text.
+    #[test]
+    fn keeps_filtered_output_when_a_signal_line_survives() {
+        // Arrange
+        let input = "would reformat src/main.py\nOh no! 1 file would be reformatted.\n";
+
+        // Act
+        let outcome = black_noise_filter(None).apply_batch(input);
+
+        // Assert
+        assert_eq!(
+            outcome,
+            BatchFilterOutcome::Filtered("Oh no! 1 file would be reformatted.".to_string())
+        );
+    }
+
+    /// Stream-mode filters call `apply` once per line, where an empty result is
+    /// the instruction to suppress that one noise line. The batch guard must not
+    /// turn streaming suppression into an echo.
+    #[test]
+    fn still_removes_a_noise_line_when_applied_in_stream_mode() {
+        let out = black_noise_filter(None).apply("would reformat src/main.py");
+
+        assert_eq!(out, "");
     }
 
     #[test]


### PR DESCRIPTION
## What

- introduce a batch outcome that distinguishes filtered output from an unhandled empty result
- make PostToolUse decline the rewrite and pipe mode return the original bytes when a matching filter strips every line without `fallback_message`
- keep explicit `fallback_message` values, surviving signal lines, and stream-mode suppression unchanged

## Why

`TomlFilter::apply` returned an empty string when line rules removed every row and the filter had no `fallback_message`. The post-hook accepted that as 100% compression and replaced non-empty stdout with nothing.

Simply returning the input is not sufficient: it misses the size guardrail and falls through to another distiller, which changed the synthetic 200-row Black reproduction into `Build: ok`. The batch outcome now makes fail-open explicit at both caller boundaries.

The reported Black trigger is deliberately synthetic; normal Black output also prints a summary line, which survives the filter.

## Validation

The three Rust files in this patch were fully validated before the upstream 0.6.8 release cut:

- `cargo fmt --all -- --check` (Rust 1.97.0 and 1.97.1)
- `cargo check --all-targets --all-features`
- `cargo build`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --lib`: 526 passed
- `cargo test --test toml_filter_integration`: 44 passed
- focused batch filter tests: 3 passed
- mutation check: removing the new passthrough branch fails both hook-boundary regressions

After rebasing onto current `main`, those Rust files are byte-identical and the pinned Rust 1.97.0 formatter still passes. On this Windows host, Application Control blocks the newly hashed 0.6.8 build-script executable before check/test can run; it produces no compiler diagnostic or failed assertion. CI should provide the authoritative pinned-toolchain full-suite result.

Closes #224

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a data-loss bug (#224) where `TomlFilter::apply` returned an empty string when its line rules stripped every row and no `fallback_message` was configured. The post-hook accepted that empty string as valid 100%-compression output and silently replaced non-empty tool stdout with nothing.

- Introduces `BatchFilterOutcome::Passthrough | Filtered(String)` and `apply_batch`, which distinguishes an all-stripped-no-fallback result from an intentional filter output — `apply` is left unchanged so stream-mode (one-line-at-a-time) callers that expect `\"\"` to mean \"drop this line\" are unaffected.
- `post_tool.rs` returns `None` on `Passthrough` (host keeps original bytes) and records a passthrough telemetry event; `pipe.rs` returns the original `input_text` with `Route::Passthrough` so the output flows through the normal downstream logging path.
- Seven new tests cover the all-stripped, configured-fallback, surviving-signal, and stream-suppression outcomes across all three changed Rust files.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The core fix is logically sound and well-covered by targeted unit tests; the one concern is a test-to-signal-file coupling that would surface only if `black.toml` is updated

The `apply_batch` condition correctly mirrors the `on_empty` check already inside `apply`, so the two paths stay in sync. Both hook boundaries handle `Passthrough` correctly — `post_tool` returns `None` and `pipe` returns the original bytes with `Route::Passthrough`. The only concern is that the new `post_tool.rs` integration tests load the live `signals/tools/black.toml` via `load_all_filters()` and will break if that file ever gains an `on_empty`/`fallback_message` field, even though the hook code itself would remain correct.

**Files Needing Attention:** src/hooks/post_tool.rs — the two new integration tests are implicitly coupled to the content of signals/tools/black.toml
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/pipeline/toml_filter.rs | Introduces `BatchFilterOutcome` enum and `apply_batch` method; cleanly separates "all-lines-stripped with no fallback" (Passthrough) from "filtered result" (Filtered); refactors `capped_filter` to use struct update syntax; adds 4 focused unit tests covering all outcome branches |
| src/hooks/post_tool.rs | Replaces direct `apply` call with `apply_batch`, early-returns `None` on Passthrough (fail-open), records telemetry via `record_passthrough`; new integration tests rely on the production `black.toml` signal file content, creating a coupling that could silently break if that file gains a `fallback_message` |
| src/hooks/pipe.rs | Replaces direct `apply` call with `apply_batch`, propagates `Route::Passthrough` when filter strips every line (returning original input bytes), adds a regression test; asymmetry with `post_tool.rs` (no explicit `record_passthrough` call) is intentional — telemetry flows through the `Route` enum downstream |
| CHANGELOG.md | Adds an Unreleased entry documenting the #224 fix; entry is unusually verbose but technically accurate |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["TOML filter matches command"] --> B["apply_batch(input)"]
    B --> C{"apply() result"}
    C -->|"output non-empty\n(signal survives or fallback set)"| D["Filtered(output)"]
    C -->|"output empty/whitespace\nAND on_empty is None\nAND input non-empty"| E["Passthrough"]
    C -->|"on_empty is Some\n(output = fallback from apply)"| D

    D --> F{"beats_guardrail?"}
    F -->|"Yes"| G_hook["post_tool: return Some(distilled)\npipe: Route::Keep"]
    F -->|"No"| H["Fall through to distiller"]

    E --> I_hook["post_tool: record_passthrough\nreturn None (host keeps original)"]
    E --> I_pipe["pipe: return input_text\nRoute::Passthrough"]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fhooks%2Fpost_tool.rs%3A973-1034%0A**Tests%20couple%20hook%20logic%20to%20production%20signal%20file%20content**%0A%0A%60declines_a_batch_filter_that_removes_every_line%60%20and%20%60still_applies_a_batch_filter_when_a_signal_survives%60%20both%20call%20%60process_payload%60%20with%20%60command%3A%20%22black%20--check%20.%22%60.%20%60process_payload%60%20calls%20%60load_all_filters%28%29%60%2C%20which%20includes%20the%20embedded%20%60signals%2Ftools%2Fblack.toml%60.%20Those%20tests%20therefore%20depend%20on%20that%20file%20having%20no%20%60fallback_message%60.%20If%20%60black.toml%60%20gains%20an%20%60on_empty%60%2F%60fallback_message%60%20in%20a%20future%20signal%20update%2C%20%60apply_batch%60%20would%20return%20%60Filtered%28fallback%29%60%20instead%20of%20%60Passthrough%60%2C%20flipping%20the%20first%20test%20from%20pass%20to%20fail%20%E2%80%94%20even%20though%20the%20hook%20logic%20is%20untouched.%0A%0AThe%20three%20unit%20tests%20in%20%60toml_filter.rs%60%20side-step%20this%20by%20using%20the%20in-memory%20%60black_noise_filter%60%20fixture.%20The%20same%20approach%20would%20make%20the%20%60post_tool.rs%60%20hook-path%20tests%20resilient%3A%20inject%20a%20%60TomlFilter%60%20directly%20%28or%20a%20thin%20test-only%20override%20for%20%60load_all_filters%60%29%20rather%20than%20relying%20on%20a%20particular%20state%20of%20the%20shipped%20signal%20file.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni&pr=253&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fajarhide%2Fomni%22%20on%20the%20existing%20branch%20%22fix%2F224-toml-empty-fail-open%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F224-toml-empty-fail-open%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fhooks%2Fpost_tool.rs%3A973-1034%0A**Tests%20couple%20hook%20logic%20to%20production%20signal%20file%20content**%0A%0A%60declines_a_batch_filter_that_removes_every_line%60%20and%20%60still_applies_a_batch_filter_when_a_signal_survives%60%20both%20call%20%60process_payload%60%20with%20%60command%3A%20%22black%20--check%20.%22%60.%20%60process_payload%60%20calls%20%60load_all_filters%28%29%60%2C%20which%20includes%20the%20embedded%20%60signals%2Ftools%2Fblack.toml%60.%20Those%20tests%20therefore%20depend%20on%20that%20file%20having%20no%20%60fallback_message%60.%20If%20%60black.toml%60%20gains%20an%20%60on_empty%60%2F%60fallback_message%60%20in%20a%20future%20signal%20update%2C%20%60apply_batch%60%20would%20return%20%60Filtered%28fallback%29%60%20instead%20of%20%60Passthrough%60%2C%20flipping%20the%20first%20test%20from%20pass%20to%20fail%20%E2%80%94%20even%20though%20the%20hook%20logic%20is%20untouched.%0A%0AThe%20three%20unit%20tests%20in%20%60toml_filter.rs%60%20side-step%20this%20by%20using%20the%20in-memory%20%60black_noise_filter%60%20fixture.%20The%20same%20approach%20would%20make%20the%20%60post_tool.rs%60%20hook-path%20tests%20resilient%3A%20inject%20a%20%60TomlFilter%60%20directly%20%28or%20a%20thin%20test-only%20override%20for%20%60load_all_filters%60%29%20rather%20than%20relying%20on%20a%20particular%20state%20of%20the%20shipped%20signal%20file.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni&pr=253&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Asrc%2Fhooks%2Fpost_tool.rs%3A973-1034%0A**Tests%20couple%20hook%20logic%20to%20production%20signal%20file%20content**%0A%0A%60declines_a_batch_filter_that_removes_every_line%60%20and%20%60still_applies_a_batch_filter_when_a_signal_survives%60%20both%20call%20%60process_payload%60%20with%20%60command%3A%20%22black%20--check%20.%22%60.%20%60process_payload%60%20calls%20%60load_all_filters%28%29%60%2C%20which%20includes%20the%20embedded%20%60signals%2Ftools%2Fblack.toml%60.%20Those%20tests%20therefore%20depend%20on%20that%20file%20having%20no%20%60fallback_message%60.%20If%20%60black.toml%60%20gains%20an%20%60on_empty%60%2F%60fallback_message%60%20in%20a%20future%20signal%20update%2C%20%60apply_batch%60%20would%20return%20%60Filtered%28fallback%29%60%20instead%20of%20%60Passthrough%60%2C%20flipping%20the%20first%20test%20from%20pass%20to%20fail%20%E2%80%94%20even%20though%20the%20hook%20logic%20is%20untouched.%0A%0AThe%20three%20unit%20tests%20in%20%60toml_filter.rs%60%20side-step%20this%20by%20using%20the%20in-memory%20%60black_noise_filter%60%20fixture.%20The%20same%20approach%20would%20make%20the%20%60post_tool.rs%60%20hook-path%20tests%20resilient%3A%20inject%20a%20%60TomlFilter%60%20directly%20%28or%20a%20thin%20test-only%20override%20for%20%60load_all_filters%60%29%20rather%20than%20relying%20on%20a%20particular%20state%20of%20the%20shipped%20signal%20file.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=253&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fajarhide%2Fomni%22%20on%20the%20existing%20branch%20%22fix%2F224-toml-empty-fail-open%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F224-toml-empty-fail-open%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fhooks%2Fpost_tool.rs%3A973-1034%0A**Tests%20couple%20hook%20logic%20to%20production%20signal%20file%20content**%0A%0A%60declines_a_batch_filter_that_removes_every_line%60%20and%20%60still_applies_a_batch_filter_when_a_signal_survives%60%20both%20call%20%60process_payload%60%20with%20%60command%3A%20%22black%20--check%20.%22%60.%20%60process_payload%60%20calls%20%60load_all_filters%28%29%60%2C%20which%20includes%20the%20embedded%20%60signals%2Ftools%2Fblack.toml%60.%20Those%20tests%20therefore%20depend%20on%20that%20file%20having%20no%20%60fallback_message%60.%20If%20%60black.toml%60%20gains%20an%20%60on_empty%60%2F%60fallback_message%60%20in%20a%20future%20signal%20update%2C%20%60apply_batch%60%20would%20return%20%60Filtered%28fallback%29%60%20instead%20of%20%60Passthrough%60%2C%20flipping%20the%20first%20test%20from%20pass%20to%20fail%20%E2%80%94%20even%20though%20the%20hook%20logic%20is%20untouched.%0A%0AThe%20three%20unit%20tests%20in%20%60toml_filter.rs%60%20side-step%20this%20by%20using%20the%20in-memory%20%60black_noise_filter%60%20fixture.%20The%20same%20approach%20would%20make%20the%20%60post_tool.rs%60%20hook-path%20tests%20resilient%3A%20inject%20a%20%60TomlFilter%60%20directly%20%28or%20a%20thin%20test-only%20override%20for%20%60load_all_filters%60%29%20rather%20than%20relying%20on%20a%20particular%20state%20of%20the%20shipped%20signal%20file.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/hooks/post_tool.rs:973-1034
**Tests couple hook logic to production signal file content**

`declines_a_batch_filter_that_removes_every_line` and `still_applies_a_batch_filter_when_a_signal_survives` both call `process_payload` with `command: "black --check ."`. `process_payload` calls `load_all_filters()`, which includes the embedded `signals/tools/black.toml`. Those tests therefore depend on that file having no `fallback_message`. If `black.toml` gains an `on_empty`/`fallback_message` in a future signal update, `apply_batch` would return `Filtered(fallback)` instead of `Passthrough`, flipping the first test from pass to fail — even though the hook logic is untouched.

The three unit tests in `toml_filter.rs` side-step this by using the in-memory `black_noise_filter` fixture. The same approach would make the `post_tool.rs` hook-path tests resilient: inject a `TomlFilter` directly (or a thin test-only override for `load_all_filters`) rather than relying on a particular state of the shipped signal file.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(toml): fail open on empty batch outp..."](https://github.com/fajarhide/omni/commit/89723d555939b8a9eaf6007ff03ac1c66d5854cf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48235279)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->