### PR TITLE
docs(roadmap): state the goal, the non-goals, and how each axis is done

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,96 +1,109 @@
 # OMNI Roadmap
 
-## Current: v0.6.0 (Intelligence Layer)
+What OMNI is for, what it will not become, and how we will know it is finished.
 
-**Status: In Progress** 🏗️
+This file holds direction only. The queue lives on the
+[Now / Next / Later board](https://github.com/users/fajarhide/projects/2) and the
+shipped history lives in [CHANGELOG.md](../CHANGELOG.md). Copying either one here
+is how the previous version of this file spent six weeks announcing v0.6.0 as
+in progress while 0.6.8 shipped.
 
-Focusing on architectural refinement, multi-agent support, and autonomous loop orchestration.
+**Last reviewed: 2026-07-29, against v0.6.8.** Review at every minor release, and
+whenever one of the three axes below changes state.
 
----
+## The goal
 
-## v0.5.9 (Autonomous Loop Engineering)
+OMNI removes noise from what an AI agent reads, without removing the answer and
+without overstating what it removed.
 
-**Status: Complete** ✅
+Compression is the easy half. A distiller that deletes a whole `kubectl` table and
+reports 99% saved compressed perfectly and did the job wrongly. So the target is
+not a reduction percentage. It is output an agent can act on, next to a number a
+human can reproduce.
 
-Introduced native support for iterative, autonomous agent loops and multi-agent coordination.
+Three properties, in the order they win when they conflict:
 
-### What Was Delivered
-- **Loop Orchestration**: `OMNI_LOOP_BUDGET` and `OMNI_LOOP_GOAL` environment variables.
-- **Context Pressure**: Predictive token exhaustion warnings (Normal -> Warning -> Critical).
-- **Maker-Checker Support**: Secure execution verification across distinct agent sessions using `omni_verify`.
-- **Handoff Export**: Portable JSON and markdown state summaries for transitioning across IDEs and scripts.
+1. **Never fabricate.** A stage that recognised nothing hands back what it was
+   given. A failed command passes through verbatim. Structured payloads are never
+   touched.
+2. **Never lose the answer quietly.** Anything dropped leaves a marker and, where
+   the content allows, a rewind hash.
+3. **Then compress**, as hard as the first two allow and no harder.
 
----
+## Non-goals
 
-## v0.5.0 (Rust Rewrite)
+Recorded with dates, because the useful part of a rejected option is the reason.
 
-**Status: Complete** ✅
+| not building | why | decided |
+|---|---|---|
+| An HTTP proxy in front of the model | It puts OMNI on the request path and routes the user's API key through a local process. The hook is the product, and the absence of that friction is most of the advantage. | 2026-07-23 |
+| A model or an ML compressor inside the pipeline | Hooks have a sub-10 ms budget (`AGENTS.md`). Nothing with an inference call meets it. | 2026-07-23 |
+| Filter marketplace, team mode, remote RewindStore, IDE extension | Ecosystem features for a tool whose core claims are not all true yet. Worth reopening once the three axes below are done. | 2026-07-29 |
 
-The full rewrite from Node.js + Zig hybrid to a single Rust binary.
+## The three axes
 
-### What Was Delivered
+Everything that counts as progress moves one of these. A change that moves none of
+them can still be worth making, but it is maintenance, not direction.
 
-- **Single binary** — no runtime dependencies (no Node.js, no Zig, no Wasm)
-- **10-type content classifier** — GitDiff, GitStatus, GitLog, BuildOutput, TestOutput, InfraOutput, LogOutput, TabularData, StructuredData, Unknown
-- **Semantic scoring engine** — signal tiers (Critical/Important/Context/Noise) with session context boost
-- **RewindStore** — SHA-256 hashed content storage, never-drop guarantee
-- **Session continuity** — hot files, active errors, domain inference, task inference
-- **5 MCP tools** — retrieve, learn, density, trust, compress
-- **3 Claude Code hooks** — PostToolUse, SessionStart, PreCompact
-- **TOML filter engine** — user-defined filters with inline tests
-- **Auto-learn** — pattern detection from passthrough output
-- **Analytics dashboard** — `omni stats` with filter breakdowns and cost estimation
-- **Doctor diagnostics** — `omni doctor` installation validation
-- **147 tests** — unit, snapshot, E2E, security, smoke
-- **Cross-platform CI/CD** — GitHub Actions with 4-target release builds
+### 1. Correctness — nothing is asserted that was not parsed
 
----
+**Done when** a distiller cannot ship a confident summary of input it failed to
+read, because the dispatch boundary enforces it instead of each author
+remembering to.
 
-## Next: v0.6.0 (Intelligence Layer)
+**Where it stands.** `require_parsed` exists and is voluntary. On `main` at the
+time of writing, 3 of 12 distiller files call it: `cloud.rs` at four sites,
+`jsts.rs` at four, `security.rs` at one. Every fabrication issue in the CHANGELOG
+landed in one of the other nine. Tracked as #250.
 
-### Planned Features
+**How to check:** no open bug describes OMNI asserting a result it did not parse,
+and that stays true across a full release cycle. The tracker is the measurement;
+this class of issue has been filed against nine separate releases, so a quiet
+month is not evidence.
 
-#### Adaptive Scoring
-- Learn from RewindStore retrievals — if Claude frequently retrieves, OMNI is too aggressive
-- Automatically adjust scoring thresholds per content type
-- Per-project scoring profiles
+### 2. Coverage — the hook reaches the tools agents actually use
 
-#### Multi-Agent Support
-- Cursor AI integration (native hooks)
-- Codex CLI integration
-- Generic JSONRPC hook interface
-- Agent-specific scoring profiles
+**Done when** OMNI distills the tool calls that dominate a real session rather
+than `Bash` alone.
 
-#### Filter Marketplace
-- Community-shared TOML filters
-- `omni filter install <name>` from registry
-- Filter versioning and updates
+**Where it stands.** The `PostToolUse` matcher is registered for `Bash` only, so
+the Read, Grep and WebFetch distillers are written, tested, and have never run in
+a live Claude Code session. Tracked as #172, gated on #246.
 
-#### Enhanced Analytics
-- Cost tracking per project / per agent
-- Trend visualization (reduction% over time)
-- Export to CSV/JSON
+**How to check:** the installed hook configuration names more than one matcher,
+and `~/.omni/omni.db` holds distillation rows for a tool other than `Bash`.
 
----
+### 3. Proof — every published number can be reproduced
 
-## Future: v0.7.0 (Ecosystem)
+**Done when** a stranger with the repo can re-derive any figure the README
+claims, and no headline blends measurements from environments that behave
+differently.
 
-### Ideas Under Consideration
+**Where it stands.** The headline is one blended number. Terminal runs
+(`omni exec`, pipe mode) and hook runs (`claude_code`) compress very differently
+and are counted together; a saving is booked when OMNI produces it, whether or not
+the host applied it; duplicate rows inflate the top entries. Tracked as #212,
+#173 and #118.
 
-- **Team mode** — shared session state across multiple developers
-- **Remote RewindStore** — cloud-backed content storage
-- **Plugin system** — custom distillers as shared libraries
-- **IDE integration** — VS Code extension for stats overlay
-- **Streaming mode** — real-time distillation of long-running commands
-- **LLM-assisted scoring** — use a small model to evaluate content importance
+**How to check:** every published figure states the `agent_id` it was measured
+on, the corpus it was measured over, and the command that reproduces it.
 
----
+## Off the axes
+
+Dependency and CI hygiene, i18n README sync, dead-code removal, packaging and
+release mechanics. Real work, regularly done, and deliberately not part of the
+direction above.
+
+## After the three axes
+
+The ecosystem questions become worth asking once the core claims hold. The first
+two are what a second agent besides Claude Code actually needs, and whether
+anyone wants a filter they did not write themselves. Both are cheap to answer
+later and expensive to guess at now.
 
 ## Contributing
 
-See [docs/DEVELOPMENT.md](DEVELOPMENT.md) for the contributor guide. We welcome:
-
-- New distillers for uncommon tools
-- TOML filters for internal company tools
-- Performance optimizations
-- Documentation improvements
+See [DEVELOPMENT.md](DEVELOPMENT.md). The most useful contributions are a
+distiller for a tool we do not cover, a TOML filter for an internal tool, and a
+reproduction of any case where OMNI's output claims more than its input
+supports.


### PR DESCRIPTION
## What

Rewrites `docs/ROADMAP.md`, 96 lines to 109. The per-version "What Was Delivered" lists are gone; direction, non-goals and a done-criterion per axis take their place.

## Why

The file was last touched on 2026-06-14 and still opened with `## Current: v0.6.0 (Intelligence Layer)` / `**Status: In Progress**` while 0.6.8 shipped on 2026-07-29. It promised a filter marketplace, team mode, a remote RewindStore, an IDE extension and LLM-assisted scoring. None of it was built, and the last one cannot be: `AGENTS.md:10` gives hooks a sub-10 ms budget, which rules out an inference call.

Meanwhile the work of the last eight releases was one defect class, the one where a stage deletes the answer and publishes a saving for it. The file that is supposed to state the direction said nothing about it. A contributor deciding whether to work on this project was reading exactly the kind of unsupported claim OMNI exists to catch.

## What changed

- **Goal, stated once.** Three properties in priority order when they conflict: never fabricate, never lose the answer quietly, then compress.
- **Non-goals with dates and reasons.** No proxy and no model in the pipeline (both decided 2026-07-23), and the ecosystem features deferred until the axes below hold. A rejected option is worth nothing without the reason, which is why they keep getting re-proposed.
- **Three axes, each with where it stands and how to check it.** Correctness (#250), coverage (#172, gated on #246), proof (#212, #173, #118).
- **No issue list and no shipped history.** The board is the queue, `CHANGELOG.md` is the history. Duplicating either is how the previous version went stale against a release it did not mention.
- **A last-reviewed date and a review trigger**, so staleness is visible rather than assumed.

## Verification

Documentation only. No Rust changed, and nothing in `src/`, `tests/`, `build.rs`, `Makefile` or `.github/` references `ROADMAP`, so no gate reads this file.

Checked by hand:

- Both relative links resolve from `docs/`: `../CHANGELOG.md` and `DEVELOPMENT.md`.
- The `require_parsed` count in the file is measured on this branch, not carried over from #250's text: `cloud.rs` 4 sites, `jsts.rs` 4, `security.rs` 1, and the `system_ops.rs` grep hit is a comment rather than a call, so it stays 3 of 12 distiller files.
- The six `i18n/README-*.md` files link `../docs/ROADMAP.md` and describe it as upcoming features. The link target and the description both still hold, so they are untouched here.

## Deliberately not done

No `CHANGELOG.md` entry. Nothing a user runs behaves differently, and `build.rs` counts entries under `## [Unreleased]` to drive `omni doctor`'s release warning. Say the word if you would rather it were listed.

Closes #255
