### PR TITLE
perf(hooks): walk the import graph only when the line it feeds is printed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Every hooked `Read` rebuilt the whole import graph, 48 ms, to sometimes append one advisory line (#320)**: `hooks/post_tool.rs` called `graph::indexer::build_graph(&cwd)` unconditionally on the Read arm and passed the resulting count into `distill_readfile_with_context`. That count has exactly one use, the dependents guard at `readfile.rs:50`, and the guard sits behind two gates that reject most payloads: `estimated_tokens >= MIN_DISTILL_TOKENS` (2,000) and a distillation that actually shrank the file by a fifth. So a `Read` of any small file walked the repository and threw the answer away a few lines later. Measured on the release binary against this repository, 125 files indexed: **116.6 ms cold, 48.0 ms median warm**, against an `AGENTS.md` budget of 10 ms for the whole hook and a Bash post-hook that measures 18.9 ms end to end. `MAX_FILES` is 5,000 and there is no cache, so a larger project pays more. The count is passed as `impl FnOnce() -> usize` now and consulted at the guard, so the walk happens only when the line it feeds is about to be printed. The test asserts the closure is **not called** for a file below the threshold, because "it compiles with a closure" was equally true of the version that still walked every time. This became reachable rather than being missed: #258 recorded the Read arm as unreachable on 2026-07-29, and #172 widened the `PostToolUse` matcher to `Bash`, `Read`, `Grep` and `WebFetch` in 0.6.9 after it. #258 itself stays open and still describes something else, feeding `imported_by` into the scorer. The now-unreachable `graph failed` fallback goes with it, and `distill_readfile` becomes the test-only helper it had already turned into.
+
+
 ## [0.6.11] - 2026-08-03
 
 ### Fixed

--- a/src/distillers/readfile.rs
+++ b/src/distillers/readfile.rs
@@ -1,15 +1,30 @@
-pub fn distill_readfile(content: &str, filepath: &str) -> Option<String> {
-    distill_readfile_with_context(content, filepath, 0)
+/// The no-dependency-context form, kept for the tests below that exercise the
+/// per-language distillers without caring about the dependents guard.
+///
+/// Production has no caller: the Read hook always has a way to count dependents,
+/// and since #320 it passes that as a closure the distiller may never call. The
+/// `graph failed` fallback that used to call this was unreachable once the graph
+/// stopped being built up front.
+#[cfg(test)]
+fn distill_readfile(content: &str, filepath: &str) -> Option<String> {
+    distill_readfile_with_context(content, filepath, || 0)
 }
 
 const MIN_DISTILL_TOKENS: usize = 2000;
 
 /// `imported_by_count`: number of files that import this file (from graph).
 /// When > 3, append a factual warning suggesting omni_context.
+/// `imported_by` is a closure, not a number, because computing it walks the
+/// repository. It is consulted at one place, the dependents guard below, and
+/// only after two earlier gates have already decided there is something to
+/// return. Passing the value meant `hooks::post_tool` built the whole import
+/// graph before either gate ran, so every hooked `Read` of a small file paid
+/// **48 ms** on this repository to produce a number that was discarded a few
+/// lines later, against a 10 ms budget for the entire hook (#320).
 pub fn distill_readfile_with_context(
     content: &str,
     filepath: &str,
-    imported_by_count: usize,
+    imported_by: impl FnOnce() -> usize,
 ) -> Option<String> {
     let line_count = content.lines().count();
     let ext = std::path::Path::new(filepath)
@@ -46,7 +61,9 @@ pub fn distill_readfile_with_context(
             "[OMNI ReadFile: {} → distilled ({} lines)]\n{}",
             filepath, line_count, distilled
         );
-        // Phase 6: factual guard — file has many dependents
+        // Phase 6: factual guard — file has many dependents. The walk happens
+        // here or not at all.
+        let imported_by_count = imported_by();
         if imported_by_count > 3 {
             out.push_str(&format!(
                 "\n[OMNI Guard: {} is imported by {} files — changes here may have wide impact. Call omni_context(\"{}\") for full dependency map.]",
@@ -415,6 +432,56 @@ fn distill_unknown_file(content: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+
+    /// #320: `hooks::post_tool` built the whole import graph before calling this,
+    /// so every hooked `Read` paid 48 ms on this repository, most of them for a
+    /// number discarded a few lines later. The count is a closure now, consulted
+    /// only at the dependents guard, which sits behind two gates that reject the
+    /// common case.
+    ///
+    /// Asserting the closure is *not called*, because "it compiles with a
+    /// closure" was true of the version that still walked the repository every
+    /// time.
+    #[test]
+    fn the_dependents_walk_is_skipped_when_the_file_is_too_small_to_distil() {
+        use std::cell::Cell;
+        let called = Cell::new(false);
+
+        // Well under MIN_DISTILL_TOKENS, so both gates reject it.
+        let tiny = "fn main() {}\n";
+        let out = distill_readfile_with_context(tiny, "src/main.rs", || {
+            called.set(true);
+            9
+        });
+
+        assert!(out.is_none(), "a tiny file must pass through");
+        assert!(
+            !called.get(),
+            "the import graph was walked for a file that was never distilled"
+        );
+    }
+
+    /// The other half: when the guard is reached the count is consulted and the
+    /// advisory line appears, so deferring did not disable the feature.
+    #[test]
+    fn the_dependents_guard_still_fires_when_it_is_reached() {
+        let mut content = String::new();
+        for i in 0..400 {
+            content.push_str(&format!(
+                "// comment line {i} explaining a thing at some length for bulk\n"
+            ));
+            content.push_str(&format!("fn helper_{i}(x: usize) -> usize {{ x + {i} }}\n"));
+        }
+
+        let out = distill_readfile_with_context(&content, "src/lib.rs", || 9)
+            .expect("large enough to distil");
+
+        assert!(
+            out.contains("imported by 9 files"),
+            "the dependents guard did not fire: {out}"
+        );
+    }
+
     use super::*;
 
     #[test]

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -328,26 +328,26 @@ pub fn process_payload(
             } else {
                 &normalized.command
             };
-            // Phase 6: check graph for many dependents
-            let graph = std::env::current_dir()
-                .ok()
-                .and_then(|cwd| crate::graph::indexer::build_graph(&cwd).ok());
+            // Phase 6: the dependents guard needs a count, and getting one walks
+            // the repository. Handed over as a closure so the walk happens only
+            // if the distiller reaches the guard, which it does after two gates
+            // that reject most payloads. Building it here cost 48 ms on every
+            // hooked Read, most of them for a number nothing read (#320).
+            let count_dependents = || {
+                std::env::current_dir()
+                    .ok()
+                    .and_then(|cwd| crate::graph::indexer::build_graph(&cwd).ok())
+                    .map(|g| g.context_for(filepath).imported_by.len())
+                    .unwrap_or(0)
+            };
 
-            if let Some(g) = graph {
-                let imported_by_count = g.context_for(filepath).imported_by.len();
-                return crate::distillers::readfile::distill_readfile_with_context(
-                    &content,
-                    filepath,
-                    imported_by_count,
-                )
-                .and_then(|d| archive_tool_reply(store.as_ref(), &content, d))
-                .map(|d| wrap_hook_output(normalized.raw_response.as_ref(), d));
-            }
-
-            // Fallback if graph fails
-            return crate::distillers::readfile::distill_readfile(&content, filepath)
-                .and_then(|d| archive_tool_reply(store.as_ref(), &content, d))
-                .map(|d| wrap_hook_output(normalized.raw_response.as_ref(), d));
+            return crate::distillers::readfile::distill_readfile_with_context(
+                &content,
+                filepath,
+                count_dependents,
+            )
+            .and_then(|d| archive_tool_reply(store.as_ref(), &content, d))
+            .map(|d| wrap_hook_output(normalized.raw_response.as_ref(), d));
         }
         "Grep" => {
             if !agent_config.grep_enabled() {


### PR DESCRIPTION
Closes #320

Found while re-validating whether the open issues are still relevant, which is the point: #258 recorded this code path as **unreachable** on 2026-07-29, and #172 made it reachable in 0.6.9 by widening the `PostToolUse` matcher to `Bash`, `Read`, `Grep`, `WebFetch`. Nobody measured it afterwards.

## What it costs

`hooks/post_tool.rs` built the whole import graph on the Read arm and passed the count to `distill_readfile_with_context`. That count has exactly one use, the dependents guard at `readfile.rs:50`, and the guard sits behind two gates that reject most payloads: `estimated_tokens >= MIN_DISTILL_TOKENS` (2,000), and a distillation that actually shrank the file by a fifth.

So a `Read` of any small file walked the repository and threw the answer away a few lines later. Release binary, this repository, 125 files indexed:

```
build_graph  116.6 ms  cold
              48.0 ms  median warm
```

`AGENTS.md` budgets the whole hook at 10 ms, and the Bash post-hook measures 18.9 ms end to end, so a hooked Read cost roughly **2.5x an entire Bash hook** before any distillation happened. `MAX_FILES` is 5,000 and there is no cache, so a larger project pays more, not less.

## The fix

The count is `impl FnOnce() -> usize` and is consulted at the guard, so the walk happens only when the line it feeds is about to be printed.

The regression test asserts the closure is **not called** for a file below the threshold. That distinction matters: "it compiles with a closure" was equally true of a version that still walked the repository every time, and only the not-called assertion goes red when the evaluation moves back up.

Two things fall out: the `graph failed` fallback is unreachable once the graph is not built up front, and `distill_readfile` becomes the test-only helper it had already turned into.

## Scope

**#258 stays open.** It is about feeding `imported_by` into the *scorer*, which is a different thing, and its "the blocker is making the graph cheap" analysis is still correct. This is only the part that was already shipping.

Regression test proven to fail: forcing the count to evaluate eagerly turns `the_dependents_walk_is_skipped_when_the_file_is_too_small_to_distil` red.

`make ci` green end to end on cargo 1.97.0, the pinned toolchain: 45/45 smoke.