### PR TITLE
fix(codex): replace a prior hook entry when the binary path changes, instead of hooking twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **`omni init --codex` hooked every command twice after the binary moved (#369)**: dedupe matched the exact command string, so repointing OMNI (a dev build to a stable copy, a changed Homebrew prefix, a relocated binary) left the previous entry beside the new one and both fired. Each `distillations` row was then written twice, which inflates that host's counts and savings in Agent Distribution, so the defect corrupts the measurement #351 asks for rather than merely duplicating a line. Installing now removes every prior OMNI entry for the event, in either shape and at any path, using the same `is_omni_hook_command` predicate uninstall already relies on; other tools' entries in the same file are left alone. Same family as #364: the install path recognised only the exact thing it wrote last time, so anything that changed underneath it accumulated instead of migrating. Found by repointing a real install, not by a test.
+
+### Fixed
 - **`omni doctor` reported Codex hooks `[OK]` when its own upgrade had just disabled them (#367)**: the Trust check asked whether a `hooks.state` record exists, and Codex also re-checks the entry's hash. `omni init --codex` has to rewrite the entries to migrate the dead shape from #364, which invalidates every approval that was working, and doctor then found the stale records and said nothing. Reproduced on a live install. The hash cannot be verified from the config, so doctor no longer implies it: a missing record is still a `[WARNING]`, and a present one now reads `recorded; Codex re-checks the hash, so re-approve after any upgrade`. `omni init --codex` says outright that the rewrite voided earlier approvals, because an upgrade that silently disables a working integration is worse than a fresh install that was never approved.
 
 ### Changed

--- a/src/agents/codex.rs
+++ b/src/agents/codex.rs
@@ -408,22 +408,26 @@ fn ensure_hook_entry(arr_val: &mut Value, cmd: &str) {
         return;
     };
 
-    // Drop our own entry in the old flat shape, so an upgrade repairs a config
-    // that has been silently doing nothing instead of adding a second copy.
-    arr.retain(|v| v.get("command").and_then(|c| c.as_str()) != Some(cmd));
-
-    let already = arr.iter().any(|v| {
-        v.get("hooks")
+    // Drop every prior entry of ours, in either shape and at any path, before
+    // adding the current one. Matching on the exact command was not enough:
+    // moving the binary (a dev build to a stable copy, or a Homebrew upgrade)
+    // left the old entry in place, so the hook ran twice per command and every
+    // distillation was recorded twice (#369). Third-party entries are untouched.
+    arr.retain(|v| {
+        let flat = v.get("command").and_then(|c| c.as_str());
+        let nested = v
+            .get("hooks")
             .and_then(|h| h.as_array())
-            .is_some_and(|inner| {
+            .map(|inner| {
                 inner
                     .iter()
-                    .any(|h| h.get("command").and_then(|c| c.as_str()) == Some(cmd))
+                    .filter_map(|h| h.get("command").and_then(|c| c.as_str()))
+                    .any(is_omni_hook_command)
             })
+            .unwrap_or(false);
+
+        !(flat.is_some_and(is_omni_hook_command) || nested)
     });
-    if already {
-        return;
-    }
 
     arr.push(json!({
         "hooks": [{ "type": "command", "command": cmd, "timeout": 10 }]
@@ -483,6 +487,40 @@ pub fn remove_omni_hooks() -> anyhow::Result<()> {
 
 #[cfg(test)]
 mod tests {
+
+    /// #369: dedupe matched the exact command string, so moving the binary left
+    /// the previous entry in place. Both fired, every command was distilled
+    /// twice and recorded twice. Reproduced by repointing a live install from a
+    /// build directory to a stable copy.
+    #[test]
+    fn replaces_an_entry_that_points_at_an_older_binary_path() {
+        let mut arr = json!([{
+            "hooks": [{ "type": "command", "command": "/old/path/omni --pre-hook" }]
+        }]);
+
+        ensure_hook_entry(&mut arr, "/new/path/omni --pre-hook");
+
+        let arr = arr.as_array().unwrap();
+        assert_eq!(arr.len(), 1, "the old path survived: {arr:?}");
+        assert_eq!(arr[0]["hooks"][0]["command"], "/new/path/omni --pre-hook");
+    }
+
+    /// The purge is scoped to OMNI's own entries. A launcher's hooks share the
+    /// file and must come through untouched.
+    #[test]
+    fn leaves_another_tools_entry_alone() {
+        let mut arr = json!([
+            { "hooks": [{ "type": "command", "command": "/opt/other/agent-hook.sh" }] },
+            { "hooks": [{ "type": "command", "command": "/old/omni --pre-hook" }] }
+        ]);
+
+        ensure_hook_entry(&mut arr, "/new/omni --pre-hook");
+
+        let arr = arr.as_array().unwrap();
+        assert_eq!(arr.len(), 2, "{arr:?}");
+        assert_eq!(arr[0]["hooks"][0]["command"], "/opt/other/agent-hook.sh");
+        assert_eq!(arr[1]["hooks"][0]["command"], "/new/omni --pre-hook");
+    }
 
     /// #367: the Trust check asks only whether a record exists, and Codex also
     /// re-checks the entry's hash. `omni init --codex` rewrites the entries, so


### PR DESCRIPTION
Closes #369.

Dedupe matched the exact command string, so moving the binary left the previous entry in place and both fired:

```
PreToolUse  -> .../target/release/omni --pre-hook     <- previous install
PreToolUse  -> ~/.omni/bin/omni --pre-hook            <- this install
```

Any path change reaches it: a dev build moved to a stable copy, a changed Homebrew prefix, a relocated binary. A version bump does not, because the path is stable there, which is why it went unnoticed.

**The cost is the measurement, not the duplicate line.** Each `distillations` row is written twice, so that host's counts and savings inflate in Agent Distribution, and #351's "counts increase in a real session" would be reading a doubled number. This project's whole argument rests on those figures being earned.

Install now drops every prior OMNI entry for the event, in either shape and at any path, reusing the `is_omni_hook_command` predicate uninstall already relies on. Entries belonging to other tools in the same file are untouched, which the second test pins, and a live config with 8 launcher hooks came through with all 8 intact.

Same family as #364: the install path recognised only the exact thing it wrote last time, so anything that changed underneath it accumulated instead of migrating.

## Verification

Teeth: reverting to exact-match dedupe fails `replaces_an_entry_that_points_at_an_older_binary_path` and `leaves_another_tools_entry_alone`.

On the live install that exposed it:

```
before   2 omni entries per event, third-party 8
after    1 omni entry per event,  third-party 8
```

```
fmt ok, clippy ok, 19 suites, 0 failed
```

Toolchain 1.97.1 locally against a repo pinned to 1.97.0, so CI decides clippy.

Found by repointing a real install, not by a test. The unit tests were all passing before and after the defect existed, because none of them changed the path.
