### PR TITLE
fix(docs): repoint every dead selector, and give the manual a way back to the site

### DIFF
--- a/docs/website/book.toml
+++ b/docs/website/book.toml
@@ -23,7 +23,7 @@ no-section-label = true
 git-repository-url = "https://github.com/fajarhide/omni"
 edit-url-template = "https://github.com/fajarhide/omni/edit/main/docs/website/{path}"
 additional-css = ["theme/omni.css"]
-additional-js = ["theme/pagetoc.js"]
+additional-js = ["theme/pagetoc.js", "theme/siteframe.js"]
 
 [output.html.playground]
 runnable = false

--- a/docs/website/theme/omni.css
+++ b/docs/website/theme/omni.css
@@ -149,9 +149,11 @@
 /* The three built-in themes this design does not cover. A half-styled theme
    reads as a bug, so they are removed from the picker rather than left to
    render in mdBook's own colours. */
-#theme-list li a#coal,
-#theme-list li a#ayu,
-#theme-list li a#rust { display: none; }
+/* Buttons, not anchors, and hiding the button leaves its empty row behind, so
+   the row is what gets hidden. */
+#mdbook-theme-list li:has(#mdbook-theme-coal),
+#mdbook-theme-list li:has(#mdbook-theme-ayu),
+#mdbook-theme-list li:has(#mdbook-theme-rust) { display: none; }
 
 /* --------------------------------------------------------------------------
    Page
@@ -312,8 +314,8 @@ blockquote p:last-child { margin-bottom: 0; }
    eyebrow the site uses for the same job.
    -------------------------------------------------------------------------- */
 
-#sidebar { font-size: 0.9rem; }
-#sidebar .sidebar-scrollbox { padding: 1.5rem 1.5rem 4rem; }
+#mdbook-sidebar { font-size: 0.9rem; }
+#mdbook-sidebar .sidebar-scrollbox { padding: 1.5rem 1.5rem 4rem; }
 
 .chapter li.chapter-item { line-height: 1.5; margin: 0.34em 0; }
 
@@ -339,13 +341,59 @@ blockquote p:last-child { margin-bottom: 0; }
 /* Nested chapters sit under their parent without a bullet or a number. */
 .chapter li > ol.section { padding-left: 0.9rem; }
 
-#menu-bar { background: var(--bg); border-bottom: 1px solid transparent; }
-#menu-bar.sticky, #menu-bar:not(.folded) { border-bottom-color: var(--rule); }
-#menu-bar h1.menu-title {
+#mdbook-menu-bar { background: var(--bg); border-bottom: 1px solid transparent; }
+#mdbook-menu-bar.sticky, #mdbook-menu-bar:not(.folded) { border-bottom-color: var(--rule); }
+#mdbook-menu-bar h1.menu-title {
   font-family: var(--font-display);
   font-weight: 700;
   font-size: 1.05rem;
   letter-spacing: 0.01em;
+}
+
+/* --------------------------------------------------------------------------
+   The way back to the site (#477), injected by theme/siteframe.js.
+
+   The manual matched the palette and not the frame, so nothing on 37 pages
+   linked home and `Docs` in the site navbar was a one-way door. These are the
+   site's own destinations in the site's own quiet style, not a second
+   navigation: the sidebar is the navigation.
+   -------------------------------------------------------------------------- */
+
+#mdbook-menu-bar .menu-title .site-home {
+  color: inherit;
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+}
+#mdbook-menu-bar .menu-title .site-home:hover {
+  border-bottom-color: currentColor;
+}
+
+.site-links {
+  display: flex;
+  align-items: center;
+  gap: 1.15rem;
+  margin-right: 1.15rem;
+  padding-right: 1.15rem;
+  border-right: 1px solid var(--rule);
+}
+
+.site-links a {
+  font-family: var(--font-body);
+  font-size: 0.86rem;
+  color: var(--ink-soft);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  padding: 2px 0;
+}
+.site-links a:hover {
+  color: var(--fg);
+  border-bottom-color: var(--fg);
+}
+
+/* On a phone the icon buttons already crowd the bar, and the sidebar toggle
+   matters more there than a link to the journal. */
+@media (max-width: 700px) {
+  .site-links { display: none; }
 }
 
 /* --------------------------------------------------------------------------
@@ -392,12 +440,12 @@ blockquote p:last-child { margin-bottom: 0; }
    Search
    -------------------------------------------------------------------------- */
 
-#searchbar {
+#mdbook-searchbar {
   font-family: var(--font-body);
   border-radius: 4px;
   padding: 0.6em 0.8em;
 }
-#searchresults a { border-bottom: 0; }
+#mdbook-searchresults a { border-bottom: 0; }
 mark { border-radius: 2px; padding: 0 0.15em; }
 
 /* --------------------------------------------------------------------------

--- a/docs/website/theme/siteframe.js
+++ b/docs/website/theme/siteframe.js
@@ -1,0 +1,90 @@
+/* Put the manual back inside the site it is served from (#477).
+ *
+ * The palette and the fonts already match, which made the seam invisible until
+ * someone tried to leave: nothing on any page linked back to
+ * omni.weekndlabs.com, so `Docs` in the site navbar was a one-way door.
+ *
+ * Done here rather than by forking `index.hbs`, because owning mdBook's whole
+ * page template in order to add a header is a bad trade on every future upgrade.
+ * `.menu-title` and `.right-buttons` are the classes `theme/omni.css` already
+ * styles, so this adds to markup the theme is already committed to.
+ *
+ * Relative links, not absolute ones. `mdbook serve` on localhost has no site
+ * around it, and hardcoding the production origin would send a local reader to
+ * production. `../` from /docs/ is the site root and is also simply wrong-free
+ * when the book is opened from disk: it fails to navigate rather than navigating
+ * somewhere misleading.
+ */
+(function () {
+  'use strict';
+
+  // Where a reader of the manual actually goes next. Deliberately short: the
+  // sidebar is the navigation, this is the way out.
+  var LINKS = [
+    { href: '../', text: 'Site' },
+    { href: '../releases', text: 'Releases' },
+    { href: '../blog', text: 'Journal' },
+    { href: 'https://discord.gg/zHTuvZhF2M', text: 'Discord', external: true },
+  ];
+
+  function depth() {
+    // mdBook stamps the page's own distance from the book root as
+    // `path_to_root`: "" at the root, "../" one level down. Taking it from there
+    // beats probing a link, which is what the first draft did and got wrong: it
+    // read the sidebar, and the sidebar is rendered client-side by toc.js, so at
+    // DOMContentLoaded there was nothing to read and every page resolved as the
+    // root. Counting slashes in the URL is no better, because Vercel serves
+    // these paths without the .html there is nothing to discount.
+    //
+    // Read as a bare identifier, not off `window`. mdBook declares it as
+    // `const path_to_root = "../";` in a classic script, and a top-level `const`
+    // lives in the global lexical environment without becoming a property of
+    // `window`, so `window.path_to_root` is undefined while `path_to_root`
+    // resolves. Both scripts being classic is what makes that work; `typeof`
+    // keeps it from throwing if a future mdBook stops emitting it.
+    return typeof path_to_root === 'string' ? path_to_root : '';
+  }
+
+  function build() {
+    var bar = document.querySelector('.right-buttons');
+    var title = document.querySelector('.menu-title');
+    if (!bar && !title) return;
+
+    var root = depth();
+
+    // The wordmark is the way home on every site that has one, so make it one
+    // here too rather than adding a fifth link that says Home.
+    if (title && !title.querySelector('a')) {
+      var home = document.createElement('a');
+      home.href = root + '../';
+      home.textContent = title.textContent.trim();
+      home.className = 'site-home';
+      title.textContent = '';
+      title.appendChild(home);
+    }
+
+    if (!bar) return;
+    var nav = document.createElement('nav');
+    nav.className = 'site-links';
+    nav.setAttribute('aria-label', 'Site');
+    LINKS.forEach(function (l) {
+      var a = document.createElement('a');
+      a.href = l.external ? l.href : root + l.href;
+      a.textContent = l.text;
+      if (l.external) {
+        a.target = '_blank';
+        a.rel = 'noopener noreferrer';
+      }
+      nav.appendChild(a);
+    });
+    // Before mdBook's icon buttons, so print/repo/edit stay where a returning
+    // reader expects them at the far right.
+    bar.insertBefore(nav, bar.firstChild);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', build);
+  } else {
+    build();
+  }
+})();


### PR DESCRIPTION
Closes #477

Reported as "the style did not carry over", and it had not, in two ways. The
second is the larger one and was not in the original report.

## Every id selector in the theme was dead

mdBook 0.5 prefixes its ids with `mdbook-`. The theme targeted the old names, so
8 of 8 matched nothing:

| written | actual |
|---|---|
| `#sidebar` | `#mdbook-sidebar` |
| `#menu-bar` | `#mdbook-menu-bar` |
| `#searchbar` | `#mdbook-searchbar` |
| `#searchresults` | `#mdbook-searchresults` |
| `#theme-list` | `#mdbook-theme-list` |
| `#coal` `#ayu` `#rust` | `#mdbook-theme-coal` and siblings |

**The palette survived, which is why nobody caught it.** `.light` and `.navy` are
class selectors, and their variables are consumed by mdBook's own stylesheet, so
the colours and fonts landed while the sidebar, menu bar and search rules did not.

It also meant the rule hiding the three themes this design does not cover never
fired: Coal, Rust and Ayu were live in the picker, rendering in mdBook's own
colours, which is the "half-styled theme" the comment above that rule says is
worse than an absent one. They are hidden with `:has()` on the row, since the
entries are buttons and hiding a button leaves its empty row behind.

## The manual linked home from nowhere

37 pages, zero links back to the site serving them:

```sh
curl -sL https://omni.weekndlabs.com/docs/ \
  | grep -oE 'href="(https://omni\.weekndlabs\.com[^"]*|/)"' | sort -u
# no output
```

`Docs` in the site navbar was a one-way door, and Discord was unreachable from
the pages most likely to make a reader want it.

`theme/siteframe.js` makes the wordmark the way home and puts Site, Releases,
Journal and Discord in the header. Done in a script rather than by forking
`index.hbs`, because owning mdBook's whole page template through every future
upgrade is a bad trade for a header.

Depth comes from mdBook's own `path_to_root`. The first draft probed a sidebar
link and was wrong twice: the sidebar is rendered client-side by `toc.js` so there
was nothing to read at `DOMContentLoaded`, and the id it looked for was one of the
eight dead ones. It is read as a bare identifier, not off `window`, because mdBook
declares it `const` in a classic script and a top-level `const` never becomes a
property of `window`.

## Verified

```
mdbook build                      40 pages
8 of 8 id selectors               present in the built markup
script ordering                   declaration at byte 1547, reader at 29001
resolver, per depth               /docs/ -> ../    /docs/a/b -> ../../    /docs/a/b/c -> ../../../
```

**Not verified in a browser**: there is none in this harness, so the injection is
checked through the markup and globals it depends on rather than by watching it
render. Worth a look on the deploy preview before merging.
