### PR TITLE
ci: typecheck plugins/pi, so a dependency bump is checked by something

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,3 +66,29 @@ jobs:
 
       - name: Run tests
         run: cargo test --all
+
+  plugin-pi:
+    name: typecheck (plugins/pi)
+    # Not `needs: ci`, for the same reason the matrix is not: it shares nothing
+    # with the Rust jobs and serialising it would only add its wall clock to
+    # theirs.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: plugins/pi/package-lock.json
+
+      # `npm ci` rather than `npm install`, so a dependency bump is typechecked
+      # against the lockfile the PR proposes rather than against whatever
+      # resolves today.
+      - name: Install
+        working-directory: plugins/pi
+        run: npm ci
+
+      - name: Typecheck
+        working-directory: plugins/pi
+        run: npm run typecheck

--- a/plugins/pi/package.json
+++ b/plugins/pi/package.json
@@ -10,6 +10,9 @@
     "index.ts",
     "README.md"
   ],
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
   "pi": {
     "extensions": [
       "./index.ts"


### PR DESCRIPTION
Closes #464

`make ci` is fmt, clippy, test, security and binary-check, all Rust, and nothing in
the workflow ran `tsc` or `npm` against `plugins/pi`. `index.ts` is the whole
extension Pi loads, so a TypeScript **major** bump merged on a matrix that had not
compiled a line of it.

#461 took typescript from 5.9.3 to 7.0.2 and passed all three checks. The bump was
fine, verified by hand afterwards. That is the point: it was fine and the matrix
could not have said either way.

Same shape as #423, an `undici` advisory in this package that `cargo audit`
structurally could not see.

## Two small choices

The command is `scripts.typecheck` in `package.json`, not only in the workflow, so
CI and a contributor run the same thing rather than CI knowing an incantation the
package does not declare.

`npm ci`, not `npm install`, so a dependency bump is typechecked against the
lockfile the PR proposes rather than against whatever resolves on the day.

Not `needs: ci`, for the same reason the test matrix is not: it shares nothing with
the Rust jobs, and serialising it would add its wall clock to theirs for no
ordering benefit.

## Verified

```
$ npm run typecheck        # in plugins/pi
> tsc --noEmit
$ echo $?
0
```

And it has teeth, which is the part worth checking on a job whose whole purpose is
to fail:

```
$ printf '\nconst _teeth: number = "not a number";\n' >> index.ts
$ npm run typecheck
index.ts(337,7): error TS2322: Type 'string' is not assignable to type 'number'.
```

Restored, green again. `index.ts` is unchanged in this diff.
