### PR TITLE
docs(website): read the manual's palette, type and accent from @weekndlabs/design

### DIFF
--- a/docs/website/theme/omni.css
+++ b/docs/website/theme/omni.css
@@ -32,12 +32,12 @@
    -------------------------------------------------------------------------- */
 
 @font-face { font-family: 'IBM Plex Sans'; font-style: normal; font-weight: 400; font-display: swap; src: url('../fonts/ibm-plex-sans-400.woff2') format('woff2'); }
-@font-face { font-family: 'IBM Plex Sans'; font-style: normal; font-weight: 500; font-display: swap; src: url('../fonts/ibm-plex-sans-500.woff2') format('woff2'); }
+@font-face { font-family: 'IBM Plex Sans'; font-style: normal; font-weight: var(--wl-weight-medium); font-display: swap; src: url('../fonts/ibm-plex-sans-500.woff2') format('woff2'); }
 @font-face { font-family: 'IBM Plex Sans'; font-style: normal; font-weight: 600; font-display: swap; src: url('../fonts/ibm-plex-sans-600.woff2') format('woff2'); }
 @font-face { font-family: 'IBM Plex Sans Condensed'; font-style: normal; font-weight: 600; font-display: swap; src: url('../fonts/ibm-plex-sans-condensed-600.woff2') format('woff2'); }
-@font-face { font-family: 'IBM Plex Sans Condensed'; font-style: normal; font-weight: 700; font-display: swap; src: url('../fonts/ibm-plex-sans-condensed-700.woff2') format('woff2'); }
+@font-face { font-family: 'IBM Plex Sans Condensed'; font-style: normal; font-weight: var(--wl-weight-display); font-display: swap; src: url('../fonts/ibm-plex-sans-condensed-700.woff2') format('woff2'); }
 @font-face { font-family: 'IBM Plex Mono'; font-style: normal; font-weight: 400; font-display: swap; src: url('../fonts/ibm-plex-mono-400.woff2') format('woff2'); }
-@font-face { font-family: 'IBM Plex Mono'; font-style: normal; font-weight: 500; font-display: swap; src: url('../fonts/ibm-plex-mono-500.woff2') format('woff2'); }
+@font-face { font-family: 'IBM Plex Mono'; font-style: normal; font-weight: var(--wl-weight-medium); font-display: swap; src: url('../fonts/ibm-plex-mono-500.woff2') format('woff2'); }
 
 /* --------------------------------------------------------------------------
    Every value in this file that decides how the book looks is a --wl-* token
@@ -178,11 +178,11 @@
 
 html { font-family: var(--font-body); -webkit-text-size-adjust: 100%; }
 
-body { font-size: 16px; line-height: 1.6; -webkit-font-smoothing: antialiased; }
+body { font-size: var(--wl-text-body); line-height: var(--wl-leading-body); -webkit-font-smoothing: antialiased; }
 
 .content main { max-width: var(--doc-measure); }
 
-.content p, .content li { line-height: 1.72; }
+.content p, .content li { line-height: var(--wl-leading-body); }
 .content p { margin: 0 0 1.15em; }
 .content ul, .content ol { margin: 0 0 1.15em; padding-left: 1.35em; }
 .content li + li { margin-top: 0.35em; }
@@ -197,39 +197,39 @@ body { font-size: 16px; line-height: 1.6; -webkit-font-smoothing: antialiased; }
 
 .content h1, .content h2, .content h3, .content h4 {
   font-family: var(--font-display);
-  font-weight: 600;
-  letter-spacing: -0.015em;
-  line-height: 1.15;
+  font-weight: var(--wl-weight-semibold);
+  letter-spacing: var(--wl-tracking-section);
+  line-height: var(--wl-leading-heading);
   text-wrap: balance;
 }
 
 .content h1 {
-  font-size: 2.45rem;
-  font-weight: 700;
-  letter-spacing: -0.03em;
-  line-height: 1.05;
+  font-size: var(--wl-text-display);
+  font-weight: var(--wl-weight-display);
+  letter-spacing: var(--wl-tracking-hero);
+  line-height: var(--wl-leading-hero);
   margin: 0 0 0.55em;
 }
 
 /* Whitespace separates sections, not a border. The one exception is h2, which
    marks the joints a reader scans for. */
 .content h2 {
-  font-size: 1.6rem;
+  font-size: var(--wl-text-title);
   margin: 2.9em 0 0.75em;
   padding-bottom: 0.3em;
   border-bottom: 1px solid var(--rule);
 }
 
-.content h3 { font-size: 1.16rem; margin: 2.2em 0 0.6em; }
-.content h4 { font-size: 1rem; margin: 1.8em 0 0.5em; color: var(--ink-soft); }
+.content h3 { font-size: var(--wl-text-lede); margin: 2.2em 0 0.6em; }
+.content h4 { font-size: var(--wl-text-body); margin: 1.8em 0 0.5em; color: var(--ink-soft); }
 
 .content h1 a.header, .content h2 a.header,
 .content h3 a.header, .content h4 a.header { color: inherit; }
 
 /* The paragraph directly under an h1 is the page's lede. */
 .content h1 + p {
-  font-size: 1.1rem;
-  line-height: 1.62;
+  font-size: var(--wl-text-lede);
+  line-height: var(--wl-leading-body);
   color: var(--ink-soft);
 }
 
@@ -245,7 +245,7 @@ code { font-family: var(--font-mono); font-size: 0.875em; }
 .content :not(pre) > code {
   background: var(--code-bg);
   border: 1px solid var(--code-border);
-  border-radius: 3px;
+  border-radius: var(--wl-radius-control);
   padding: 0.05em 0.35em;
   color: var(--inline-code-color);
 }
@@ -253,7 +253,7 @@ code { font-family: var(--font-mono); font-size: 0.875em; }
 .content pre {
   background: var(--code-bg);
   border: 1px solid var(--code-border);
-  border-radius: 4px;
+  border-radius: var(--wl-radius-control);
   padding: 0.95rem 1.05rem;
   margin: 1.5em 0;
   overflow-x: auto;
@@ -261,13 +261,13 @@ code { font-family: var(--font-mono); font-size: 0.875em; }
 
 .content pre code {
   font-size: 0.845em;
-  line-height: 1.62;
+  line-height: var(--wl-leading-body);
   background: none;
   border: 0;
   padding: 0;
 }
 
-.content pre > .buttons { opacity: 0; transition: opacity 140ms ease; }
+.content pre > .buttons { opacity: 0; transition: opacity var(--wl-duration-fast) var(--wl-ease-out); }
 .content pre:hover > .buttons { opacity: 0.6; }
 
 /* --------------------------------------------------------------------------
@@ -281,14 +281,14 @@ code { font-family: var(--font-mono); font-size: 0.875em; }
   width: 100%;
   border-collapse: collapse;
   margin: 1.6em 0;
-  font-size: 0.94rem;
+  font-size: var(--wl-text-body);
 }
 
 .content table thead th {
   font-family: var(--font-mono);
-  font-weight: 400;
-  font-size: 0.72rem;
-  letter-spacing: 0.12em;
+  font-weight: var(--wl-weight-body);
+  font-size: var(--wl-text-label);
+  letter-spacing: var(--wl-tracking-label);
   text-transform: uppercase;
   color: var(--ink-soft);
   text-align: left;
@@ -331,7 +331,7 @@ blockquote p:last-child { margin-bottom: 0; }
    eyebrow the site uses for the same job.
    -------------------------------------------------------------------------- */
 
-#mdbook-sidebar { font-size: 0.9rem; }
+#mdbook-sidebar { font-size: var(--wl-text-body); }
 #mdbook-sidebar .sidebar-scrollbox { padding: 1.5rem 1.5rem 4rem; }
 
 .chapter li.chapter-item { line-height: 1.5; margin: 0.34em 0; }
@@ -341,13 +341,13 @@ blockquote p:last-child { margin-bottom: 0; }
   border-bottom: 1px solid transparent;
 }
 .chapter li.chapter-item a:hover { color: var(--fg); }
-.chapter li.chapter-item a.active { font-weight: 500; }
+.chapter li.chapter-item a.active { font-weight: var(--wl-weight-medium); }
 
 .chapter li.part-title {
   font-family: var(--font-mono);
-  font-size: 0.7rem;
-  font-weight: 400;
-  letter-spacing: 0.14em;
+  font-size: var(--wl-text-label);
+  font-weight: var(--wl-weight-body);
+  letter-spacing: var(--wl-tracking-label);
   text-transform: uppercase;
   color: var(--sidebar-non-existant);
   margin: 2.2em 0 0.7em;
@@ -362,8 +362,8 @@ blockquote p:last-child { margin-bottom: 0; }
 #mdbook-menu-bar.sticky, #mdbook-menu-bar:not(.folded) { border-bottom-color: var(--rule); }
 #mdbook-menu-bar h1.menu-title {
   font-family: var(--font-display);
-  font-weight: 700;
-  font-size: 1.05rem;
+  font-weight: var(--wl-weight-display);
+  font-size: var(--wl-text-lede);
   letter-spacing: 0.01em;
 }
 
@@ -396,7 +396,7 @@ blockquote p:last-child { margin-bottom: 0; }
 
 .site-links a {
   font-family: var(--font-body);
-  font-size: 0.86rem;
+  font-size: var(--wl-text-meta);
   color: var(--ink-soft);
   text-decoration: none;
   border-bottom: 1px solid transparent;
@@ -424,7 +424,7 @@ blockquote p:last-child { margin-bottom: 0; }
   width: var(--toc-width);
   max-height: calc(100vh - 8rem);
   overflow-y: auto;
-  font-size: 0.82rem;
+  font-size: var(--wl-text-meta);
   line-height: 1.5;
   border-left: 1px solid var(--rule);
   padding-left: 0.9rem;
@@ -432,8 +432,8 @@ blockquote p:last-child { margin-bottom: 0; }
 
 .pagetoc-label {
   font-family: var(--font-mono);
-  font-size: 0.68rem;
-  letter-spacing: 0.14em;
+  font-size: var(--wl-text-label);
+  letter-spacing: var(--wl-tracking-label);
   text-transform: uppercase;
   color: var(--sidebar-non-existant);
   margin-bottom: 0.7em;
@@ -459,11 +459,11 @@ blockquote p:last-child { margin-bottom: 0; }
 
 #mdbook-searchbar {
   font-family: var(--font-body);
-  border-radius: 4px;
+  border-radius: var(--wl-radius-control);
   padding: 0.6em 0.8em;
 }
 #mdbook-searchresults a { border-bottom: 0; }
-mark { border-radius: 2px; padding: 0 0.15em; }
+mark { border-radius: var(--wl-radius-control); padding: 0 0.15em; }
 
 /* --------------------------------------------------------------------------
    Footer navigation
@@ -477,7 +477,6 @@ mark { border-radius: 2px; padding: 0 0.15em; }
    -------------------------------------------------------------------------- */
 
 @media (max-width: 700px) {
-  .content h1 { font-size: 1.95rem; }
-  .content h2 { font-size: 1.35rem; }
-  .content table { font-size: 0.88rem; }
+  .content h2 { font-size: var(--wl-text-subtitle); }
+  .content table { font-size: var(--wl-text-meta); }
 }

--- a/docs/website/theme/omni.css
+++ b/docs/website/theme/omni.css
@@ -20,8 +20,9 @@
    ========================================================================== */
 
 /* --------------------------------------------------------------------------
-   Fonts. Vendored into src/fonts/ so the book is self-contained and renders
-   identically under `mdbook serve` and under /docs on the live origin.
+   Fonts, vendored into src/fonts/ so a checkout of this repository renders
+   without a package manager. Published pages load the design system's families
+   over the top of these and never reach them; see the note below the block.
 
    The `../` is load-bearing. mdBook copies this file to `book/theme/` and
    fingerprints its name, while `src/fonts/` lands at `book/fonts/`, so a URL
@@ -38,10 +39,26 @@
 @font-face { font-family: 'IBM Plex Mono'; font-style: normal; font-weight: 400; font-display: swap; src: url('../fonts/ibm-plex-mono-400.woff2') format('woff2'); }
 @font-face { font-family: 'IBM Plex Mono'; font-style: normal; font-weight: 500; font-display: swap; src: url('../fonts/ibm-plex-mono-500.woff2') format('woff2'); }
 
+/* --------------------------------------------------------------------------
+   Every value in this file that decides how the book looks is a --wl-* token
+   from @weekndlabs/design, and every one of them carries the pre-system value
+   as its fallback.
+
+   The tokens are not vendored here. omni-pages depends on that package for its
+   own pages and, at publish time, drops the same copy into this book and links
+   it from theme/head.hbs (see scripts/build-docs.sh over there). That is what
+   keeps /docs and the rest of omni.weekndlabs.com on one palette through a
+   style change: one version bump, in one repository.
+
+   The consequence to know about: `mdbook serve` here renders the fallbacks, so
+   a local preview is the pre-system look and correct only in layout. Judge
+   colour and type on the published site, not on localhost:3000.
+   -------------------------------------------------------------------------- */
+
 :root {
-  --font-display: 'IBM Plex Sans Condensed', 'IBM Plex Sans', system-ui, sans-serif;
-  --font-body:    'IBM Plex Sans', system-ui, sans-serif;
-  --font-mono:    'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+  --font-display: var(--wl-font-sans, 'IBM Plex Sans Condensed', 'IBM Plex Sans', system-ui, sans-serif);
+  --font-body:    var(--wl-font-sans, 'IBM Plex Sans', system-ui, sans-serif);
+  --font-mono:    var(--wl-font-mono, 'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo, monospace);
 
   /* 68 characters at this size. Long enough for a wide reference table to
      breathe, short enough that prose is read rather than skimmed. */
@@ -54,14 +71,14 @@
    -------------------------------------------------------------------------- */
 
 .light {
-  --paper:       #E3E4E0;
-  --paper-panel: #DBDCD6;
-  --paper-sunk:  #D3D5CD;
-  --ink:         #16161A;
-  --ink-soft:    #56585A;
-  --rule:        #C6C8C1;
-  --rule-strong: #A9ABA3;
-  --accent:      #7A4E00;   /* the only amber allowed on paper, 5.6:1 */
+  --paper:       var(--wl-background, #E3E4E0);
+  --paper-panel: var(--wl-card, #DBDCD6);
+  --paper-sunk:  var(--wl-muted, #D3D5CD);
+  --ink:         var(--wl-foreground, #16161A);
+  --ink-soft:    var(--wl-muted-foreground, #56585A);
+  --rule:        var(--wl-border, #C6C8C1);
+  --rule-strong: var(--wl-input, #A9ABA3);
+  --accent:      var(--wl-warning, #7A4E00);   /* the only amber allowed on paper */
 
   --bg: var(--paper);
   --fg: var(--ink);
@@ -90,7 +107,7 @@
   --searchresults-header-fg: var(--ink-soft);
   --searchresults-border-color: var(--rule);
   --searchresults-li-bg: var(--paper-panel);
-  --search-mark-bg: #E8C879;
+  --search-mark-bg: oklch(from var(--wl-warning, #7A4E00) calc(l + 0.32) c h);
 
   --code-bg: var(--paper-sunk);
   --code-fg: var(--ink);
@@ -102,21 +119,21 @@
    -------------------------------------------------------------------------- */
 
 .navy {
-  --crt:          #0B0B0C;
-  --crt-panel:    #121214;
-  --crt-sunk:     #161618;
-  --phosphor:     #FFB000;
-  --phosphor-dim: #A87400;
-  --ink:          #DEDFDA;
-  --ink-soft:     #8C8E88;
-  --rule:         #26262A;
-  --rule-strong:  #3A3A40;
+  --crt:          var(--wl-background, #0B0B0C);
+  --crt-panel:    var(--wl-card, #121214);
+  --crt-sunk:     var(--wl-muted, #161618);
+  --phosphor:     var(--wl-terminal-yellow, #FFB000);
+  --phosphor-dim: var(--wl-terminal-dim, #A87400);
+  --ink:          var(--wl-foreground, #DEDFDA);
+  --ink-soft:     var(--wl-muted-foreground, #8C8E88);
+  --rule:         var(--wl-border, #26262A);
+  --rule-strong:  var(--wl-input, #3A3A40);
 
   --bg: var(--crt);
   --fg: var(--ink);
-  --sidebar-bg: #0E0E10;
+  --sidebar-bg: var(--wl-sidebar, #0E0E10);
   --sidebar-fg: var(--ink-soft);
-  --sidebar-non-existant: #4A4A50;
+  --sidebar-non-existant: var(--wl-input, #4A4A50);
   --sidebar-active: var(--phosphor);
   --sidebar-spacer: var(--rule);
   --scrollbar: var(--rule-strong);
@@ -135,11 +152,11 @@
   --searchbar-border-color: var(--rule);
   --searchbar-bg: var(--crt-panel);
   --searchbar-fg: var(--ink);
-  --searchbar-shadow-color: #000;
+  --searchbar-shadow-color: var(--wl-background, #000);
   --searchresults-header-fg: var(--ink-soft);
   --searchresults-border-color: var(--rule);
   --searchresults-li-bg: var(--crt-panel);
-  --search-mark-bg: #5C3E00;
+  --search-mark-bg: oklch(from var(--wl-terminal-yellow, #FFB000) calc(l - 0.42) c h);
 
   --code-bg: var(--crt-panel);
   --code-fg: var(--ink);

--- a/docs/website/theme/omni.css
+++ b/docs/website/theme/omni.css
@@ -6,8 +6,9 @@
 
      1. Mono type means a machine emitted it. Sans means a person wrote it.
         Never mix the two inside one block.
-     2. Amber phosphor appears only inside a black terminal. It is the
-        instrument's colour, so it never leaks onto the page.
+     2. Yellow appears only inside the terminal. It is the instrument's
+        colour, so it never leaks onto the page. The accent both themes
+        spend is --accent, the same one omni.weekndlabs.com uses.
 
    Rule 2 is also what decides the dark theme. mdBook's `light` is the site's
    paper; its `navy` is the instrument, which is the one place amber belongs.
@@ -78,7 +79,7 @@
   --ink-soft:    var(--wl-muted-foreground, #56585A);
   --rule:        var(--wl-border, #C6C8C1);
   --rule-strong: var(--wl-input, #A9ABA3);
-  --accent:      var(--wl-warning, #7A4E00);   /* the only amber allowed on paper */
+  --accent:      var(--wl-ring, #7A4E00);      /* the house accent, as on the site */
 
   --bg: var(--paper);
   --fg: var(--ink);
@@ -122,6 +123,7 @@
   --crt:          var(--wl-background, #0B0B0C);
   --crt-panel:    var(--wl-card, #121214);
   --crt-sunk:     var(--wl-muted, #161618);
+  --accent:       var(--wl-ring, #FFB000);
   --phosphor:     var(--wl-terminal-yellow, #FFB000);
   --phosphor-dim: var(--wl-terminal-dim, #A87400);
   --ink:          var(--wl-foreground, #DEDFDA);
@@ -134,12 +136,12 @@
   --sidebar-bg: var(--wl-sidebar, #0E0E10);
   --sidebar-fg: var(--ink-soft);
   --sidebar-non-existant: var(--wl-input, #4A4A50);
-  --sidebar-active: var(--phosphor);
+  --sidebar-active: var(--accent);
   --sidebar-spacer: var(--rule);
   --scrollbar: var(--rule-strong);
   --icons: var(--ink-soft);
-  --icons-hover: var(--phosphor);
-  --links: var(--phosphor);
+  --icons-hover: var(--accent);
+  --links: var(--accent);
   --inline-code-color: var(--ink);
   --theme-popup-bg: var(--crt-panel);
   --theme-popup-border: var(--rule);


### PR DESCRIPTION
The book and omni.weekndlabs.com kept two copies of the same palette, so a
colour change on the site left `/docs` on the old one until somebody noticed and
copied it across. Every value in `theme/omni.css` that decides how the manual
looks is now a `--wl-*` token from `@weekndlabs/design`, carrying the
pre-system value as its fallback: palette, type scale, weights, tracking,
leading, radii and the one transition.

Links, the active sidebar entry and the focus ring were amber on paper and
terminal yellow in navy, so the manual had two accents and neither matched the
site. Both themes read `--accent` now, which is `--wl-ring`. Yellow keeps its
old rule and is narrower for it: inside the terminal only.

The tokens are not vendored here. omni-pages depends on that package for its own
pages and drops the same copy into this book at publish time, so one version
bump there moves the site and the manual together. That side is
weekndlabs/omni-pages#27 and needs to merge second.

One consequence to know about: `mdbook serve` in this repository renders the
fallbacks, so a local preview is the pre-system look and correct only in layout.
There is a note saying so at the top of the file.

Rendered against this branch and checked in both themes over CDP. Light gives
`data-theme=light` and links at `oklch(0.5462 0.1891 256.36)`; navy gives
`data-theme=dark` and `oklch(0.6854 0.1699 252.99)`. Both are the design
system's `--wl-ring` at that theme. No Rust touched, so `make ci` is unaffected.
