### PR TITLE
fix(website): code blocks in the manual render in the wrong mono

### DIFF
--- a/docs/website/theme/omni.css
+++ b/docs/website/theme/omni.css
@@ -61,6 +61,14 @@
   --font-body:    var(--wl-font-sans, 'IBM Plex Sans', system-ui, sans-serif);
   --font-mono:    var(--wl-font-mono, 'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo, monospace);
 
+  /* mdBook's general.css carries `code { font-family: var(--mono-font)
+     !important }`, so a `code` rule here loses whatever its specificity or
+     order. Its variable is the seam that works, and it is the same one the
+     palette already goes through. Without this, every code block and inline
+     span in the manual renders in Source Code Pro while the rest of the site
+     is on the design system's mono. */
+  --mono-font: var(--font-mono);
+
   /* 68 characters at this size. Long enough for a wide reference table to
      breathe, short enough that prose is read rather than skimmed. */
   --doc-measure: 46rem;


### PR DESCRIPTION
Follow-up to #484, found by rebuilding `/docs` against `main` after it merged
and checking what the browser actually resolved.

mdBook's `general.css` carries `code { font-family: var(--mono-font)
!important }`. This theme has had `code { font-family: var(--font-mono) }` the
whole time and it never won, whatever its order or specificity, so every code
block and inline span in the manual rendered in Source Code Pro while the rest
of omni.weekndlabs.com was on the design system's mono. On a reference manual
that is the largest mono surface there is.

Setting mdBook's own `--mono-font` is the seam that works, and it is the same
one the palette already goes through. The existing `code` rule is left alone;
it is correct and simply outranked.

Measured over CDP on `/docs/reference/commands`, before and after:

```
before  .content code -> "Source Code Pro", Consolas, "Ubuntu Mono", …
after   .content code -> "JetBrains Mono", ui-monospace, SFMono-Regular, …
```

Source Code Pro stops being fetched with it, so the page makes one request
fewer.
