### PR TITLE
fix(session): a session belongs to one project

### DIFF
--- a/src/hooks/dispatcher.rs
+++ b/src/hooks/dispatcher.rs
@@ -203,7 +203,21 @@ mod tests {
         let (store, _dir) = get_store();
         let mut state = SessionState::new();
         state.add_command("cargo build");
+        // Both rows, so the session is continuable: continuation is scoped by
+        // project since #482, and a `sessions` row alone is a state the product
+        // never leaves behind.
+        //
+        // It has to continue for this test to mean anything. A fresh session
+        // returns output only when it found watch paths or a prompt to register,
+        // and `/tmp` has neither on Windows, so without this the assertion below
+        // passes on macOS and Linux and fails on the runner.
         store.upsert_session(&state);
+        store.sync_agent_session(
+            &crate::agents::multiagent::detect_agent_id(),
+            &state.session_id,
+            &crate::agents::multiagent::project_hash("/tmp"),
+            &serde_json::to_string(&state).unwrap_or_else(|_| "{}".to_string()),
+        );
 
         let session = Arc::new(Mutex::new(SessionState::new())); // dipatcher state doesn't matter much for SessionStart
 

--- a/src/hooks/dispatcher.rs
+++ b/src/hooks/dispatcher.rs
@@ -225,10 +225,18 @@ mod tests {
     #[test]
     fn routes_before_agent_start_to_startup_logic() {
         let (store, _dir) = get_store();
-        // Seed a recent session so BeforeAgentStart has something to summarize
+        // Seed a recent session so BeforeAgentStart has something to summarize.
+        // Both rows, because continuation is scoped by project since #482 and a
+        // `sessions` row on its own is a state the product never leaves behind.
         let mut state = SessionState::new();
         state.add_command("cargo build");
         store.upsert_session(&state);
+        store.sync_agent_session(
+            &crate::agents::multiagent::detect_agent_id(),
+            &state.session_id,
+            &crate::agents::multiagent::project_hash("/tmp"),
+            &serde_json::to_string(&state).unwrap_or_else(|_| "{}".to_string()),
+        );
 
         let session = Arc::new(Mutex::new(SessionState::new()));
 

--- a/src/hooks/session_start.rs
+++ b/src/hooks/session_start.rs
@@ -308,7 +308,6 @@ pub fn process_before_agent_start_payload(
         return None;
     }
 
-
     let summary = build_summary_with_context(&state, now, &store, &cwd_for_ctx);
     let summary_truncated = crate::util::text::safe_truncate_with_ellipsis(summary.trim(), 797);
     if summary_truncated.is_empty() {

--- a/src/hooks/session_start.rs
+++ b/src/hooks/session_start.rs
@@ -100,12 +100,33 @@ pub fn process_payload(input_str: &str, store: Arc<Store>, cfg: SessionConfig) -
         return None;
     }
 
+    // The project decides which session may be continued, so it is resolved
+    // before the decision rather than after it (#482).
+    let cwd_for_ctx = if parsed.working_directory.is_empty() {
+        std::env::current_dir()
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_else(|_| ".".to_string())
+    } else {
+        parsed.working_directory.clone()
+    };
+    let proj_hash = multiagent::project_hash(&cwd_for_ctx);
+    let agent_id = multiagent::detect_agent_id();
+
     let now = Utc::now().timestamp();
     let mut should_continue = false;
     let mut prev_state: Option<SessionState> = None;
 
+    // Scoped to this project. The old lookup was
+    // `SELECT ... FROM sessions ORDER BY last_active DESC LIMIT 1`, which has no
+    // project in it, so opening a second repository inside the TTL continued the
+    // first one's session and inherited its task hint, hot files, active errors
+    // and command history. One session id was measured spanning six projects.
+    //
+    // Asking per project also handles going back: A, then B, then A again inside
+    // the window resumes A's own session rather than refusing because the newest
+    // session belongs to B.
     if !cfg.force_fresh
-        && let Some(state) = store.find_latest_session()
+        && let Some(state) = store.find_latest_session_for_project(&agent_id, &proj_hash)
     {
         let age_mins = (now - state.last_active) / 60;
         if cfg.force_continue || age_mins < cfg.ttl_mins {
@@ -115,17 +136,6 @@ pub fn process_payload(input_str: &str, store: Arc<Store>, cfg: SessionConfig) -
     }
 
     if should_continue && let Some(state) = prev_state {
-        let cwd_for_ctx = if parsed.working_directory.is_empty() {
-            std::env::current_dir()
-                .map(|p| p.to_string_lossy().to_string())
-                .unwrap_or_else(|_| ".".to_string())
-        } else {
-            parsed.working_directory.clone()
-        };
-
-        // Auto-sync agent session for multi-agent awareness
-        let proj_hash = multiagent::project_hash(&cwd_for_ctx);
-        let agent_id = multiagent::detect_agent_id();
         let state_json = serde_json::to_string(&state).unwrap_or_else(|_| "{}".to_string());
         store.sync_agent_session(&agent_id, &state.session_id, &proj_hash, &state_json);
 
@@ -181,6 +191,22 @@ pub fn process_payload(input_str: &str, store: Arc<Store>, cfg: SessionConfig) -
     };
 
     store.upsert_session(&new_state);
+    // A fresh session records which project it belongs to, which only the
+    // continued branch used to do. Without this the scoping above can never fire:
+    // the first session in a repository would leave no `agent_sessions` row, so
+    // the next one would find nothing to continue and start fresh again, forever
+    // (#482).
+    //
+    // It also closes a gap that predates that. `get_active_agents_for_project`
+    // reads the same table, so multi-agent awareness could not see an agent whose
+    // session had just started, which is exactly when a second agent most wants
+    // to know about it.
+    store.sync_agent_session(
+        &multiagent::detect_agent_id(),
+        &new_state.session_id,
+        &multiagent::project_hash(&cwd),
+        &serde_json::to_string(&new_state).unwrap_or_else(|_| "{}".to_string()),
+    );
     let start_msg = format!("Fresh session started (Client ID: {})", parsed.session_id);
     store.index_event(&new_state.session_id, "SessionStart", &start_msg);
 
@@ -261,14 +287,9 @@ pub fn process_before_agent_start_payload(
         return None;
     }
 
-    let state = store.find_latest_session()?;
-
-    let now = Utc::now().timestamp();
-    let age_mins = (now - state.last_active) / 60;
-    if !cfg.force_continue && age_mins >= cfg.ttl_mins {
-        return None;
-    }
-
+    // `BeforeAgentStart` is the second door into continuation, and it carried the
+    // same unscoped lookup as `SessionStart`. Fixing one and leaving the other is
+    // the failure this repository keeps repeating, so both ask per project (#482).
     let cwd_for_ctx = if parsed.working_directory.is_empty() {
         std::env::current_dir()
             .map(|p| p.to_string_lossy().to_string())
@@ -276,6 +297,17 @@ pub fn process_before_agent_start_payload(
     } else {
         parsed.working_directory.clone()
     };
+    let state = store.find_latest_session_for_project(
+        &multiagent::detect_agent_id(),
+        &multiagent::project_hash(&cwd_for_ctx),
+    )?;
+
+    let now = Utc::now().timestamp();
+    let age_mins = (now - state.last_active) / 60;
+    if !cfg.force_continue && age_mins >= cfg.ttl_mins {
+        return None;
+    }
+
 
     let summary = build_summary_with_context(&state, now, &store, &cwd_for_ctx);
     let summary_truncated = crate::util::text::safe_truncate_with_ellipsis(summary.trim(), 797);
@@ -569,6 +601,23 @@ mod tests {
         }
     }
 
+    /// A previous session, as the product actually leaves one behind.
+    ///
+    /// `upsert_session` alone is not that. Since #482 a session records the
+    /// project it belongs to in `agent_sessions`, and continuation is scoped by
+    /// it, so a fixture that writes only the `sessions` row describes a state the
+    /// code never produces and then asserts against it. Six tests were doing
+    /// exactly that and passed only because continuation ignored the project.
+    fn seed_previous_session(store: &Arc<Store>, state: &SessionState, cwd: &str) {
+        store.upsert_session(state);
+        store.sync_agent_session(
+            &multiagent::detect_agent_id(),
+            &state.session_id,
+            &multiagent::project_hash(cwd),
+            &serde_json::to_string(state).unwrap_or_else(|_| "{}".to_string()),
+        );
+    }
+
     #[test]
     fn fresh_session_exits_without_output() {
         let (store, _dir) = get_store();
@@ -599,7 +648,7 @@ mod tests {
         let cwd = dir.path().to_string_lossy().to_string();
         let mut state = SessionState::new();
         state.add_command("cargo test");
-        store.upsert_session(&state);
+        seed_previous_session(&store, &state, &cwd);
         let project_hash = crate::agents::multiagent::project_hash(&cwd);
         store.upsert_project_knowledge(&project_hash, "toolchain_rust", "1.97.0", 0.95);
 
@@ -627,6 +676,93 @@ mod tests {
         );
     }
 
+    /// A session belongs to one project (#482).
+    ///
+    /// The lookup used to be `ORDER BY last_active DESC LIMIT 1` over every
+    /// session on the machine, so opening a second repository inside the TTL
+    /// continued the first one's session and inherited its task hint, hot files,
+    /// active errors and command history. Measured on a live database, one
+    /// session id spanned six project paths.
+    ///
+    /// `force_continue` is on deliberately: this must hold because the projects
+    /// differ, not because the session aged out.
+    #[test]
+    fn does_not_continue_a_session_from_another_project() {
+        let (store, _dir) = get_store();
+
+        let mut state = SessionState::new();
+        state.add_command("cargo test");
+        state.add_error("missing semicolon");
+        state.add_hot_file("src/main.rs");
+        seed_previous_session(&store, &state, "/tmp/project-a");
+
+        let input = json!({
+            "hookEventName": "SessionStart",
+            "sessionId": "in-project-b",
+            "workingDirectory": "/tmp/project-b",
+        });
+        let mut cfg = default_config();
+        cfg.force_continue = true;
+
+        let out = process_payload(&input.to_string(), store.clone(), cfg);
+
+        // A fresh session emits either nothing or a watch-path reply; what it
+        // must never carry is the other project's state.
+        let body = out.unwrap_or_default();
+        assert!(
+            !body.contains("missing semicolon"),
+            "project B inherited project A's active error: {body}"
+        );
+        assert!(
+            !body.contains("src/main.rs"),
+            "project B inherited project A's hot files: {body}"
+        );
+    }
+
+    /// The other half of the same rule: scoping must not break returning.
+    ///
+    /// A, then B, then A again inside the window resumes A's own session. A guard
+    /// that merely refused when the newest session belonged elsewhere would fail
+    /// this, and would have looked like a fix.
+    #[test]
+    fn still_continues_when_returning_to_an_earlier_project() {
+        let (store, _dir) = get_store();
+
+        // Ids are set by hand because `SessionState::new` mints them from a
+        // millisecond clock, so two states built back to back collide and the
+        // second overwrites the first (#490). This test is about scoping, not
+        // about id minting, so it uses ids that are actually distinct.
+        let mut a = SessionState::new();
+        a.session_id = "sess-a".to_string();
+        a.add_error("error from project a");
+        seed_previous_session(&store, &a, "/tmp/project-a");
+
+        let mut b = SessionState::new();
+        b.session_id = "sess-b".to_string();
+        b.add_error("error from project b");
+        seed_previous_session(&store, &b, "/tmp/project-b");
+
+        let input = json!({
+            "hookEventName": "SessionStart",
+            "sessionId": "back-in-a",
+            "workingDirectory": "/tmp/project-a",
+        });
+        let mut cfg = default_config();
+        cfg.force_continue = true;
+
+        let out = process_payload(&input.to_string(), store.clone(), cfg)
+            .expect("returning to a project with history continues it");
+
+        assert!(
+            out.contains("error from project a"),
+            "returning to A did not resume A: {out}"
+        );
+        assert!(
+            !out.contains("error from project b"),
+            "returning to A resumed B, which is the bug wearing a different hat: {out}"
+        );
+    }
+
     #[test]
     fn continue_session_injects_summary() {
         let (store, _dir) = get_store();
@@ -635,7 +771,7 @@ mod tests {
         state.add_command("cargo test");
         state.add_error("missing semicolon");
         state.add_hot_file("src/main.rs");
-        store.upsert_session(&state);
+        seed_previous_session(&store, &state, "/tmp");
 
         let input = json!({
             "hookEventName": "SessionStart",
@@ -661,7 +797,7 @@ mod tests {
         let mut state = SessionState::new();
         state.add_hot_file(&"A".repeat(400));
         state.add_error(&"B".repeat(400));
-        store.upsert_session(&state);
+        seed_previous_session(&store, &state, "/tmp");
 
         let input = json!({
             "hookEventName": "SessionStart",
@@ -685,7 +821,7 @@ mod tests {
     fn force_fresh_overrides_continue() {
         let (store, _dir) = get_store();
         let state = SessionState::new();
-        store.upsert_session(&state);
+        seed_previous_session(&store, &state, "/tmp");
 
         let input = json!({
             "hookEventName": "SessionStart",
@@ -706,7 +842,7 @@ mod tests {
         let (store, _dir) = get_store();
         let mut state = SessionState::new();
         state.last_active = Utc::now().timestamp() - (500 * 60); // 500 minutes ago
-        store.upsert_session(&state);
+        seed_previous_session(&store, &state, "/tmp");
 
         let input = json!({
             "hookEventName": "SessionStart",
@@ -778,7 +914,13 @@ mod tests {
         let (store, _dir) = get_store();
         let mut state = SessionState::new();
         state.add_command("cargo test");
-        store.upsert_session(&state);
+        seed_previous_session(
+            &store,
+            &state,
+            &std::env::current_dir()
+                .map(|p| p.to_string_lossy().to_string())
+                .unwrap_or_else(|_| ".".to_string()),
+        );
 
         let input = json!({
             "hookEventName": "BeforeAgentStart",
@@ -799,7 +941,7 @@ mod tests {
         let mut state = SessionState::new();
         state.add_command("cargo build");
         state.add_hot_file("src/main.rs");
-        store.upsert_session(&state);
+        seed_previous_session(&store, &state, "/tmp");
 
         let input = json!({
             "hookEventName": "BeforeAgentStart",
@@ -865,7 +1007,7 @@ mod tests {
         let (store, _dir) = get_store();
         let mut state = SessionState::new();
         state.last_active = Utc::now().timestamp() - (500 * 60);
-        store.upsert_session(&state);
+        seed_previous_session(&store, &state, "/tmp");
 
         let input = json!({
             "hookEventName": "BeforeAgentStart",
@@ -893,7 +1035,7 @@ mod tests {
         let mut state = SessionState::new();
         state.add_hot_file("secret.txt");
         state.add_command("cat secret.txt");
-        store.upsert_session(&state);
+        seed_previous_session(&store, &state, "/tmp");
 
         let input = json!({
             "hookEventName": "SessionStart",

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -1264,6 +1264,40 @@ impl SqliteBackend {
         );
     }
 
+    /// The most recent session **this agent had in this project**.
+    ///
+    /// `sessions` has no project column and its id is a wall-clock stamp, so the
+    /// project comes from `agent_sessions`, which is already keyed
+    /// `(agent_id, project_hash)` and already written on every session start and
+    /// end. Joining is what lets a session be found for one repository without
+    /// giving `sessions` a schema it does not have.
+    ///
+    /// Returning `None` for a project this agent has never worked in is the
+    /// answer, not a miss: the caller then starts fresh, which is what should
+    /// happen the first time you open a repository (#482).
+    pub fn find_latest_session_for_project(
+        &self,
+        agent_id: &str,
+        project_hash: &str,
+    ) -> Option<SessionState> {
+        let conn = self.pool.get().ok()?;
+        let state_json: Option<String> = conn
+            .query_row(
+                "SELECT s.state_json
+                 FROM sessions s
+                 JOIN agent_sessions a ON a.session_id = s.id
+                 WHERE a.agent_id = ?1 AND a.project_hash = ?2
+                 ORDER BY s.last_active DESC
+                 LIMIT 1",
+                params![agent_id, project_hash],
+                |row| row.get(0),
+            )
+            .optional()
+            .unwrap_or(None);
+
+        state_json.and_then(|json| serde_json::from_str(&json).ok())
+    }
+
     pub fn find_latest_session(&self) -> Option<SessionState> {
         let conn = match self.pool.get() {
             Ok(c) => c,


### PR DESCRIPTION
Closes #482

Continuation was decided by

```sql
SELECT state_json FROM sessions ORDER BY last_active DESC LIMIT 1
```

over every session on the machine. Opening a second repository inside the 240
minute TTL therefore continued the first one's session and inherited its task
hint, hot files, active errors and command history. Measured on a live database:
**one session id spanning six project hashes**, and only two sessions in the whole
file.

This is #118 item 1, which is closed. That fix addressed the analytics and the
ledger, and the ledger was deliberately moved onto the **host** session id for
exactly this reason. The session state was never moved with it.

`find_latest_session_for_project` joins `agent_sessions`, already keyed
`(agent_id, project_hash)` and already written on session start and end. No schema
change and no new field on `SessionState`. Asking **per project**, rather than
merely refusing to continue across a boundary, also handles returning: A, then B,
then A again inside the window resumes A's own session.

## Two things this turned up

**A fresh session never recorded its project.** `sync_agent_session` was called
only in the continued branch, so scoping alone would have deadlocked: the first
session in a repository leaves no row, the next finds nothing, forever. It also
means `get_active_agents_for_project` could not see an agent whose session had
just started, which is when a second agent most wants to know.

**Seven test fixtures described a state the product never produces**, seeding a
previous session with `upsert_session` alone. They passed only because
continuation ignored the project. `seed_previous_session` writes both rows.

Both continuation doors are fixed. `BeforeAgentStart` carried the same unscoped
lookup, and fixing one and leaving the other is the failure this repository keeps
repeating.

## Filed, not fixed here

**#490**: `SessionState::new` mints its id from a millisecond clock, so two
sessions created in the same millisecond are the same session and `INSERT OR
REPLACE` keeps one. Found because the returning test hit it. It narrows this fix
in that case and deserves its own change; the test sets explicit ids so it
measures scoping rather than id minting.

## Verified

```
cargo fmt --all -- --check                                   clean
cargo clippy --all-targets --all-features -- -D warnings     clean
cargo test --all                                             1713 passed, 0 failed
```

Teeth: restoring `find_latest_session()` turns
`does_not_continue_a_session_from_another_project` red, and restoring the fix
turns it green. The returning test stays green under that break, correctly, since
it guards the opposite failure.
