### PR TITLE
fix(website): the page title sat level with the bottom of the menu bar

### DIFF
--- a/docs/website/src/index.md
+++ b/docs/website/src/index.md
@@ -1,4 +1,3 @@
-#
 # OMNI
 
 Your agent reads terminal output. Most of that output is noise, and you pay for

--- a/docs/website/theme/omni.css
+++ b/docs/website/theme/omni.css
@@ -219,6 +219,14 @@ body { font-size: var(--text-body); line-height: var(--wl-leading-body); -webkit
   margin-inline-start: 0;
   margin-inline-end: auto;
   padding-inline-start: 1.5rem;
+  /* The page title's box started level with the bottom of the menu bar on 37 of
+     38 pages, measured: bar bottom 51, h1 top 51, gap 0. A heading's own top
+     margin collapses straight through `main`, which has no padding or border to
+     stop it, so the answer has to be padding here rather than a margin
+     anywhere. index.md had been carrying a bare `#` on line 1 to buy the space;
+     it renders to nothing at all, which is why that page measured 18 and the
+     other 37 measured 0. */
+  padding-block-start: 4rem;
 }
 
 /* Below the point where the outline plus the measure fit beside the sidebar,


### PR DESCRIPTION
Reported as the title sitting too close to the bar. It is, and the measurement
is flat across the manual:

```
before   bar bottom 51, h1 top 51, gap 0    on 37 of 38 pages
         bar bottom 51, h1 top 69, gap 18   on index
after    bar bottom 51, h1 top 91, gap 40   on all of them
```

The title's box begins exactly where the bar ends. A heading's own top margin
collapses straight through `main`, which has no padding or border to stop it, so
the fix has to be padding on `main` rather than a margin on the heading. 4rem is
40px against this book's 10px root.

**index.md was carrying a bare `#` on line 1 to buy that space, and it does not
work.** It renders to nothing: the generated HTML goes from `<main>` straight to
`<h1 id="omni">`, so index's 18px was margin collapsing differently, not the
empty heading doing anything. The suggestion was to copy that line into the other
37 files; this removes it instead. Copying it would have been 38 files edited for
an effect that is not there, a rule every future page has to remember, and an
empty heading in every page outline.

Measured after, over CDP, on index, what-it-is, commands, install and
benchmarks: 40px on every one.
