### PR TITLE
fix(session): a session id that identifies a session

### DIFF
--- a/src/hooks/session_start.rs
+++ b/src/hooks/session_start.rs
@@ -727,10 +727,11 @@ mod tests {
     fn still_continues_when_returning_to_an_earlier_project() {
         let (store, _dir) = get_store();
 
-        // Ids are set by hand because `SessionState::new` mints them from a
-        // millisecond clock, so two states built back to back collide and the
-        // second overwrites the first (#490). This test is about scoping, not
-        // about id minting, so it uses ids that are actually distinct.
+        // Ids are set by hand so this test cannot depend on how they are minted.
+        // It was a workaround when `SessionState::new` read a millisecond clock
+        // and two states built back to back collided; #490 fixed that, and the
+        // explicit ids stay because a scoping test should not be able to fail for
+        // a reason that has nothing to do with scoping.
         let mut a = SessionState::new();
         a.session_id = "sess-a".to_string();
         a.add_error("error from project a");

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -452,8 +452,34 @@ pub struct DistillSummary {
 }
 
 impl SessionState {
+    /// A session id that identifies a session.
+    ///
+    /// It was `timestamp_millis()` alone, so two sessions created in the same
+    /// millisecond were the same session, and `INSERT OR REPLACE INTO sessions`
+    /// kept one of them (#490). That is not hypothetical on a machine running
+    /// several agents: two `SessionStart` hooks landing together is exactly when
+    /// it fires.
+    ///
+    /// The millisecond stays first because four call sites slice
+    /// `session_id[..8]` for display, and it keeps ids roughly sortable by age.
+    /// The process id separates concurrent hooks, which are separate processes,
+    /// and the counter separates sessions minted inside one process. Both are
+    /// stdlib; a uuid crate for this would be a dependency to avoid a format
+    /// string.
+    ///
+    /// This does not make the id meaningful. It is still minted state rather than
+    /// an identity the host supplied, which is why the ledger scopes on
+    /// `host_session()` instead. The fuller fix is to stop minting where a host
+    /// id exists, and it is not this one.
     pub fn new() -> Self {
-        let id = format!("{}", chrono::Utc::now().timestamp_millis());
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static MINTED: AtomicU64 = AtomicU64::new(0);
+        let id = format!(
+            "{}-{}-{}",
+            chrono::Utc::now().timestamp_millis(),
+            std::process::id(),
+            MINTED.fetch_add(1, Ordering::Relaxed)
+        );
         let now = chrono::Utc::now().timestamp();
         let mut state = Self {
             session_id: id,
@@ -620,6 +646,44 @@ impl SessionState {
                     && gap >= PRESSURE_WARNING_COOLDOWN
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod session_id_tests {
+    use super::SessionState;
+
+    /// Two sessions are two sessions (#490).
+    ///
+    /// The id was a millisecond clock reading, so a pair minted in the same
+    /// millisecond collided and `INSERT OR REPLACE INTO sessions` kept one. Found
+    /// while writing #482's regression test, which creates two states back to
+    /// back and could not tell them apart.
+    #[test]
+    fn mints_a_distinct_id_every_time() {
+        let ids: Vec<String> = (0..1000).map(|_| SessionState::new().session_id).collect();
+        let unique: std::collections::HashSet<&String> = ids.iter().collect();
+        assert_eq!(
+            unique.len(),
+            ids.len(),
+            "ids collided: {} distinct out of {}",
+            unique.len(),
+            ids.len()
+        );
+    }
+
+    /// Four call sites render `session_id[..8]`, and byte slicing panics off a
+    /// char boundary, so the id has to stay ASCII and long enough to survive it.
+    #[test]
+    fn stays_sliceable_for_display() {
+        let id = SessionState::new().session_id;
+        assert!(id.len() >= 12, "too short to slice: {id}");
+        assert!(id.is_ascii(), "not ascii, [..8] could panic: {id}");
+        // The assertion above is the boundary proof clippy wants, and slicing is
+        // the point of the test: it reproduces exactly what the four display call
+        // sites do.
+        #[allow(clippy::string_slice, reason = "asserted ascii on the line above")]
+        let _ = &id[..8];
     }
 }
 


### PR DESCRIPTION
Closes #490

`SessionState::new` read a millisecond clock and nothing else, so two sessions created in the same millisecond were the same session and `INSERT OR REPLACE INTO sessions` kept one of them.

**Not a rare edge.** Minting a thousand states in a loop produces **4 distinct ids**. Two `SessionStart` hooks landing together is exactly the case that matters, because that is a machine running more than one agent.

```
ids collided: 4 distinct out of 1000
```

## The shape

`{millis}-{pid}-{counter}`. The millisecond stays first because four call sites render `session_id[..8]` and it keeps ids roughly sortable by age. The process id separates concurrent hooks, which are separate processes. The counter separates sessions minted inside one process.

Both are stdlib. A uuid crate to avoid a format string would be a dependency bought for nothing.

**This does not make the id meaningful**, and the doc comment says so. It is still minted state rather than an identity the host supplied, which is why the ledger scopes on `host_session()` instead. The fuller fix is to stop minting where a host id exists, and it is not this one.

## Verified

```
cargo fmt --all -- --check                                   clean
cargo clippy --all-targets --all-features -- -D warnings     clean
cargo test --all                                             1721 passed, 0 failed
```

Two tests. One mints a thousand and requires them distinct, which fails at 4 of 1000 with the bare clock restored. The other pins the properties the display sites depend on, ascii and at least twelve characters, since byte slicing panics off a char boundary. The clippy allow on that slice carries its reason: the assertion directly above it is the boundary proof.

#482's regression test no longer needs its explicit ids but keeps them, because a scoping test should not be able to fail for a reason that has nothing to do with scoping.