### PR TITLE
fix(pipeline): treat `run` as a wrapper, so container stdout survives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`kubectl run` container stdout was judged as kubectl output, so every payload line was dropped (#497)**: `wraps_another_command` recognised `exec` and not `run`, so `kubectl run --rm -i -- <cmd>` was routed to the kubectl grammar. An eight-line probe came back as `pod "omni-repro" deleted` plus a marker: the one line kubectl prints itself survived and the eight the command was run for did not. `run` now counts as a wrapper for `kubectl`, `docker` and `podman`, the same as `exec`.
+
+  The failure is silent in the direction that matters, because a probe returning nothing is a plausible result and nothing in the delivered text separates it from an answer that was thrown away. **The two doors disagreed**: the same payload through `hooks::post_tool` was never rewritten, so only `hooks::pipe` destroyed it, which is why a post-hook probe reported no defect. The corpus cannot arbitrate the widening to `docker` and `podman`: it holds two `podman run` and no `kubectl run` in 6,656 commands.
+
 ## [0.7.2] - 2026-08-12
 
 The release that stopped four published numbers from being wrong, and paid 0.06% to

--- a/src/pipeline/registry.rs
+++ b/src/pipeline/registry.rs
@@ -629,10 +629,27 @@ fn wraps_another_command(command: &str) -> bool {
         // `ssh host '<cmd>'`, but not `ssh host` alone, which is interactive and
         // produces nothing to distil either way.
         Some("ssh") => true,
-        // `kubectl exec … -- <cmd>`, `docker exec … <cmd>`, `podman exec …`.
-        Some("kubectl") | Some("docker") | Some("podman") => {
-            command.split_whitespace().any(|t| t == "exec")
-        }
+        // `kubectl exec … -- <cmd>`, `docker exec … <cmd>`, `podman exec …`,
+        // and `run`, which is the same thing with a container created first.
+        //
+        // `kubectl run --rm -i -- <cmd>` is the standard way to probe from inside
+        // a cluster, and its stdout is arbitrary program output. Routed here it
+        // was judged against kubectl's grammar, which `curl` headers, `nc`
+        // results and `openssl` output were never going to match, so all eight
+        // payload lines were discarded and the one line kubectl prints itself,
+        // `pod "…" deleted`, was kept (#497).
+        //
+        // That reads like a probe that ran and found nothing, which is a
+        // plausible answer, so there is no way to tell it from the endpoint
+        // actually being silent without a retrieval on every call.
+        //
+        // `run` is included for docker and podman too. The reasoning does not
+        // change with the binary, and fixing one door and leaving the others is
+        // how #112 and #234 kept coming back. The corpus cannot arbitrate:
+        // 6,656 recorded commands hold two `podman run` and no `kubectl run`.
+        Some("kubectl") | Some("docker") | Some("podman") => command
+            .split_whitespace()
+            .any(|t| t == "exec" || t == "run"),
         // `az aks command invoke -c '<cmd>'`.
         Some("az") => command.contains("command invoke"),
         _ => false,
@@ -1103,6 +1120,16 @@ mod tests {
         assert!(wraps_another_command("kubectl exec pod -- ls"));
         assert!(wraps_another_command("az aks command invoke -c 'ls'"));
         assert!(wraps_another_command("ssh host 'ls'"));
+
+        // `run` creates the container first and then hands back the program's
+        // stdout, which is the same thing `exec` does (#497). The reported case
+        // lost all eight payload lines and kept `pod "…" deleted`, which reads
+        // like a probe that found nothing.
+        assert!(wraps_another_command(
+            "kubectl -n probe run p --rm -i --restart=Never --image=busybox --command -- sh -c 'echo hi'"
+        ));
+        assert!(wraps_another_command("docker run --rm busybox echo hi"));
+        assert!(wraps_another_command("podman run --rm alpine ls"));
 
         assert!(!wraps_another_command("kubectl get pods"));
         assert!(!wraps_another_command("az aks show -n cluster"));


### PR DESCRIPTION
`wraps_another_command` recognised `exec` and not `run`, so `kubectl run --rm -i -- <cmd>` was routed to the kubectl grammar. The reported eight-line probe came back as `pod "omni-repro" deleted` and a marker: the one line kubectl prints itself survived, the eight the command was run for did not.

`run` now counts alongside `exec` for kubectl, docker and podman. Widening past kubectl is deliberate, the reasoning does not change with the binary. The corpus cannot arbitrate it either way: 6,656 recorded commands hold two `podman run` and no `kubectl run`.

**The two doors disagreed, and that is why it first looked unreproducible.** The same payload through `hooks::post_tool` is never rewritten, so a post-hook probe reports no defect. Only `hooks::pipe` destroys it. Reproduced through the pipe against the installed 0.7.2 and against `main`:

```
$ OMNI_CMD="kubectl ... run omni-repro --rm -i ... -- sh -c '...'" omni < payload
pod "omni-repro" deleted
[OMNI: 8 lines omitted, omni retrieve 157beec2a1d5fa10 for full output]
[OMNI Active] ⏺ 33.1% reduction (145 B → 97 B) 5ms
```

With the fix, all nine lines arrive. Removing just the `run` arm puts the two-line output back, and the regression test panics on the `kubectl run` assertion.

```
passed=1719 failed=0     # cargo test --all, isolated OMNI_DB_PATH
fmt rc=0  clippy rc=0    # --all-targets -D warnings
```

Closes #497
