### PR TITLE
Record which agent the ledger showed each line to, and document how it remembers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **The ledger records which agent it showed each line to (#509)**: `ledger_lines` was keyed `(scope, line_hash)` with no agent anywhere, and the project scope is the working directory string alone. Two agents in one repo therefore write into one history and read from it, so a fold can hand agent B a `from an earlier session` marker for bytes only agent A ever received, and nothing in the data could say how often that happens.
+
+  **Recorded, not keyed on, because the measurement decides that.** `PROJECT_FLOOR_MULT = 3` was calibrated in #448 on cross-session repetition within one agent, and keying the scope on `(project, agent_id)` would end the cross-agent case along with whatever reuse in it is real. On the maintainer's corpus 1 of 28 project paths carries two agent ids and the second is `terminal`, so the effect is latent rather than live, which is the argument for a column now and a decision later. `INSERT OR IGNORE` keeps the first writer, so an existing row names the agent that was actually shown that line rather than the last one to repeat it. The id is the caller's resolved value, never `detect_agent_id()` at the write: a Codex payload arriving while `CLAUDECODE` is set answers `claude_code` to the naive check, which is the exact distinction the column exists to make.
+
 ### Fixed
 - **The 50 KB safety truncation kept the head and cut the answer (#508)**: on a 1,400 line synthetic log the cut returned 817 routine `status=200` lines and removed the single `RuntimeError: FATAL: connection pool exhausted` line, which was the last in the stream, under a footer reporting 42% saved. On the stdout of a failing command the answer is at the end: the stack trace, the exit reason, the last error before the process died. The cut is now a middle elision that reserves a fifth of the budget for the tail, so both ends survive.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `cargo tree --edges normal` goes 220 to 218 unique crates, and the full tree 265 to 237. No runtime behaviour changes.
 
 ### Changed
+- **The ledger page now says how it remembers (#511)**: it explained what the ledger is worth and which claim each marker makes, and never store, retrieve or forget. Added the premise the whole design follows from, a flow of one command through the stage, the two tables and why hashes and bytes live apart, retrieval as an exact lookup with no ranking or candidate set, and the three ways it forgets: compaction drops the session scope, 30 days prunes both, and nothing is evicted by size. Also what two agents in one repo share, which is the project scope keyed on the directory alone (#509), and the corresponding note on `Reading the markers` and `Memory across sessions`.
+
+  The page carried a warning about #465 as a live defect. It has been closed since 0.7.3, so the text now describes the fix, that only delivered lines are recorded, as part of the flow.
+
 - **The README now demos the half we win on (#503)**: the existing pair shows `git log` compression, which is filter work, and filters are 2.7% on our own corpus against rtk's 6.2%. A new pair shows the ledger instead: the same file read twice in one session, where the second read comes back as one marker and a retrieval handle. Measured on 0.7.3 through the Homebrew binary, `cat src/guard/limits.rs` twice is 7.6 KB then 214 B, a 97.2% reduction on the second call.
 
   **Figures re-measured on 0.7.3 across the manual and the translations.** Same 6,656-trace corpus, so the only variable is the build. The aggregate is unchanged at 14.9% and three cells moved: other 6.8 to 6.9, file read 25.2 to 25.0, `git` 22.3 to 22.1. The tape carries `unset OMNI_PASSTHROUGH`, because `vhs` inherits the recorder's environment and a stray passthrough records a second read that never folds, which is the claim backwards.

--- a/docs/website/src/concepts/the-ledger.md
+++ b/docs/website/src/concepts/the-ledger.md
@@ -45,11 +45,157 @@ Because the project claim is not free, it carries a higher bar. A session-origin
 must save 150 bytes over its marker; a project-origin run must save three times that,
 since the agent has no choice about paying a retrieval if it needs the content.
 
-> There is a known defect here as of 0.7.2. A run that was folded gets recorded as
-> shown in the session scope, even though only the marker was delivered, so the next
-> occurrence in that session says `already shown` about bytes it never received and
-> folds at a third of the intended bar. Tracked as
-> [#465](https://github.com/fajarhide/omni/issues/465).
+## The premise everything else follows from
+
+> The agent is still holding these bytes.
+
+That single statement is what licenses replacing forty lines with a handle. Every rule
+below is either a consequence of it or a defence of the moment it stops being true.
+When you find yourself asking why the ledger does something, ask what it would take
+for the premise to be false, and the answer is usually there.
+
+It is also why this is a cache invalidation problem and not a memory system. The
+ledger does not store knowledge. It stores receipts.
+
+## The flow, one command at a time
+
+```
+  command output
+        │
+        ▼
+  ┌───────────────┐   structured?  ──yes──▶  untouched, ledger never sees it
+  │  format sniff │
+  └───────┬───────┘
+          │ no
+          ▼
+  ┌───────────────────────────────────────────────┐
+  │ split into lines, hash each one (trimmed)     │
+  └───────┬───────────────────────────────────────┘
+          │
+          ▼
+  ┌───────────────────────────────────────────────┐
+  │ which have been seen?                         │
+  │   session scope   ──▶ Origin::Session         │
+  │   project scope   ──▶ Origin::Project         │
+  │   states a failure ─▶ never folded            │
+  └───────┬───────────────────────────────────────┘
+          │
+          ▼
+  ┌───────────────────────────────────────────────┐
+  │ group consecutive lines that agree            │
+  │ per run: does it save more than its marker?   │
+  └───────┬───────────────────────────────────────┘
+          │ yes                          │ no
+          ▼                              ▼
+  ┌────────────────────┐          run stays verbatim
+  │ archive the run    │
+  │ (rewind_store)     │──failed──▶ run stays verbatim
+  └────────┬───────────┘
+           │ stored
+           ▼
+  ┌────────────────────┐
+  │ write the marker   │
+  └────────┬───────────┘
+           │
+           ▼
+  record every line that was DELIVERED, into both scopes
+           │
+           ▼
+     output to the agent
+```
+
+Two details in that diagram are easy to read past and are the whole correctness story.
+
+The archive happens **before** the marker, so a handle never names content that was
+not stored. And what gets recorded is what was **delivered**, not what arrived: a run
+that became a marker never reached the agent, so recording it would let the next
+occurrence claim `already shown` about bytes nobody received. That was a real defect
+([#465](https://github.com/fajarhide/omni/issues/465)) and it cut both ways, because
+session origin charges a third of what project origin does, so the false claim also
+made the ledger three times more willing to fold.
+
+## How it remembers
+
+Three verbs, and each one is a different table or a different trigger.
+
+### Store
+
+Two tables, on purpose.
+
+| | holds | size |
+|---|---|---|
+| `ledger_lines` | `(scope, line_hash, ts, agent_id)` | 16 bytes of hash per line |
+| `rewind_store` | the actual bytes of a folded run, keyed by their SHA-256 | the content, once per distinct block |
+
+Recording every emitted line is cheap because the line itself is never stored, only
+its hash. The content only goes to the archive when a handle is actually issued.
+
+The hash is taken on the **trimmed** line, so the same line reached through `sed -n`
+and through `cat` is one line rather than two.
+
+**Recording is unconditional; folding is not.** A block is worth remembering because
+it may show up again, not because it compressed today. So a command whose output is
+entirely new still writes its lines, and pays for itself the next time.
+
+### Retrieve
+
+```sh
+omni retrieve 3f7bfd89bc5d7cee
+```
+
+An exact lookup on a content address. There is no candidate set, no ranking, no
+merging of results, and no search: one handle names one block of bytes. The handle is
+derived from the content, so identical output is one row however many commands
+produced it.
+
+Nothing is ever pulled back automatically. The marker is a pointer, and the agent
+decides whether the content is worth a retrieval. That is the trade the whole design
+rests on: the worst case is not "the answer is gone", it is "the answer costs one
+round trip".
+
+Where MCP is wired the agent calls `omni_retrieve` itself. Otherwise it runs the shell
+command the marker printed.
+
+### Forget
+
+Time, plus one event.
+
+**At compaction, the session scope is dropped entirely.** Compaction is the moment
+inside a session where the agent stops holding what it was shown, so every claim the
+session scope could make becomes false at once. Forgetting costs a missed reduction.
+Not forgetting means telling an agent it has content its context no longer contains,
+which is the defect, not the cost.
+
+**At 30 days, both scopes prune on the same window.** A session scope cannot outlive
+its session, so the ordinary retention window already bounds it. The project scope is
+the one that could grow without limit, and the honest bound on it is the same window:
+content nobody has produced in a month is content this project has stopped emitting,
+and a handle for it buys a retrieval of something the agent will not recognise either.
+
+A repeat refreshes the timestamp rather than being ignored, so output that is still
+being produced does not age out on the strength of when it was first seen.
+
+There is no eviction by size, and that is deliberate. Evicting by size drops the
+oldest rows of the busiest project first, which is exactly where the repeats are.
+
+## What two agents in one repo share
+
+The session scope is one agent's, because a host session id belongs to one host. The
+**project scope is keyed on the working directory and nothing else**, so two agents
+running in the same repository write into one history and read from it.
+
+That is sharing by side effect rather than by design. Nothing in the ledger knows
+which agent it is talking to, so a project-origin marker can hand agent B a handle for
+lines only agent A was ever shown. The wording is still true, those lines did come
+from an earlier session, and the higher bar means the trade is priced as a retrieval
+either way. But `from an earlier session` reads as *your* earlier session, and it
+might not be.
+
+As of [#509](https://github.com/fajarhide/omni/issues/509) the agent is recorded on
+every line, and nothing keys on it yet. The measurement decides that: keying the scope
+on `(project, agent)` would end the cross-agent case together with whatever reuse in
+it is genuinely free, and the corpus says the effect is currently latent rather than
+live. The column is what makes it possible to ask.
 
 ## The rules it inherits
 
@@ -62,8 +208,8 @@ retroactive compaction would destroy it.
 a content address and carries no timestamp. An earlier design used
 `{timestamp}_{hash}` and made 4 of 73 repeated inputs emit different bytes.
 
-**Nothing is lost.** A run is archived before its marker is written, and a failed
-archive leaves the run verbatim.
+**Nothing is lost.** Stated above and enforced by the order of two writes. The general
+rule and what it costs are in [Nothing is deleted](nothing-is-deleted.md).
 
 **Failures are never folded.** A line stating a failure is exempt however often it
 has been shown. "You have seen this already" is sound for informational lines and

--- a/docs/website/src/use/markers.md
+++ b/docs/website/src/use/markers.md
@@ -30,6 +30,10 @@ project, and this agent has never seen them. The wording is deliberately not "al
 shown", because that would be false. Folding them is a bet that the agent will not
 need them, and it carries three times the profitability bar for that reason.
 
+That other session may also have been a different agent. The project history is keyed
+on the directory, so anything running in this repository contributes to it. See
+[what two agents share](../concepts/the-ledger.md#what-two-agents-in-one-repo-share).
+
 ```
 [N similar lines collapsed]
 ```

--- a/docs/website/src/use/memory.md
+++ b/docs/website/src/use/memory.md
@@ -16,6 +16,13 @@ The short answer to "will OMNI still know my project after a month away" is yes 
 the conclusions and no for the raw bytes. The boundary that matters in practice:
 `omni retrieve` on content archived more than 30 days ago will not resolve.
 
+The ledger has one more way of forgetting that is not on a clock. **At compaction its
+session half is dropped entirely**, because compaction is where the agent stops
+holding what it was shown, and every "already shown" claim becomes false at the same
+moment. If folding seems to stop after a long session compacts, that is this, working.
+The project half survives, and [The ledger](../concepts/the-ledger.md#forget) explains
+the split.
+
 ## Pinning a goal
 
 ```sh

--- a/src/hooks/pipe.rs
+++ b/src/hooks/pipe.rs
@@ -348,6 +348,7 @@ fn distill(
         && crate::pipeline::format::sniff(&output).is_none()
         && let Some(view) = crate::ledger::Ledger::new(s, scope)
             .with_project(&project_path)
+            .by(resolve_pipe_agent_id())
             .project(&output)
     {
         output = view;

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -392,6 +392,7 @@ fn fold_cross_turn(
         .unwrap_or_else(|_| "unknown".to_string());
     crate::ledger::Ledger::new(s, scope)
         .with_project(&project)
+        .by(crate::hooks::normalize::stats_agent_id(&normalized.agent))
         .project(&text)
         .unwrap_or(text)
 }
@@ -672,6 +673,7 @@ pub fn process_payload(
         && crate::pipeline::format::sniff(&final_out).is_none()
         && let Some(view) = crate::ledger::Ledger::new(s, scope)
             .with_project(&project_path)
+            .by(_agent_id)
             .project(&final_out)
     {
         final_out = view;
@@ -1285,6 +1287,52 @@ mod tests {
         );
 
         assert_eq!(retrieval, None, "a retrieval must reach the agent verbatim");
+    }
+
+    /// #509 at the boundary the unit test cannot see: the hook has three agent
+    /// ids in scope and only one of them is the resolved host. Asserting a
+    /// literal here would read the ambient environment (`CLAUDECODE` is set
+    /// while developing under Claude Code, and unset on CI), so the check is
+    /// that the ledger row and the distillation row for the same call agree.
+    /// They are written from one value, and any rewiring that reaches for
+    /// `normalized.agent_id` or hardcodes a default separates them.
+    #[test]
+    fn files_a_ledger_line_under_the_same_agent_as_its_distillation() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = dir.path().join("omni.db");
+        let store = Arc::new(Store::open_path(&db).expect("store"));
+        let repetitive = (0..200)
+            .map(|i| format!("2026-08-11T00:00:00Z  handler finished request {i} in 12ms\n"))
+            .collect::<String>();
+        let payload = serde_json::json!({
+            "session_id": "s-agent",
+            "tool_name": "Bash",
+            "tool_input": {"command": "cat log.txt"},
+            "tool_response": {"stdout": repetitive, "stderr": ""}
+        })
+        .to_string();
+
+        let _ = process_payload(&payload, Some(store.clone()), None);
+
+        let conn = rusqlite::Connection::open(&db).expect("open");
+        let ledger: Vec<String> = conn
+            .prepare("SELECT DISTINCT agent_id FROM ledger_lines")
+            .and_then(|mut s| {
+                s.query_map([], |r| r.get(0))?
+                    .collect::<rusqlite::Result<Vec<String>>>()
+            })
+            .expect("ledger agents");
+        let distilled: String = conn
+            .query_row("SELECT agent_id FROM distillations LIMIT 1", [], |r| {
+                r.get(0)
+            })
+            .expect("a distillation row");
+
+        assert_eq!(
+            ledger,
+            vec![distilled.clone()],
+            "the ledger filed lines under a different agent than the call they came from ({distilled})"
+        );
     }
 
     /// #379: a rewritten command was recorded twice. `omni exec` distills the

--- a/src/ledger/mod.rs
+++ b/src/ledger/mod.rs
@@ -119,6 +119,13 @@ pub struct Ledger<'a> {
     /// `None` disables project scope entirely, which is what every caller that
     /// cannot name a project passes.
     project: Option<String>,
+    /// Who is being shown these lines, recorded and read by nothing (#509).
+    ///
+    /// The project scope is keyed on the directory alone, so two agents in one
+    /// repo already share a history and a fold cannot tell whose bytes it is
+    /// replacing. Recording the agent is what makes that measurable; changing
+    /// the key is the decision the measurement is for.
+    agent: String,
 }
 
 /// One stretch of output, and where it was seen before if it was.
@@ -134,12 +141,23 @@ impl<'a> Ledger<'a> {
             store,
             scope: scope.into(),
             project: None,
+            agent: "unknown".to_string(),
         }
     }
 
     /// Adds the project history to what this ledger can draw on.
     pub fn with_project(mut self, project: impl Into<String>) -> Self {
         self.project = Some(project.into());
+        self
+    }
+
+    /// Names the agent these lines are being delivered to.
+    ///
+    /// Resolved by the caller rather than from the environment here: a Codex
+    /// payload arriving while `CLAUDECODE` is set answers `claude_code` to the
+    /// naive check, and this column exists precisely to tell hosts apart.
+    pub fn by(mut self, agent: impl Into<String>) -> Self {
+        self.agent = agent.into();
         self
     }
 
@@ -244,13 +262,14 @@ impl<'a> Ledger<'a> {
                 .collect(),
             None => hashes.clone(),
         };
-        self.store.ledger_record(&self.scope, &delivered);
+        self.store
+            .ledger_record(&self.scope, &delivered, &self.agent);
         // The project history is written too, so a later session can draw on this
         // one. Same rows, a second scope key. A folded line is already in both
         // scopes, since that is what made it foldable, so filtering it out of
         // this write changes nothing and keeps the two calls saying one thing.
         if let Some(p) = &self.project {
-            self.store.ledger_record(p, &delivered);
+            self.store.ledger_record(p, &delivered, &self.agent);
         }
 
         projected.map(|(view, _)| view)
@@ -432,6 +451,61 @@ mod tests {
         Ledger::new(&store, "s1").project(&text);
 
         assert_eq!(Ledger::new(&store, "s2").project(&text), None);
+    }
+
+    /// #509. The project scope is one history per directory, so the column is
+    /// the only thing that can say whose lines it holds. `INSERT OR IGNORE`
+    /// keeps the first writer, which is what makes "a different agent was shown
+    /// this" answerable at all: overwriting on a repeat would report the last
+    /// reader as the one who saw it.
+    #[test]
+    fn records_which_agent_was_shown_each_line() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = dir.path().join("omni.db");
+        let store = Store::open_path(&db).expect("store");
+        // Above `MIN_LEDGER_INPUT` and below the project scope's fold bar, so
+        // the second agent is *shown* every line rather than handed a marker.
+        // Sized against the constants because the obvious fixture, the same
+        // 200-line payload the floor test uses, folds the whole run: the second
+        // agent then delivers nothing, writes nothing, and the test passes with
+        // `INSERT OR REPLACE` in place of `INSERT OR IGNORE`.
+        let text: String = (0..6)
+            .map(|i| format!("2026-08-10T00:00:00Z  handler finished request {i} in 12ms\n"))
+            .collect();
+        assert!(
+            text.len() > MIN_LEDGER_INPUT && text.len() < MIN_LEDGER_RUN_GAIN * PROJECT_FLOOR_MULT,
+            "fixture sits on the wrong side of a threshold: {} bytes",
+            text.len()
+        );
+
+        Ledger::new(&store, "s1")
+            .with_project("/repo")
+            .by("claude_code")
+            .project(&text);
+        Ledger::new(&store, "s2")
+            .with_project("/repo")
+            .by("codex")
+            .project(&text);
+
+        let conn = rusqlite::Connection::open(&db).expect("open");
+        let rows = |agent: &str| -> i64 {
+            conn.query_row(
+                "SELECT COUNT(*) FROM ledger_lines WHERE scope = '/repo' AND agent_id = ?1",
+                [agent],
+                |r| r.get(0),
+            )
+            .expect("count")
+        };
+
+        assert!(
+            rows("claude_code") > 0,
+            "the agent the lines were delivered to was not recorded"
+        );
+        assert_eq!(
+            rows("codex"),
+            0,
+            "a repeat rewrote the agent that was actually shown the line"
+        );
     }
 
     /// The whole licence for the project scope. A second session may reuse the

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -469,10 +469,17 @@ impl SqliteBackend {
             -- costs 16 bytes a line rather than a second copy of the corpus.
             -- WITHOUT ROWID because every read is a primary-key probe and the
             -- table is nothing but its key.
+            -- `agent_id` is recorded and read by nothing on the hook path (#509).
+            -- The project scope is the working directory and nothing else, so two
+            -- agents in one repo share a history and neither the fold nor the
+            -- marker can tell them apart. Keying on the agent would end that, and
+            -- would also give up whatever cross-agent reuse is real, which is the
+            -- question this column exists to answer before the key changes.
             CREATE TABLE IF NOT EXISTS ledger_lines (
                 scope     TEXT NOT NULL,
                 line_hash TEXT NOT NULL,
                 ts        INTEGER NOT NULL,
+                agent_id  TEXT NOT NULL DEFAULT 'unknown',
                 PRIMARY KEY (scope, line_hash)
             ) WITHOUT ROWID;
             CREATE INDEX IF NOT EXISTS idx_ledger_ts ON ledger_lines(ts);
@@ -751,6 +758,13 @@ impl SqliteBackend {
         );
         let _ = conn.execute(
             "ALTER TABLE distillations ADD COLUMN filtered_tokens INTEGER DEFAULT 0",
+            [],
+        );
+        // #509. `INSERT OR IGNORE` keeps the first writer, so an existing row is
+        // the agent that first emitted that line into that scope and the default
+        // is honest about rows written before anyone was recorded.
+        let _ = conn.execute(
+            "ALTER TABLE ledger_lines ADD COLUMN agent_id TEXT NOT NULL DEFAULT 'unknown'",
             [],
         );
         // #212: `output_bytes` is what the distiller returned, which is not the
@@ -1670,7 +1684,7 @@ impl SqliteBackend {
     /// One transaction and one cached statement for the whole batch: this is the
     /// loop where `prepare_cached` actually pays, unlike the one-shot statements
     /// a hook process runs once each.
-    pub fn ledger_record(&self, scope: &str, hashes: &[String]) {
+    pub fn ledger_record(&self, scope: &str, hashes: &[String], agent_id: &str) {
         let Ok(mut conn) = self.pool.get() else {
             return;
         };
@@ -1680,12 +1694,13 @@ impl SqliteBackend {
         };
         {
             let Ok(mut stmt) = tx.prepare_cached(
-                "INSERT OR IGNORE INTO ledger_lines (scope, line_hash, ts) VALUES (?1, ?2, ?3)",
+                "INSERT OR IGNORE INTO ledger_lines (scope, line_hash, ts, agent_id)
+                 VALUES (?1, ?2, ?3, ?4)",
             ) else {
                 return;
             };
             for h in hashes {
-                let _ = stmt.execute(params![scope, h, ts]);
+                let _ = stmt.execute(params![scope, h, ts, agent_id]);
             }
         }
         let _ = tx.commit();


### PR DESCRIPTION
`ledger_lines` carried no agent, and the project scope is keyed on the working directory alone, so two agents in one repo share a history and a `from an earlier session` marker can name lines only the other one was shown. This records the agent on every line without keying on it. Keying would end the cross-agent case together with whatever reuse in it is free, and #448 calibrated `PROJECT_FLOOR_MULT = 3` on a single agent, so the column is what makes the decision measurable. On the maintainer's corpus 1 of 28 project paths carries two agent ids and the second is `terminal`, which is why this is latent and not urgent.

The docs half is the other question the page never answered: store, retrieve and forget, a flow for one command, and what two agents share. It also drops a warning box describing #465 as live, closed since 0.7.3.

Two things changed because they were checked rather than assumed. The first unit test passed with `INSERT OR REPLACE` in place: its 200-line fixture folds the whole run for the second agent, which then delivers nothing and writes nothing. Resized to sit above `MIN_LEDGER_INPUT` and below the project fold bar it goes red on the break. And the page briefly claimed the ledger's archive is capped at 64 KB; `MAX_REWIND_BYTES` gates the `post_tool` and `pipe` rewind path, not `store_rewind` as the ledger calls it.

```
fmt 0 · clippy --all-targets -D warnings 0 · cargo test 0 (21 targets) · smoke 44/44
mdbook build rc=0, no warnings; the three new cross-link anchors verified in the built HTML
migration checked on a hand-built old-schema db: column lands on the WITHOUT ROWID table,
pre-existing row reads `unknown`, omni doctor exits 0
```

Closes #509
Closes #511
