### PR TITLE
Stop crediting any process in the group as the command that produced stdin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   **Drawing the pipeline found the page describing it backwards.** `Collapse` was documented as running before `Distill` and feeding it markers. That was true until #116 and wrong for the two releases since: both hooks score and distill the **raw** bytes, and the collapsed form is used only when the distilled one misses `beats_guardrail`. The prose and the stage summary are corrected. `kubectl_table_distills_from_raw_not_collapse_markers` was already pinning the real behaviour, so the code was right and only the description was wrong.
 
   `media/architecture.svg` is deleted. Nothing referenced it, and it carried the drop shadows and mono-for-everything the new set avoids.
+- **Any process in the group could be credited as the command that produced stdin (#516)**: `detect_sibling_command`'s first pass returned the first non-shell line of `ps -o command= -g <pgid>`, with no test that the process had anything to do with the payload. Two failures came out of it, and the second is the one with the row count.
+
+  **Output stopped being deterministic.** Benchmarked through a Node harness whose process group holds an `esbuild --service=... --ping` daemon, a 4,421 byte application log was attributed to esbuild and folded to 129 bytes on one run, then passed through unchanged on the next: same binary, same stdin, same machine, minutes apart. `AGENTS.md` requires deterministic hook output and `ledger` opens by calling determinism a rule it must not break; this sat above both.
+
+  **Its own shell exclusion never fired.** The guard tested `starts_with("zsh ")` and Claude Code invokes `/bin/zsh -c`, so **282 of 289 pipe-path rows in the maintainer's database recorded `/bin/zsh` as the producing command**, dragging the whole shell-snapshot wrapper into `filter_name` and `command`. Re-running the same benchmark on the fix moves all 123 rows from the esbuild path to `[pipe]`.
+
+  The pass is gone. What remains parses an actual `cmd | omni` pipeline out of the group's command lines, which is evidence rather than proximity, and now lives in a pure `pipeline_in` that a test can drive.
+
 
 ### Added
 - **The ledger records which agent it showed each line to (#509)**: `ledger_lines` was keyed `(scope, line_hash)` with no agent anywhere, and the project scope is the working directory string alone. Two agents in one repo therefore write into one history and read from it, so a fold can hand agent B a `from an earlier session` marker for bytes only agent A ever received, and nothing in the data could say how often that happens.

--- a/src/hooks/pipe.rs
+++ b/src/hooks/pipe.rs
@@ -698,6 +698,38 @@ fn emit_output<W: Write, E: Write>(
     Ok(())
 }
 
+/// The command feeding `omni` in a `cmd | omni` pipeline, read out of `ps` output.
+///
+/// Pure so it can be tested: everything above it is `ps` plumbing that a unit test
+/// cannot drive, and everything that decides *which* command gets the credit is here.
+///
+/// **There used to be a pass above this one that returned the first non-shell process
+/// in the group, whatever it was (#516).** A process sharing a process group is not
+/// evidence about what is on stdin, and it produced two failures. It attributed a
+/// payload to an unrelated daemon, so a Node harness whose group held an
+/// `esbuild --service=... --ping` had a 4,421 byte application log routed as esbuild
+/// output, folded to 129 bytes on one run and passed through on the next: identical
+/// stdin, identical binary, two answers. And its own shell exclusion never fired,
+/// because it tested `starts_with("zsh ")` while Claude Code invokes `/bin/zsh -c`,
+/// so **282 of 289 pipe-path rows in the maintainer's database recorded `/bin/zsh` as
+/// the producing command**, carrying the whole shell-snapshot wrapper with them.
+///
+/// What is left needs an actual pipe and an actual `omni` on the right of it, which is
+/// evidence rather than proximity. No match means no command, which is a state the
+/// pipeline already supports: `filter_name` becomes `[pipe]` and the payload takes the
+/// generic path.
+fn pipeline_in(siblings: &str) -> Option<String> {
+    siblings
+        .lines()
+        .map(str::trim)
+        .filter(|line| {
+            (line.contains("sh ") || line.contains("zsh ") || line.contains("bash "))
+                && line.contains('|')
+                && line.contains("omni")
+        })
+        .find_map(extract_command_from_pipeline)
+}
+
 fn detect_sibling_command() -> Option<String> {
     use std::process::Command;
 
@@ -732,39 +764,9 @@ fn detect_sibling_command() -> Option<String> {
         .map(|o| String::from_utf8_lossy(&o.stdout).to_string())
         .unwrap_or_default();
 
-    // 5. Pass 1: Look for an active sibling (real process) in PGID
-    for line in siblings.lines() {
-        let line = line.trim();
-        if line.is_empty() || line.contains("omni") {
-            continue;
-        }
-
-        // Exclude common shells and ps itself
-        if line.starts_with("ps ")
-            || line.starts_with("sh ")
-            || line.starts_with("zsh ")
-            || line.starts_with("bash ")
-            || line.starts_with("grep ")
-        {
-            continue;
-        }
-
-        // Found a candidate sibling command
-        return Some(line.to_string());
-    }
-
-    // 6. Pass 2: Fallback to parsing shell command lines in the PGID
-    for line in siblings.lines() {
-        let line = line.trim();
-        if (line.contains("sh ") || line.contains("zsh ") || line.contains("bash "))
-            && line.contains('|')
-            && line.contains("omni")
-        {
-            #[allow(clippy::collapsible_if)]
-            if let Some(cmd) = extract_command_from_pipeline(line) {
-                return Some(cmd);
-            }
-        }
+    // 5. Parse a real `cmd | omni` pipeline out of the group's command lines.
+    if let Some(cmd) = pipeline_in(&siblings) {
+        return Some(cmd);
     }
 
     // 7. Pass 3: Fallback to Parent Command if no sibling found
@@ -937,6 +939,52 @@ mod tests {
         let out_str = String::from_utf8(out).expect("must succeed");
 
         assert_eq!(out_str, input);
+    }
+
+    /// #516. A process that merely shares a process group is not evidence about what
+    /// is on stdin, and the pass that treated it as evidence made output depend on
+    /// which unrelated daemon happened to be alive. This is the exact `ps -o command=`
+    /// block from the run that produced the report.
+    #[test]
+    fn an_unrelated_daemon_in_the_group_is_not_the_command() {
+        let siblings = "\
+node /path/to/tokenbench/node_modules/.bin/tsx core/src/cli.ts --tools omni
+/path/to/node_modules/@esbuild/darwin-arm64/bin/esbuild --service=0.28.2 --ping
+omni";
+
+        assert_eq!(
+            pipeline_in(siblings),
+            None,
+            "a sibling process was credited as the command that produced stdin"
+        );
+    }
+
+    /// The other half of #516, and the bigger one by row count: the old pass excluded
+    /// shells with `starts_with("zsh ")`, and Claude Code runs `/bin/zsh -c`, so the
+    /// exclusion never fired and 282 of 289 pipe-path rows recorded `/bin/zsh` as the
+    /// producing command, wrapper and all.
+    #[test]
+    fn an_absolute_path_shell_is_not_the_command() {
+        let siblings = "/bin/zsh -c source ~/.claude/shell-snapshots/snap.sh 2>/dev/null || true && eval 'npx tsx cli.ts'";
+
+        assert_eq!(
+            pipeline_in(siblings),
+            None,
+            "the shell wrapper was credited as the command: {:?}",
+            pipeline_in(siblings)
+        );
+    }
+
+    /// What survives, and why the pass is not simply deleted: a real pipeline names
+    /// the command feeding omni, and that is evidence rather than proximity.
+    #[test]
+    fn a_real_pipeline_still_names_its_command() {
+        let siblings = "/bin/zsh -c cat /var/log/app.log | omni\nomni";
+
+        assert_eq!(
+            pipeline_in(siblings),
+            Some("cat /var/log/app.log".to_string())
+        );
     }
 
     /// #456 reached through the sibling door. `post_tool` declined a recovery


### PR DESCRIPTION
Closes #516.

`detect_sibling_command`'s first pass returned the first non-shell line of
`ps -o command= -g <pgid>` and called that the command that produced stdin. Sharing a
process group is not evidence about what is on stdin, and it failed in two ways.

**Output stopped being deterministic.** Benchmarked through a Node harness whose process
group holds an `esbuild --service=... --ping` daemon, a 4,421 byte application log was
attributed to esbuild and folded to 129 bytes on one run, then passed through unchanged
on the next. Same binary, same stdin, same machine, minutes apart. The database is where
this is visible:

```
run 1:  .../@esbuild/darwin-arm64/bin/esbuild --service=0.28.2 --ping | 4421 | 129  | Rewind
run 2:                                                                 | 4421 | 4421 | Passthrough
```

**Its own shell exclusion never fired.** The guard tested `starts_with("zsh ")` and
Claude Code invokes `/bin/zsh -c`, so the shell was never excluded:

```sql
SELECT COUNT(*) FROM distillations WHERE filter_name = '/bin/zsh';   -- 282
SELECT COUNT(*) FROM distillations WHERE filter_name = '[pipe]';     --   7
```

282 of 289 pipe-path rows recorded `/bin/zsh` as the producing command, carrying the
whole shell-snapshot wrapper into `filter_name` and `command`.

The pass is deleted. What remains needs a real pipe with `omni` on the right of it, and
it moved into a pure `pipeline_in` so the rule that decides attribution is testable. No
match means no command, which the pipeline already supports: `filter_name` becomes
`[pipe]` and the payload takes the generic path.

## Verification

`make ci` green: fmt, clippy `-D warnings`, 21 test binaries, security, binary-check
including `smoke_test.sh`.

Re-ran the benchmark that produced the report, on the release build. Every row moves
from the daemon to the honest state:

```
before:  .../@esbuild/darwin-arm64/bin/esbuild | 123 rows
after:   [pipe]                                | 123 rows
```

Three sweeps on the fixed build, `logs` lane 0% reduction and 100% fidelity on all four
categories each time, no anomalous cell.

The three new tests were run against a `pipeline_in` rewritten back to first-process-wins
and all three went red, then were restored:

```
an_unrelated_daemon_in_the_group_is_not_the_command ... FAILED
an_absolute_path_shell_is_not_the_command ... FAILED
a_real_pipeline_still_names_its_command ... FAILED
```

**What is not covered by a test:** that `detect_sibling_command` actually reaches
`pipeline_in`. The `ps` calls above it cannot be driven from a unit test. After this
change that function has no other path that can return a command, which is a thirty line
read, and it is stated here rather than implied.

Noticed in passing and not addressed here: `cargo audit` reports RUSTSEC-2026-0190,
an `unsound` warning on `anyhow` 1.0.102 dated 2026-06-25. It does not fail the gate and
predates this branch.
