### PR TITLE
Put the architecture diagram where the page is named after it, and sweep what the last three releases invalidated

### DIFF
--- a/docs/website/src/concepts/how-it-decides.md
+++ b/docs/website/src/concepts/how-it-decides.md
@@ -1,12 +1,15 @@
 # How it decides what to cut
 
-The pipeline is fixed and every payload walks the same six stages:
+The pipeline is fixed and every payload walks the same stages:
 
 ```
-Read → Guard → Score → Collapse → Distill → Persist
+Read → Guard → Score → Distill → [Collapse] → Ledger → Route → Persist
 ```
 
 None of them is allowed to invent anything, and each one is allowed to decline.
+Collapse is bracketed because it is a fallback rather than a step: it runs only when
+the distilled form failed to beat the guardrail. [The pipeline, stage by
+stage](../develop/pipeline.md) has the diagram and the reasoning.
 
 ## Guard
 
@@ -31,17 +34,6 @@ The tiering happens **before** any distiller sees the block, which matters when 
 are debugging why a distiller behaved oddly: the tier may already have decided the
 outcome, so probe the segment tiers before rewriting the distiller.
 
-## Collapse
-
-Runs of near-identical lines become one line stating the count. Twenty
-`Downloading foo v1.2.3` lines become one.
-
-Two things about this stage surprise people. It runs **before** the distiller, so a
-distiller is often reading `[N similar lines collapsed]` markers rather than the
-original output, and a distiller written as though it sees raw text will misbehave.
-And which collapse mode fires is chosen by specificity, so a `kubectl` command piped
-into `grep` may take the infrastructure path rather than the log path.
-
 ## Distill
 
 Now a tool-specific filter runs, chosen by matching the command. The `cargo test`
@@ -61,6 +53,25 @@ and the caller hands back the raw bytes. That is the difference between "I read 
 and here is what matters" and "I recognised nothing and here is a confident summary
 of it", and it is enforced by the compiler for all 12 rather than by each author
 remembering to check.
+
+## Collapse
+
+Runs of near-identical lines become one line stating the count. Twenty
+`Downloading foo v1.2.3` lines become one.
+
+Two things about this stage surprise people. It runs **after** the distiller and only
+when the distiller did not earn its keep: both hooks distill the raw bytes, ask
+`beats_guardrail`, and reach for the collapsed form only if that fails. So a distiller
+always reads the original output, never `[N similar lines collapsed]` markers. And
+which collapse mode fires is chosen by specificity, so a `kubectl` command piped into
+`grep` may take the infrastructure path rather than the log path.
+
+## Ledger
+
+Everything above judges this payload on its own. The ledger is the one stage that
+judges it against what the agent has already been shown, replacing a run of repeated
+lines with a marker and a handle. It is the largest single source of savings and it
+has its own page: [The ledger](the-ledger.md).
 
 ## Persist
 

--- a/docs/website/src/concepts/what-it-is.md
+++ b/docs/website/src/concepts/what-it-is.md
@@ -34,17 +34,11 @@ remembers what your agent has already been shown, and never guesses when it is u
 
 Every serious agent host can run a program when a tool finishes and use what that
 program returns. Claude Code calls it a `PostToolUse` hook, Cursor and the others have
-their own name for the same idea. OMNI installs itself there.
+their own name for the same idea. OMNI installs itself there, and in the matching slot
+before the tool runs, which it uses only to hand a matched command to itself. The
+command still runs unchanged; the shell never knows.
 
-```
-your command  →  the host runs it  →  raw output
-                                          │
-                                    OMNI's hook
-                                          │
-                              distilled output  →  the agent's context
-                                          │
-                                   raw output  →  local SQLite archive
-```
+![OMNI runs as two hooks around a tool call: a pre-hook before the command, a post-hook that distills the output before the agent reads it, with everything it removes archived to a local SQLite database that omni retrieve reads back.](../media/where-omni-sits.svg)
 
 Two consequences follow from that position, and they are the reason this shape was
 chosen over a proxy.

--- a/docs/website/src/develop/architecture.md
+++ b/docs/website/src/develop/architecture.md
@@ -15,9 +15,9 @@ src/
 ├── guard/               safety, limits, trust bounds, env hygiene
 ├── hooks/               the entry points, and the dispatcher that routes them
 ├── ledger/              cross-turn line dedup
-├── mcp/                 the MCP server and its 26 tools
-├── pipeline/            scorer, collapse, registry, format gate, toml filters
-├── session/             tracking, learning, correction
+├── mcp/                 the MCP server and its 25 tools
+├── pipeline/            scorer, collapse, registry, format gate
+├── session/             tracking, learning, adaptive thresholds
 ├── store/               SQLite and transcripts
 └── util/                command families, token estimation
 ```

--- a/docs/website/src/integrations/hermes.md
+++ b/docs/website/src/integrations/hermes.md
@@ -73,7 +73,7 @@ with every other host's and no figure about either is meaningful.
 omni doctor
 
 hermes plugins list | grep omni        # expect: omni-signal-engine enabled
-hermes tools list | grep mcp_omni_     # expect 26 tools, after a restart
+hermes tools list | grep mcp_omni_     # expect 25 tools, after a restart
 ```
 
 Then a functional check on a real fixture:

--- a/docs/website/src/reference/mcp-tools.md
+++ b/docs/website/src/reference/mcp-tools.md
@@ -1,6 +1,6 @@
 # MCP tools
 
-`omni init` registers OMNI as an MCP server, which gives the agent **26 tools** it can
+`omni init` registers OMNI as an MCP server, which gives the agent **25 tools** it can
 call itself without going through you.
 
 Confirm the list against your own binary rather than this page:

--- a/docs/website/src/use/memory.md
+++ b/docs/website/src/use/memory.md
@@ -80,8 +80,10 @@ omni engram --json
 ```sh
 omni query errors in last 5 commands
 omni patterns                # errors that keep coming back across sessions
-omni insight                 # via MCP: top recurring issues project-wide
 ```
+
+`omni_insight` ranks the same recurring issues project-wide, and is an MCP tool with no
+CLI equivalent. It was listed in the block above as though you could run it.
 
 ## What it cannot do
 

--- a/docs/website/src/use/seeing-savings.md
+++ b/docs/website/src/use/seeing-savings.md
@@ -69,13 +69,16 @@ Read-only, same database, binds loopback and nothing else.
 ## Digging further
 
 ```sh
-omni history                     # recent distillations with per-call ratios
+omni stats --detail              # per-command and per-route breakdown
 omni query errors in last 5 commands
 omni query warnings from cargo
 omni query timeline today
 omni patterns                    # errors that keep coming back
 omni patterns --tool cargo
 ```
+
+`omni_history` gives the same per-call rows to an MCP client. There is no `omni history`
+subcommand; this page listed one until 0.7.4.
 
 `omni query` speaks a small fixed query language rather than free text. The supported
 forms are listed in its own help.


### PR DESCRIPTION
Started as one missing image and turned into a sweep, because the missing image was not the only thing wrong.

`What OMNI is` has a section called "Where it sits" and the diagram called "Where OMNI sits" landed only in the README, so a reader on the manual got the ASCII sketch. The sketch is replaced rather than kept: it drew one hook, the diagram draws two, and two pictures of one mechanism disagree the moment either is edited. The prose above it named only the PostToolUse slot, so PreToolUse would have been introduced for the first time in an image.

Then the sweep. `How it decides what to cut` carried **the same wrong pipeline order #517 just fixed on the other page**: Collapse before Distill, feeding it markers. Two copies of one sentence and #517 corrected one. Its stage line and Collapse section are fixed, the two sections are reordered to match the code, and a Ledger section is added because the corrected line named a stage the page never covered.

Three counts had drifted with the deletions: `architecture.md` listed `toml filters` under `pipeline/` and `correction` under `session/`, both gone in #505, and the MCP tool count read 26 in three files against 25 in `src/mcp/server.rs`, the missing one being `omni_learn`.

Two shell blocks told the reader to run commands that exit 1. `omni history` and `omni insight` are MCP tools with no CLI form; `omni stats --detail` replaces the first, and both now say so plainly, matching how `loops.md` already handles `omni handoff`.

Checked by probing the built binary for every `omni <cmd>` inside a shell fence across the manual and the README, 16 distinct commands, rather than by reading them:

```
BROKEN: omni history -> use/seeing-savings.md
BROKEN: omni insight -> use/memory.md
```

`omni exec` and `omni remember` also come back non-zero because `--help` is a free argument to them; both exist. `omni handoff` appears in `loops.md` prose specifically to say it is not a subcommand, which is correct and stays.

No Rust changed, so the gate here is `mdbook build`, which is clean.

This class has now been fixed by hand four times (#180, #185, #390, and this). Filed as #520 rather than bolted on here.
