### PR TITLE
Check the manual against the code, and stop cutting prose the distiller never read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **The manual is checked against the code it describes (#520)**: `tests/docs_match_the_code.rs` asserts that every `omni <cmd>` written inside a shell fence is a subcommand `main.rs` dispatches, and that counts stated in prose match what they count. This class had been fixed by hand four times: #180 named two deleted subcommands, #185 two removed flags, #390 four whole documents, and the #521 sweep found `omni history` and `omni insight` in shell blocks that exit 1, plus a tool count reading 26 against 25. Every round was found by a person happening to open one page.
+
+  **The subcommand list is read from `main.rs` rather than copied**, so the check cannot become the second list that drifts from the first, which is the defect it exists to catch. A structural change that defeats the scan empties the set and a sanity assertion fails loudly instead of the suite passing vacuously. Probing the real binary would be the more honest level and is unsafe here: `reset` drops the database, `dashboard` binds a port and blocks, `update` reaches the network.
+
+  **Fence-scoped on purpose.** `integrations/loops.md` names `omni handoff` in prose precisely to say it is not a subcommand. Proven by reintroducing both defects #521 fixed: the gate reports `use/memory.md:83 omni insight` and `reference/mcp-tools.md:3 says 26 MCP tools, the code has 25`. Prose describing the pipeline in the wrong order, the fourth kind #521 found, is not checkable here and is not claimed to be.
+
 ### Fixed
 - **A re-run of an identical command came back as two markers and zero content lines (#519)**: the ledger folded the whole payload, then the rewind marker measured "what survived" *after* that fold, counted the ledger's own marker as surviving content, and reported the same loss again under a second handle. A 43 line re-run delivered `43 lines already shown` followed by `42 lines omitted`, two ids, and an arithmetic that reconciles with nothing. Same defect as #301, one stage further up: the counts now describe the distiller, taken before the ledger runs, and the ledger accounts for itself.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **A 333-line markdown spec arrived as 18 lines (#523)**: the `readfile` distiller's last arm was `distill_unknown_file`, 15 lines of head and 5 of tail, which parses nothing. Every extension without a structural distiller landed there, so a design document read before implementing from it came back as its title and its closing caveats with the 309 lines that said anything dropped. It is the rule this project holds every other distiller to, broken in place: a distiller that could not parse its input returns the input, and slicing by position is a confident answer about content nothing understood. In a log the first and last lines carry the run and its verdict, which is why `.log` keeps a summariser; in prose they carry neither. Unparsed content now passes through whole.
+
+  **Fixing it exposed a bigger one, in the opposite direction.** The three non-Bash arms chained `fold_cross_turn` onto the distiller's `Option`, so a payload the distiller declined never reached the ledger either. Cross-turn folding is the largest single source of savings and file reads are the class it earns most on, so the first version of this fix silently disabled it for every prose read: `folds_a_repeated_read_across_turns` going red is what caught it. Read, Grep and WebFetch now share one `reply_through_ledger`, and the ledger runs on what the agent is about to receive whether or not a distiller understood it. It returns `None` when neither stage changed anything, so the host is never handed an identical copy and a saving that did not happen.
+
+  **Not measured, because this path records nothing.** `distillations` holds zero readfile rows, so neither the cut being removed nor the folding being gained could be priced from the corpus. That gap is worth its own issue.
+
 ### Added
 - **The manual is checked against the code it describes (#520)**: `tests/docs_match_the_code.rs` asserts that every `omni <cmd>` written inside a shell fence is a subcommand `main.rs` dispatches, and that counts stated in prose match what they count. This class had been fixed by hand four times: #180 named two deleted subcommands, #185 two removed flags, #390 four whole documents, and the #521 sweep found `omni history` and `omni insight` in shell blocks that exit 1, plus a tool count reading 26 against 25. Every round was found by a person happening to open one page.
 

--- a/src/distillers/readfile.rs
+++ b/src/distillers/readfile.rs
@@ -46,13 +46,30 @@ pub fn distill_readfile_with_context(
         "java" | "kt" => distill_java_file(content),
         "json" => distill_json_file(content),
         "toml" | "yaml" | "yml" => distill_config_file(content, ext),
-        // `.txt` is not a log format. Sending it to a log summariser is the
-        // fingerprint problem from #105 and #112: a shape a sibling format also
-        // has. 12 of the 14 `.txt` files in the measured corpus came back as
-        // `Log: 0 errors, 0 warnings` with every line gone (#246). Head and tail
-        // with a count is what `.md` already gets, and it is true.
+        // `.log` only. `.txt` is not a log format, and sending it to a log
+        // summariser is the fingerprint problem from #105 and #112: a shape a
+        // sibling format also has. 12 of the 14 `.txt` files in the measured
+        // corpus came back as `Log: 0 errors, 0 warnings` with every line gone
+        // (#246). It falls to the arm below and is handed back whole.
         "log" => distill_log_file(content),
-        _ => distill_unknown_file(content),
+        // Everything else passes through (#523). The arm here used to be
+        // `distill_unknown_file`, which keeps 15 lines of head and 5 of tail and
+        // parses nothing: a 333-line markdown spec arrived as 18 lines, with the
+        // whole document in the 309 it dropped.
+        //
+        // That is the rule this project holds every other distiller to, broken
+        // in place. A distiller that could not parse its input returns the input;
+        // slicing by position is a confident answer about content nothing
+        // understood. In a log the first and last lines carry the run and its
+        // verdict, which is why `.log` keeps a summariser. In prose they carry
+        // the title and the closing caveats, and every requirement is in between.
+        //
+        // It also inverts on the surface it fires on. `Read` is what an agent
+        // calls before editing one named file, so the base rate of "those lines
+        // were never wanted" is close to zero, and the recovery is
+        // `omni retrieve`, which re-emits all of it: the turn then pays for the
+        // cut copy, the marker, and the whole file.
+        _ => return None,
     };
 
     // Only return if meaningful compression achieved
@@ -74,6 +91,35 @@ pub fn distill_readfile_with_context(
     } else {
         None
     }
+}
+
+fn distill_unknown_file(content: &str) -> String {
+    let lines: Vec<&str> = content.lines().collect();
+    let total = lines.len();
+    if total <= 30 {
+        return content.trim().to_string();
+    }
+    let head: Vec<String> = lines
+        .iter()
+        .take(15)
+        .enumerate()
+        .map(|(i, l)| format!("{} | {}", i + 1, l))
+        .collect();
+    let tail: Vec<String> = lines
+        .iter()
+        .enumerate()
+        .rev()
+        .take(5)
+        .map(|(i, l)| format!("{} | {}", i + 1, l))
+        .collect();
+    let tail_rev: Vec<String> = tail.into_iter().rev().collect();
+    format!(
+        "--- HEAD ({} total lines) ---\n{}\n... [{} lines omitted] ...\n--- TAIL ---\n{}",
+        total,
+        head.join("\n"),
+        total - 20,
+        tail_rev.join("\n")
+    )
 }
 
 /// What a code distiller must say about the lines it dropped (#176).
@@ -401,35 +447,6 @@ fn distill_log_file(content: &str) -> String {
     crate::distillers::require_parsed(errors + warnings > 0, content, out.trim().to_string())
 }
 
-fn distill_unknown_file(content: &str) -> String {
-    let lines: Vec<&str> = content.lines().collect();
-    let total = lines.len();
-    if total <= 30 {
-        return content.trim().to_string();
-    }
-    let head: Vec<String> = lines
-        .iter()
-        .take(15)
-        .enumerate()
-        .map(|(i, l)| format!("{} | {}", i + 1, l))
-        .collect();
-    let tail: Vec<String> = lines
-        .iter()
-        .enumerate()
-        .rev()
-        .take(5)
-        .map(|(i, l)| format!("{} | {}", i + 1, l))
-        .collect();
-    let tail_rev: Vec<String> = tail.into_iter().rev().collect();
-    format!(
-        "--- HEAD ({} total lines) ---\n{}\n... [{} lines omitted] ...\n--- TAIL ---\n{}",
-        total,
-        head.join("\n"),
-        total - 20,
-        tail_rev.join("\n")
-    )
-}
-
 #[cfg(test)]
 mod tests {
 
@@ -567,15 +584,45 @@ mod tests {
     fn never_reports_a_prose_file_as_a_clean_log() {
         let content = bulky("Active account: true, token scopes gist, project, repo\n");
 
-        let out = distill_readfile(&content, "notes.txt").expect("large enough to distill");
+        // #246 asked that prose never be summarised as a clean log, and was
+        // settled by sending it to head-and-tail with an honest count instead.
+        // #523 removed that arm: the count was honest and the cut was still
+        // positional, so a spec arrived as its title and its closing caveats.
+        // Passthrough is the same guarantee in its stronger form, and this
+        // asserts the stronger one rather than the mechanism that used to
+        // deliver it.
+        assert_eq!(
+            distill_readfile(&content, "notes.txt"),
+            None,
+            "prose OMNI cannot parse has to reach the agent whole"
+        );
+    }
 
-        assert!(
-            !out.contains("Log: 0 errors"),
-            "a document that is not a log must not be summarised as one:\n{out}"
+    /// #523, at the size it was reported. A 333-line markdown spec came back as
+    /// 13 head lines and 5 tail lines, and everything it said was in the 309
+    /// between them.
+    ///
+    /// Sized against `MIN_DISTILL_TOKENS` deliberately: the fixture has to clear
+    /// the first gate, or it would return `None` for the old reason and pass
+    /// whatever the last arm does.
+    #[test]
+    fn hands_back_a_whole_markdown_spec() {
+        let content: String = (1..=331)
+            .map(|i| format!("Line {i}: the quick brown fox jumps over the lazy dog.\n"))
+            .collect();
+        let tokens = crate::util::token_estimate::estimate_tokens(
+            content.len(),
+            crate::util::token_estimate::ContentHint::Prose,
         );
         assert!(
-            out.contains("lines omitted"),
-            "and whatever it does drop has to be counted:\n{out}"
+            tokens >= MIN_DISTILL_TOKENS,
+            "fixture is below the first gate at {tokens} tokens, so it proves nothing"
+        );
+
+        assert_eq!(
+            distill_readfile(&content, "/tmp/synthetic.md"),
+            None,
+            "a spec read before editing it must arrive whole, not as its title and its last caveat"
         );
     }
 

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -397,6 +397,35 @@ fn fold_cross_turn(
         .unwrap_or(text)
 }
 
+/// A tool reply on its way to the agent, distilled or not, through the ledger.
+///
+/// The three non-Bash arms used to chain the ledger onto the distiller's
+/// `Option`, so a payload the distiller declined was never folded across turns
+/// either. That coupling is wrong in both directions and it hid until #523
+/// changed how often `readfile` declines: the ledger's claim is about what the
+/// agent has already been shown, which has nothing to do with whether a
+/// distiller understood today's payload. File reads are the class the ledger
+/// earns the most on, and they are also the class most likely to be declined.
+///
+/// `None` when neither stage changed anything, so the host keeps its own bytes
+/// rather than being handed an identical copy and a saving that did not happen.
+fn reply_through_ledger(
+    store: Option<&Arc<Store>>,
+    normalized: &crate::hooks::normalize::NormalizedInput,
+    content: &str,
+    distilled: Option<String>,
+) -> Option<String> {
+    let shortened = distilled.and_then(|d| archive_tool_reply(store, content, d));
+    let carried = shortened.is_some();
+    let text = shortened.unwrap_or_else(|| content.to_string());
+
+    let folded = fold_cross_turn(store, normalized, text);
+    if !carried && folded == content {
+        return None;
+    }
+    Some(wrap_hook_output(normalized.raw_response.as_ref(), folded))
+}
+
 fn distil_tool_reply(
     normalized: &crate::hooks::normalize::NormalizedInput,
     content: &str,
@@ -434,38 +463,38 @@ fn distil_tool_reply(
                     .unwrap_or(0)
             };
 
-            return Some(
+            return Some(reply_through_ledger(
+                store,
+                normalized,
+                content,
                 crate::distillers::readfile::distill_readfile_with_context(
                     content,
                     filepath,
                     count_dependents,
-                )
-                .and_then(|d| archive_tool_reply(store, content, d))
-                .map(|d| fold_cross_turn(store, normalized, d))
-                .map(|d| wrap_hook_output(normalized.raw_response.as_ref(), d)),
-            );
+                ),
+            ));
         }
         "Grep" => {
             if !agent_config.grep_enabled() {
                 return Some(None);
             }
-            return Some(
-                distill_grep(content)
-                    .and_then(|d| archive_tool_reply(store, content, d))
-                    .map(|d| fold_cross_turn(store, normalized, d))
-                    .map(|d| wrap_hook_output(normalized.raw_response.as_ref(), d)),
-            );
+            return Some(reply_through_ledger(
+                store,
+                normalized,
+                content,
+                distill_grep(content),
+            ));
         }
         "WebFetch" => {
             if !agent_config.webfetch_enabled() {
                 return Some(None);
             }
-            return Some(
-                process_web_content(content)
-                    .and_then(|d| archive_tool_reply(store, content, d))
-                    .map(|d| fold_cross_turn(store, normalized, d))
-                    .map(|d| wrap_hook_output(normalized.raw_response.as_ref(), d)),
-            );
+            return Some(reply_through_ledger(
+                store,
+                normalized,
+                content,
+                process_web_content(content),
+            ));
         }
         "Edit" | "Write" | "Create" | "Move" | "Delete" | "Replace" => return None,
         "MultiEdit" => {

--- a/tests/docs_match_the_code.rs
+++ b/tests/docs_match_the_code.rs
@@ -1,0 +1,202 @@
+//! The manual, checked against the code it describes (#520).
+//!
+//! This class of defect has been fixed by hand four times: #180 named two
+//! deleted subcommands, #185 two removed flags, #390 four whole documents, and
+//! the sweep in #521 found `omni history` and `omni insight` sitting in shell
+//! blocks that exit 1, plus a tool count reading 26 against 25 in the source.
+//! Every round was found by a person happening to open one page.
+//!
+//! Two of the four kinds are mechanical, and this covers those. The fourth,
+//! prose describing the pipeline in the wrong order, is not checkable here: the
+//! fix for that is for two pages to stop each holding their own copy.
+//!
+//! **Why the source and not the binary.** Probing `omni <cmd>` for real would be
+//! the honest level, and is unsafe: `reset` drops the database, `dashboard`
+//! binds a port and blocks, `update` reaches the network. Reading the one
+//! `match` that dispatches them keeps the single source of truth without
+//! running anything.
+
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// Every markdown file the manual and the README are made of.
+fn doc_files() -> Vec<PathBuf> {
+    let root = repo_root();
+    let mut out: Vec<PathBuf> = walkdir::WalkDir::new(root.join("docs/website/src"))
+        .into_iter()
+        .filter_map(Result::ok)
+        .filter(|e| e.path().extension().is_some_and(|x| x == "md"))
+        .map(|e| e.path().to_path_buf())
+        .collect();
+    out.push(root.join("README.md"));
+    out.sort();
+    out
+}
+
+/// The subcommands `main.rs` actually dispatches, alias arms included.
+///
+/// Read from the source rather than duplicated here, so this cannot become the
+/// second list that drifts from the first, which is the defect it exists to
+/// catch. A structural change to `main.rs` that defeats the scan empties the set
+/// and the sanity check below fails loudly rather than passing vacuously.
+fn real_subcommands() -> BTreeSet<String> {
+    let main = std::fs::read_to_string(repo_root().join("src/main.rs")).expect("read main.rs");
+    let arm = regex::Regex::new(r#"(?m)^\s*("(?:[a-z][a-z-]*)"(?:\s*\|\s*"[a-z-]+")*)\s*=>"#)
+        .expect("valid regex");
+    let name = regex::Regex::new(r#""([a-z][a-z-]*)""#).expect("valid regex");
+
+    let found: BTreeSet<String> = arm
+        .captures_iter(&main)
+        .flat_map(|c| {
+            name.captures_iter(c.get(1).expect("group 1").as_str())
+                .map(|n| n[1].to_string())
+                .collect::<Vec<_>>()
+        })
+        .collect();
+
+    for known in ["exec", "stats", "doctor", "retrieve", "init"] {
+        assert!(
+            found.contains(known),
+            "the scan of main.rs missed `{known}`, so it is no longer reading the \
+             dispatch table and every assertion below would pass vacuously. Found: {found:?}"
+        );
+    }
+    found
+}
+
+/// `omni <word>` written inside a shell fence, with the file and line.
+///
+/// Fence-scoped on purpose. `integrations/loops.md` names `omni handoff` in
+/// prose precisely to say it is **not** a subcommand, and a check that read
+/// prose would have to be taught about sentences like that one.
+fn commands_in_shell_blocks() -> Vec<(String, String, usize)> {
+    let call = regex::Regex::new(r"(?:^|\s)omni\s+([a-z][a-z-]{2,})").expect("valid regex");
+    let mut out = Vec::new();
+
+    for path in doc_files() {
+        let text = std::fs::read_to_string(&path).expect("read doc");
+        let shown = path
+            .strip_prefix(repo_root())
+            .unwrap_or(&path)
+            .display()
+            .to_string();
+        let mut in_shell = false;
+
+        for (i, line) in text.lines().enumerate() {
+            if line.starts_with("```") {
+                in_shell = matches!(line.trim_end(), "```sh" | "```bash" | "```shell");
+                continue;
+            }
+            if !in_shell || line.trim_start().starts_with('#') {
+                continue;
+            }
+            if let Some(c) = call.captures(line) {
+                out.push((c[1].to_string(), shown.clone(), i + 1));
+            }
+        }
+    }
+    out
+}
+
+/// A documented command a reader can copy, paste, and watch exit 1.
+#[test]
+fn every_command_in_a_shell_block_is_a_real_subcommand() {
+    let real = real_subcommands();
+    let broken: Vec<String> = commands_in_shell_blocks()
+        .into_iter()
+        .filter(|(cmd, _, _)| !real.contains(cmd))
+        .map(|(cmd, file, line)| format!("  {file}:{line}  omni {cmd}"))
+        .collect();
+
+    assert!(
+        broken.is_empty(),
+        "the manual tells the reader to run commands that do not exist.\n{}\n\
+         If the feature moved to MCP, say so in prose instead of leaving it in a \
+         shell block, the way integrations/loops.md handles omni handoff.",
+        broken.join("\n")
+    );
+}
+
+/// Counts in prose, against the thing being counted.
+///
+/// `26 tools` outlived `omni_learn` in three files at once, because a number in
+/// a sentence has nothing pointing at it when the thing it counts is deleted.
+#[test]
+fn every_documented_count_matches_the_code() {
+    let root = repo_root();
+    let server =
+        std::fs::read_to_string(root.join("src/mcp/server.rs")).expect("read mcp/server.rs");
+    let tools: BTreeSet<&str> = regex::Regex::new(r#"name = "(omni_[a-z_]+)""#)
+        .expect("valid regex")
+        .captures_iter(&server)
+        .map(|c| c.get(1).expect("group 1").as_str())
+        .collect();
+
+    let distillers = std::fs::read_dir(root.join("src/distillers"))
+        .expect("read distillers")
+        .filter_map(Result::ok)
+        .filter(|e| {
+            let p = e.path();
+            p.extension().is_some_and(|x| x == "rs") && p.file_stem().is_some_and(|s| s != "mod")
+        })
+        .count();
+
+    // (regex, what the number has to equal, what it is counting)
+    let claims = [
+        (r"(\d+)\s+(?:MCP\s+)?tools", tools.len(), "MCP tools"),
+        (r"(\d+)\s+content filters", distillers, "distillers"),
+    ];
+
+    let mut wrong = Vec::new();
+    for path in doc_files() {
+        let text = std::fs::read_to_string(&path).expect("read doc");
+        let shown = path
+            .strip_prefix(&root)
+            .unwrap_or(&path)
+            .display()
+            .to_string();
+        for (pattern, actual, what) in &claims {
+            let re = regex::Regex::new(pattern).expect("valid regex");
+            for (i, line) in text.lines().enumerate() {
+                for c in re.captures_iter(line) {
+                    let claimed: usize = c[1].parse().expect("digits");
+                    if claimed != *actual {
+                        wrong.push(format!(
+                            "  {shown}:{}  says {claimed} {what}, the code has {actual}",
+                            i + 1
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    assert!(
+        wrong.is_empty(),
+        "the manual states counts the code disagrees with.\n{}",
+        wrong.join("\n")
+    );
+}
+
+/// The scan itself, because a checker that reads nothing reports no problems.
+#[test]
+fn the_scan_reaches_the_manual_and_the_readme() {
+    let files = doc_files();
+    assert!(
+        files.len() > 20,
+        "only {} doc files found, so the walk is not reaching the manual",
+        files.len()
+    );
+    assert!(
+        files.iter().any(|p| p.ends_with("README.md")),
+        "the README is not being scanned"
+    );
+    assert!(
+        commands_in_shell_blocks().len() > 10,
+        "no commands found in any shell block, so the fence scan is broken"
+    );
+}


### PR DESCRIPTION
Two issues, and the second one nearly shipped a regression bigger than the bug it fixed.

**#520.** Nothing checked that the manual's claims still match the code, and the class had been fixed by hand four times: #180 named two deleted subcommands, #185 two removed flags, #390 four whole documents, and the #521 sweep found `omni history` and `omni insight` in shell blocks that exit 1 beside a tool count reading 26 against 25. `tests/docs_match_the_code.rs` asserts every `omni <cmd>` inside a shell fence is a subcommand `main.rs` dispatches, and that counts stated in prose match what they count.

The subcommand list is read out of the `match` in main.rs rather than restated, or the check becomes the second list that drifts from the first. If a structural change defeats the scan the set comes back empty and a sanity assertion fails, rather than everything below it passing vacuously. Probing the built binary would be the honest level and is not safe: `reset` drops the database, `dashboard` binds a port and blocks, `update` reaches the network. Fence-scoped, because `loops.md` names `omni handoff` in prose specifically to say it is not a subcommand.

**#523.** The `readfile` distiller's last arm was `distill_unknown_file`, 15 head lines and 5 tail lines, parsing nothing, and every extension without a structural distiller landed there. A 333-line markdown spec read before implementing from it arrived as its title and its closing caveats. Unparsed content now passes through whole.

The first version of that fix was worse than the bug. The three non-Bash arms chained `fold_cross_turn` onto the distiller's `Option`, so a payload the distiller declined never reached the ledger either. Making `readfile` decline more often therefore disabled cross-turn folding on the class it earns most on. `folds_a_repeated_read_across_turns` going red is the only reason it was caught. Read, Grep and WebFetch now share one `reply_through_ledger` and the ledger runs on what the agent is about to receive, distilled or not. All three were rewired rather than only Read, because #452, #454 and #456 each fixed one copy of a shared shape and left the others.

Teeth proven by reintroducing the real defects, not by inventing fixtures:

```
#520, both defects #521 fixed:
  use/memory.md:83  omni insight
  reference/mcp-tools.md:3  says 26 MCP tools, the code has 25
#523, the old arm restored:
  a spec read before editing it must arrive whole, not as its title and its last caveat
```

Two things worth knowing. `distill_unknown_file` stays: it is still the fallback inside three code distillers, and deleting it on the assumption it was dead broke the build. And #523 could not be priced, because `distillations` holds zero readfile rows: that path runs entirely unrecorded, which is its own gap and not fixed here.

```
fmt 0 · clippy --all-targets -D warnings 0 · cargo test 0 · smoke 44/44
```

Closes #520
Closes #523
