### PR TITLE
Honour OMNI_PASSTHROUGH written in front of the command, where the hook can actually see it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **`OMNI_PASSTHROUGH=1 <cmd>` did nothing on the Claude Code hook path (#534)**: the manual documents that prefix as "raw output, every time" in four places, including `OMNI_PASSTHROUGH=1 kubectl get pods -o yaml`, which is exactly the case where someone needs exact bytes. It held for `omni exec` and the pipe, where the variable is read by the same process, and not on the host the promise matters on: a `PostToolUse` hook is a process the host spawned, so it inherits the host's environment and never sees an assignment typed in front of a command. The escape hatch was inert and nothing said so.
+
+  **The command string does reach the hook**, so the assignment is honoured by reading it there. Only a leading assignment counts, the position a shell would apply it in, so `echo OMNI_PASSTHROUGH=1` mentions the name without setting anything and is still distilled. Proven at the hook boundary rather than on the predicate, because the predicate was always right about the text it was given: `the_prefix_the_manual_documents_reaches_the_hook` feeds `process_payload` the same output twice and asserts the prefixed call returns nothing where the bare one rewrites.
+
+  **The first version of that test passed its own control by accident**, on a fixture that was never rewritten at all, which would have made the whole assertion vacuous. It now primes the ledger first so the unprefixed call is certain to be folded.
+
+### Fixed
 - **A worktree was a different project, so its ledger history was too (#525, first step)**: the project scope was `current_dir()` and nothing else, so the same repository reached by another path opened a separate history. Measured before the fix: 31 project scopes on the maintainer's database, one repository split across **six** of them, with 2,759 lines (15.6% of that project's history) stranded in scopes nothing would consult again. Four of the six were created in a single day of ordinary work, because a git worktree is a different directory. `paths::project_key` resolves the repository root and both ledger doors use it.
 
   **A linked worktree is why this is not a walk up to `.git`.** There, `.git` is a *file* holding `gitdir: <main>/.git/worktrees/<name>`, so stopping at the first `.git` returns the worktree root and splits the history exactly as before while looking like a fix. The gitdir is read and resolved back to the main checkout, and an unreadable or unfamiliar `.git` file falls back to the directory rather than to a guess. Proven by replacing the resolution with the naive walk, which fails `a_linked_worktree_answers_the_main_checkout`.

--- a/docs/website/src/concepts/format-safety.md
+++ b/docs/website/src/concepts/format-safety.md
@@ -46,6 +46,14 @@ OMNI_PASSTHROUGH=1 <your command>
 Skips the pipeline entirely. Use it when you are debugging OMNI itself and need to
 see what a command really printed, or when reading a file whose exact bytes matter.
 
+The prefix works on every path, including inside an agent, but not for the reason it
+looks like. A hook is a separate process the host spawned, so it inherits the host's
+environment and never sees a variable you assign in front of a command. What it does
+see is the command string, so OMNI reads the assignment there. Two consequences worth
+knowing: only a **leading** assignment counts, the same position a shell would apply
+it in, and `echo OMNI_PASSTHROUGH=1` mentions the name without setting anything and is
+still distilled. Exporting it for the whole session works the ordinary way.
+
 This is the single most useful environment variable here, and it is the first thing
 to reach for when you suspect OMNI has changed something it should not have. If the
 output is identical with and without it, OMNI was not involved.

--- a/src/guard/env.rs
+++ b/src/guard/env.rs
@@ -232,3 +232,70 @@ mod tests {
         assert_eq!(validate_loop_context(None, None, Some(10_000_000)), Ok(()));
     }
 }
+
+/// `OMNI_PASSTHROUGH=1 <cmd>` written on the command line, which the hook can
+/// only ever see as text (#534).
+///
+/// The manual documents that prefix as "raw output, every time", and on
+/// `omni exec` and the pipe it is, because the variable is read by the same
+/// process. The Claude Code `PostToolUse` hook is a separate process spawned by
+/// the host: it inherits the host's environment and an assignment typed in
+/// front of the command never reaches it. The prefix was inert on the one host
+/// the promise matters on, and nothing said so.
+///
+/// The command string does reach the hook, so the assignment is honoured by
+/// reading it there. Only leading assignments count, the same shape a shell
+/// would apply them in: `echo OMNI_PASSTHROUGH=1` mentions the name and sets
+/// nothing, and must keep being distilled.
+pub fn command_asks_for_passthrough(command: &str) -> bool {
+    for token in command.split_whitespace() {
+        match token.split_once('=') {
+            Some((key, value)) if key.eq_ignore_ascii_case("OMNI_PASSTHROUGH") => {
+                return means_enabled(value);
+            }
+            // Another leading assignment: keep looking past it.
+            Some((key, _))
+                if !key.is_empty()
+                    && !key.starts_with(|c: char| c.is_ascii_digit())
+                    && key.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') => {}
+            // The command itself has started; anything after this is an argument.
+            _ => return false,
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod command_passthrough_tests {
+    use super::command_asks_for_passthrough;
+
+    #[test]
+    fn honours_the_prefix_the_manual_documents() {
+        assert!(command_asks_for_passthrough(
+            "OMNI_PASSTHROUGH=1 cat secrets.env"
+        ));
+        assert!(command_asks_for_passthrough(
+            "OMNI_PASSTHROUGH=true kubectl get pods -o yaml"
+        ));
+        // Past another assignment, the way a shell applies them.
+        assert!(command_asks_for_passthrough(
+            "FOO=1 OMNI_PASSTHROUGH=on cargo test"
+        ));
+    }
+
+    #[test]
+    fn an_off_value_is_not_an_escape_hatch() {
+        assert!(!command_asks_for_passthrough("OMNI_PASSTHROUGH=0 cat file"));
+        assert!(!command_asks_for_passthrough("cat file"));
+    }
+
+    /// The line between an assignment and a mention. Naming the variable as an
+    /// argument sets nothing, so it must not turn distillation off.
+    #[test]
+    fn a_mention_is_not_an_assignment() {
+        assert!(!command_asks_for_passthrough("echo OMNI_PASSTHROUGH=1"));
+        assert!(!command_asks_for_passthrough(
+            "grep -r OMNI_PASSTHROUGH=1 src/"
+        ));
+    }
+}

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -274,7 +274,11 @@ fn declined(normalized: &crate::hooks::normalize::NormalizedInput, store: Option
         return true;
     }
 
-    if crate::guard::env::is_passthrough() {
+    // The process environment, and the assignment the user typed in front of the
+    // command, which is the only form that reaches a hook the host spawned (#534).
+    if crate::guard::env::is_passthrough()
+        || crate::guard::env::command_asks_for_passthrough(&normalized.command)
+    {
         return true;
     }
 
@@ -1414,6 +1418,49 @@ mod tests {
             ledger,
             vec![distilled.clone()],
             "the ledger filed lines under a different agent than the call they came from ({distilled})"
+        );
+    }
+
+    /// #534, at the level the promise is made. The manual says
+    /// `OMNI_PASSTHROUGH=1 <cmd>` gives raw output every time. The hook is a
+    /// process the host spawned, so it inherits the host's environment and never
+    /// sees that assignment as a variable; the only place it exists is the
+    /// command string. A predicate test cannot show this, because the predicate
+    /// was always right about the text it was given.
+    #[test]
+    fn the_prefix_the_manual_documents_reaches_the_hook() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Arc::new(Store::open_path(&dir.path().join("omni.db")).expect("store"));
+        let noisy: String = (0..200)
+            .map(|i| format!("# comment line {i} explaining a step in the script\n"))
+            .collect();
+        let payload = |cmd: &str| {
+            json!({
+                "session_id": "s-534",
+                "tool_name": "Bash",
+                "tool_input": {"command": cmd},
+                "tool_response": {"stdout": noisy, "stderr": ""}
+            })
+            .to_string()
+        };
+
+        // Primed so the ledger will certainly fold the repeat: a fixture that
+        // merely "looks noisy" can land under the route threshold and return
+        // None for the wrong reason, which is how the first version of this
+        // test passed its control assertion by accident.
+        let _ = process_payload(&payload("cat synth.sh"), Some(store.clone()), None);
+        assert!(
+            process_payload(&payload("cat synth.sh"), Some(store.clone()), None).is_some(),
+            "the fixture has to be rewritten without the prefix, or this proves nothing"
+        );
+        assert_eq!(
+            process_payload(
+                &payload("OMNI_PASSTHROUGH=1 cat synth.sh"),
+                Some(store.clone()),
+                None
+            ),
+            None,
+            "the escape hatch the manual documents did nothing on the hook path"
         );
     }
 


### PR DESCRIPTION
The manual promises `OMNI_PASSTHROUGH=1 <cmd>` gives raw output every time, in four places, one of them `kubectl get pods -o yaml`, which is exactly when someone needs exact bytes. It held on `omni exec` and the pipe, where the same process reads the variable, and did nothing on Claude Code: a `PostToolUse` hook is a process the host spawned, so it inherits the host's environment and never sees an assignment typed in front of a command. The escape hatch was inert on the one host the promise matters on, and nothing said so.

The command string does reach the hook, so the assignment is read there. Only a leading assignment counts, the position a shell would apply it in, which keeps `echo OMNI_PASSTHROUGH=1` and `grep -r OMNI_PASSTHROUGH=1 src/` distilled: they name the variable and set nothing.

Verified at the hook boundary rather than on the predicate. The predicate was always right about the text handed to it; what was wrong was that nothing handed it the text.

```
removing the condition:
  "the escape hatch the manual documents did nothing on the hook path"
```

Worth knowing, because it nearly shipped green: the first version of that test passed its own control assertion on a fixture that was never rewritten at all. "With the prefix returns nothing" proves nothing when the bare call also returns nothing. It primes the ledger first now, so the unprefixed call is certain to be rewritten and the comparison has content.

`concepts/format-safety.md` says how it actually works, including the two consequences of reading the command string: leading position only, and a mention is not an assignment.

This commit was originally pushed to #531's branch after that PR had already merged, so it never ran through CI there. Same commit, on a branch off current main.

```
fmt 0 · clippy --all-targets -D warnings 0 · cargo test 0 · smoke 44/44 · mdbook build clean
```

Closes #534
