### PR TITLE
Put the 0.7.4 plugin on the manual's start page

### DIFF
--- a/docs/website/src/index.md
+++ b/docs/website/src/index.md
@@ -9,13 +9,20 @@ locally, it needs no API key, and once it is installed you never type its name a
 brew install fajarhide/tap/omni && omni init
 ```
 
+Inside Claude Code, two lines and the agent does the rest:
+
+```
+/plugin marketplace add fajarhide/omni
+/plugin install omni@omni
+```
+
 ## The problem, in one screen
 
 Your agent runs a test suite. Four hundred lines come back, one of them matters.
 
 ```
 $ cargo test
-    Compiling omni v0.7.3
+    Compiling omni v0.7.4
      Running unittests src/lib.rs
 running 412 tests
 test pipeline::scorer::tests::scores_errors_critical ... ok


### PR DESCRIPTION
0.7.4 added a second way in and the manual's front door did not mention it. `use/install.md` has carried the plugin since #536, but the start page is where a reader who has never heard of OMNI lands, and it offered only Homebrew.

Also dates the `cargo test` sample, which still said `Compiling omni v0.7.3`. It is illustrative rather than measured.

`cargo test --test docs_match_the_code` passes. The added fence contains no `omni <cmd>`, so the subcommand scan is unaffected.