### PR TITLE
Record which scope and whose lines a fold drew on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **A fold now records what it drew on (#533, first step)**: `ledger_lines` says a line was *seen*. It cannot say a marker was ever issued against it, under which scope, or whose bytes it replaced, so the value of cross-agent reuse was unrecoverable from the corpus after the fact. `PROJECT_FLOOR_MULT = 3` prices exactly that case and was calibrated in #448 on cross-session repetition within a single agent, which is to say it has never been checked against the thing it charges for.
+
+  `ledger_folds` takes one row per (origin, source agent) per call, so the query that settles the open decision is a `GROUP BY` rather than a replay. `ledger_seen` returns the agent alongside the hash to make the source answerable at all, and `INSERT OR IGNORE` on the line table means that names the agent actually shown the line rather than the last one to repeat it.
+
+  **The decision the rows are for is deliberately not taken here.** Whether the project scope stays shared or becomes `(repo, agent)` is a choice between two unmeasured options until the corpus has run, and choosing early is what this project keeps refusing to do. Deletion ships in the same commit as the schema, pruned in the same window as the lines it describes, because `passthrough_events` shipped with no cleanup and grew unbounded.
+
 ## [0.7.4] - 2026-08-13
 
 A release about claims that were not true: a documented escape hatch that did

--- a/src/ledger/mod.rs
+++ b/src/ledger/mod.rs
@@ -38,7 +38,7 @@
 //! - **Unknown means untouched.** Structured payloads never reach here; the
 //!   caller gates on `pipeline::format::sniff` exactly as collapse does.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use crate::guard::limits::{MIN_LEDGER_INPUT, MIN_LEDGER_RUN_GAIN, PROJECT_FLOOR_MULT};
 use crate::store::sqlite::Store;
@@ -219,7 +219,7 @@ impl<'a> Ledger<'a> {
         let in_session = self.store.ledger_seen(&self.scope, &hashes);
         let in_project = match &self.project {
             Some(p) => self.store.ledger_seen(p, &hashes),
-            None => HashSet::new(),
+            None => HashMap::new(),
         };
         // A line that states a failure is never folded, however often it has been
         // shown (#458). The heuristic "you have seen this already" is sound for
@@ -245,9 +245,9 @@ impl<'a> Ledger<'a> {
             if never_fold.contains(h) {
                 return None;
             }
-            if in_session.contains(h) {
+            if in_session.contains_key(h) {
                 Some(Origin::Session)
-            } else if in_project.contains(h) {
+            } else if in_project.contains_key(h) {
                 Some(Origin::Project)
             } else {
                 None
@@ -284,6 +284,47 @@ impl<'a> Ledger<'a> {
                 .collect(),
             None => hashes.clone(),
         };
+        // What the folds drew on, before the write below makes every line look
+        // like this session's (#533). `PROJECT_FLOOR_MULT` prices cross-agent
+        // reuse and was calibrated on the single-agent case, and nothing recorded
+        // enough to tell the two apart after the fact.
+        if let Some((_, folded)) = &projected {
+            let mut tally: HashMap<(&'static str, &str), (usize, usize)> = HashMap::new();
+            for &i in folded {
+                let Some(origin) = origin_of(&hashes[i]) else {
+                    continue;
+                };
+                let (label, source) = match origin {
+                    Origin::Session => ("session", in_session.get(&hashes[i])),
+                    Origin::Project => ("project", in_project.get(&hashes[i])),
+                };
+                // A hit with no agent cannot happen through `ledger_record`, which
+                // always writes one. Counting it as `unknown` beats dropping the
+                // row and quietly understating the total.
+                let entry = tally
+                    .entry((label, source.map_or("unknown", String::as_str)))
+                    .or_default();
+                entry.0 += 1;
+                entry.1 += lines[i].len();
+            }
+            let folds: Vec<crate::store::sqlite::FoldRecord> = tally
+                .into_iter()
+                .map(
+                    |((origin, source_agent), (lines, bytes))| crate::store::sqlite::FoldRecord {
+                        source_agent: source_agent.to_string(),
+                        origin,
+                        lines,
+                        bytes,
+                    },
+                )
+                .collect();
+            // Keyed on the project when there is one: the question is about a
+            // repository two agents share, and a session scope cannot be compared
+            // across agents by definition.
+            let scope = self.project.as_deref().unwrap_or(&self.scope);
+            self.store.ledger_record_folds(scope, &self.agent, &folds);
+        }
+
         self.store
             .ledger_record(&self.scope, &delivered, &self.agent);
         // The project history is written too, so a later session can draw on this
@@ -611,6 +652,57 @@ mod tests {
             0,
             "a repeat rewrote the agent that was actually shown the line"
         );
+    }
+
+    /// #533. Whether the project scope stays shared across agents or becomes
+    /// `(repo, agent)` cannot be argued, only measured, and it could not be
+    /// measured: `ledger_lines` says a line was *seen*, never that a marker was
+    /// issued against it or whose bytes that marker replaced. This is the row
+    /// the corpus query needs, and the cross-agent case is the only one that
+    /// decides anything, so it is the one pinned here.
+    #[test]
+    fn records_the_agent_whose_lines_a_project_fold_replaced() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = dir.path().join("omni.db");
+        let store = Store::open_path(&db).expect("store");
+        // Six times the session floor, so the project scope's higher bar is
+        // cleared and a fold really happens. Under it the second agent is simply
+        // shown the lines, and a test asserting on an absent fold passes for the
+        // wrong reason.
+        let text: String = (0..200)
+            .map(|i| format!("2026-08-10T00:00:00Z  handler finished request {i} in 12ms\n"))
+            .collect();
+
+        Ledger::new(&store, "s1")
+            .with_project("/repo")
+            .by("claude_code")
+            .project(&text);
+        let view = Ledger::new(&store, "s2")
+            .with_project("/repo")
+            .by("codex")
+            .project(&text)
+            .expect("no fold on the second agent, so there is nothing to record");
+        assert!(
+            view.contains("from an earlier session"),
+            "this has to be a project fold to be the case under test: {view}"
+        );
+
+        let conn = rusqlite::Connection::open(&db).expect("open");
+        let (agent, source, lines, bytes): (String, String, i64, i64) = conn
+            .query_row(
+                "SELECT agent_id, source_agent, lines, bytes
+                 FROM ledger_folds WHERE origin = 'project'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
+            )
+            .expect("a project fold left no row, so cross-agent reuse stays unpriceable");
+
+        assert_eq!(agent, "codex", "the agent the marker was delivered to");
+        assert_eq!(
+            source, "claude_code",
+            "the agent whose lines were replaced, which is the whole measurement"
+        );
+        assert!(lines > 0 && bytes > 0, "{lines} lines, {bytes} bytes");
     }
 
     /// The whole licence for the project scope. A second session may reuse the

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -484,6 +484,29 @@ impl SqliteBackend {
             ) WITHOUT ROWID;
             CREATE INDEX IF NOT EXISTS idx_ledger_ts ON ledger_lines(ts);
 
+            -- What a fold actually drew on, which nothing recorded before (#533).
+            -- `ledger_lines` says a line was seen; it cannot say a marker was ever
+            -- issued against it, by which scope, or whose bytes it replaced. So
+            -- the value of cross-agent reuse was unrecoverable from the corpus
+            -- after the fact, and `PROJECT_FLOOR_MULT` has been pricing that case
+            -- since #448 without ever being checked against it.
+            --
+            -- One row per (origin, source agent) per fold, so the query that
+            -- settles the decision is a GROUP BY rather than a replay:
+            --   SELECT origin, agent_id = source_agent AS same, SUM(bytes)
+            --   FROM ledger_folds GROUP BY 1, 2;
+            CREATE TABLE IF NOT EXISTS ledger_folds (
+                id           INTEGER PRIMARY KEY,
+                ts           INTEGER NOT NULL,
+                scope        TEXT NOT NULL,
+                agent_id     TEXT NOT NULL,
+                source_agent TEXT NOT NULL,
+                origin       TEXT NOT NULL,
+                lines        INTEGER NOT NULL,
+                bytes        INTEGER NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_ledger_folds_ts ON ledger_folds(ts);
+
             -- 5. FTS5 for session events
             CREATE VIRTUAL TABLE IF NOT EXISTS session_events USING fts5(
                 session_id UNINDEXED,
@@ -1655,17 +1678,28 @@ impl SqliteBackend {
         );
     }
 
-    /// Which of `hashes` this scope has already been shown.
+    /// Which of `hashes` this scope has already been shown, and to whom.
     ///
     /// Asked as a bounded `IN` probe rather than by loading the scope's whole
     /// line set, because each hook is its own process: a session with 100,000
     /// recorded lines would pay to read all of them to ask about 200. Chunked
     /// under SQLite's default 32,766 parameter ceiling with room to spare.
     ///
-    /// Fails to an empty set. A ledger that cannot read is a ledger that has
+    /// The agent comes back with the hash because a fold cannot otherwise say
+    /// whose bytes it replaced, and that is the whole question #533 has to price:
+    /// a project-scoped fold drawing on another agent's lines is the reuse that
+    /// keying the scope on `(repo, agent)` would end. `INSERT OR IGNORE` keeps
+    /// the first writer, so this names the agent actually shown that line rather
+    /// than the last one to repeat it.
+    ///
+    /// Fails to an empty map. A ledger that cannot read is a ledger that has
     /// seen nothing, which costs a missed reduction and never a false claim.
-    pub fn ledger_seen(&self, scope: &str, hashes: &[String]) -> std::collections::HashSet<String> {
-        let mut found = std::collections::HashSet::new();
+    pub fn ledger_seen(
+        &self,
+        scope: &str,
+        hashes: &[String],
+    ) -> std::collections::HashMap<String, String> {
+        let mut found = std::collections::HashMap::new();
         let Ok(conn) = self.pool.get() else {
             return found;
         };
@@ -1682,7 +1716,7 @@ impl SqliteBackend {
                 .collect::<Vec<_>>()
                 .join(",");
             let sql = format!(
-                "SELECT line_hash FROM ledger_lines WHERE scope = ? AND line_hash IN ({placeholders})"
+                "SELECT line_hash, agent_id FROM ledger_lines WHERE scope = ? AND line_hash IN ({placeholders})"
             );
             let Ok(mut stmt) = conn.prepare_cached(&sql) else {
                 continue;
@@ -1690,7 +1724,9 @@ impl SqliteBackend {
             let params: Vec<&dyn rusqlite::ToSql> = std::iter::once(&scope as &dyn rusqlite::ToSql)
                 .chain(chunk.iter().map(|h| *h as &dyn rusqlite::ToSql))
                 .collect();
-            if let Ok(rows) = stmt.query_map(params.as_slice(), |r| r.get::<_, String>(0)) {
+            if let Ok(rows) = stmt.query_map(params.as_slice(), |r| {
+                Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?))
+            }) {
                 found.extend(rows.flatten());
             }
         }
@@ -1725,6 +1761,46 @@ impl SqliteBackend {
             };
             for h in hashes {
                 let _ = stmt.execute(params![scope, h, ts, agent_id]);
+            }
+        }
+        let _ = tx.commit();
+    }
+
+    /// Records what one call's folds drew on, grouped by origin and source agent.
+    ///
+    /// Written after the view is decided rather than while it is being built, so
+    /// a store that cannot be reached costs a measurement and never a marker.
+    /// Same reasoning as `ledger_record` above: the ledger's writes are evidence,
+    /// and evidence must not be able to change the output.
+    pub fn ledger_record_folds(&self, scope: &str, agent_id: &str, folds: &[FoldRecord]) {
+        if folds.is_empty() {
+            return;
+        }
+        let Ok(mut conn) = self.pool.get() else {
+            return;
+        };
+        let ts = chrono::Utc::now().timestamp();
+        let Ok(tx) = conn.transaction() else {
+            return;
+        };
+        {
+            let Ok(mut stmt) = tx.prepare_cached(
+                "INSERT INTO ledger_folds
+                     (ts, scope, agent_id, source_agent, origin, lines, bytes)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            ) else {
+                return;
+            };
+            for f in folds {
+                let _ = stmt.execute(params![
+                    ts,
+                    scope,
+                    agent_id,
+                    f.source_agent,
+                    f.origin,
+                    f.lines as i64,
+                    f.bytes as i64
+                ]);
             }
         }
         let _ = tx.commit();
@@ -1820,6 +1896,14 @@ impl SqliteBackend {
         //
         // Rows are 16 bytes of hash plus a scope key, so the cost is bounded by
         // distinct lines emitted in the window rather than by bytes shown.
+        // Pruned in the same window as the lines it describes. `passthrough_events`
+        // shipped with no cleanup at all and grew unbounded, so a new table gets
+        // its deletion in the same commit as its schema rather than a follow-up.
+        let _ = conn.execute(
+            "DELETE FROM ledger_folds WHERE ts < ?1",
+            params![ts_threshold],
+        );
+
         let _ = conn.execute(
             "DELETE FROM ledger_lines WHERE ts < ?1",
             params![ts_threshold],
@@ -2405,6 +2489,23 @@ impl SqliteBackend {
 }
 
 // ── v0.5.7 Row Types ─────────────────────────────────────────────────
+
+/// One fold's worth of evidence: whose lines it replaced, and how much.
+///
+/// Grouped by the caller so a payload folding twenty runs from one agent writes
+/// one row rather than twenty. The recipient is on the call, not the row, since
+/// it is the same for every fold in a payload.
+#[derive(Debug, Clone)]
+pub struct FoldRecord {
+    /// The agent that was shown these lines first, from `ledger_lines.agent_id`.
+    pub source_agent: String,
+    /// `session` or `project`. Kept as a string because it is read by SQL far
+    /// more often than by Rust, and a query should not have to know an enum's
+    /// discriminants.
+    pub origin: &'static str,
+    pub lines: usize,
+    pub bytes: usize,
+}
 
 #[derive(Debug, Clone)]
 pub struct PatternMemoryRow {


### PR DESCRIPTION
#533 step 1 only: record what a fold drew on. The decision the rows are for is deliberately not taken.

`ledger_lines` says a line was *seen*. It cannot say a marker was ever issued against it, under which scope, or whose bytes it replaced, so the value of cross-agent reuse was unrecoverable from the corpus after the fact. `PROJECT_FLOOR_MULT = 3` prices that exact case and was calibrated in #448 on repetition within a single agent.

`ledger_folds` takes one row per (origin, source agent) per call, so the query that settles the decision is a `GROUP BY` rather than a replay:

```sql
SELECT origin, agent_id = source_agent AS same_agent, SUM(bytes), SUM(lines)
FROM ledger_folds GROUP BY 1, 2;
```

`ledger_seen` now returns the agent alongside the hash, which is where `source_agent` comes from. `INSERT OR IGNORE` on the line table means that names the agent actually shown the line rather than the last one to repeat it.

### Validation

`make ci` green, 44/44 smoke.

The new test was run against the source lookup replaced by `None` and watched go red on `the agent whose lines were replaced, which is the whole measurement`, then restored. Its fixture is 200 lines on purpose: under the project floor the second agent is simply shown the lines, and a test asserting on an absent fold passes for the wrong reason.

Migration checked against a copy of a real 72 MB database rather than a fresh one:

```
before: 0 tables named ledger_folds
after:  1
existing ledger_lines rows preserved: 79,103
```

Deletion ships in the same commit as the schema, pruned in the same window as the lines it describes. `passthrough_events` shipped with no cleanup at all and grew unbounded; this is that lesson applied rather than restated.

Refs #533
