### PR TITLE
docs(website): the manual reads in Indonesian, and the header carries the mark

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,3 +92,20 @@ jobs:
       - name: Typecheck
         working-directory: plugins/pi
         run: npm run typecheck
+
+  manual-translations:
+    name: manual translations in step
+    # Seconds of git, so it runs on its own rather than behind thirteen minutes
+    # of Rust. Pull requests only: the check compares a branch against its merge
+    # base, and on a push to main there is no branch to compare.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # The merge base is not in a shallow clone, and without it the script
+          # would see the whole manual as changed on every run.
+          fetch-depth: 0
+
+      - name: English pages changed without their translation
+        run: scripts/check_translations.sh "origin/${{ github.base_ref }}"

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,9 @@ target/
 
 # mdBook build output for docs/website. The source is tracked, the render is not.
 docs/website/book/
+
+# The Indonesian book renders alongside the English one; same rule as above.
+docs/website/book-id/
+# Shared diagrams, copied into the Indonesian book at build time by
+# docs/website/build.sh so both books read one set of SVGs.
+docs/website/src-id/media/

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,9 @@ docs/website/book-id/
 # Shared diagrams, copied into the Indonesian book at build time by
 # docs/website/build.sh so both books read one set of SVGs.
 docs/website/src-id/media/
+# The design-system overlay. omni-pages writes src/wl into its own clone during
+# the site build and docs/website/build.sh mirrors it into src-id/wl, so neither
+# is ever source. Untracked and unignored, they are one `git add -A` away from
+# being committed by anyone who renders the book locally.
+docs/website/src/wl/
+docs/website/src-id/wl/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **The manual reads in Indonesian (#539)**: #513 shipped a language switcher whose every entry left the manual for a README on GitHub, because the manual itself was English only. It advertised seven languages and delivered one page in each. 27 pages plus a `SUMMARY` are now translated (`index`, `concepts`, `use`, `integrations`, `reference`), served at `/docs/id/`, and the `ID` entry in the switcher points at the manual instead of the README.
+
+  `develop/` is deliberately not translated. Those seven pages change fastest and are read by people about to send a patch, so an Indonesian copy of them would be wrong more often than it was useful; one Indonesian page says that and links the seven originals.
+
+  **No second `book.toml` and no new dependency.** mdBook reads configuration from the environment, so `docs/website/build.sh` renders the same book twice with a different `src`, `language` and `build-dir`, then copies the second into `book/id` so the site still copies one tree. The diagrams are copied into `src-id` at build time rather than forked: their labels are English either way, and a copy made at build time cannot fall behind the original.
+
+  **A stale translation is worse than none, so two things carry the drift.** Every Indonesian page gets a banner naming itself a translation and linking its English original, injected in `theme/siteframe.js` rather than pasted into 28 files that would then fall out of step with each other. And `scripts/check_translations.sh` fails CI when an English page changes without its counterpart being touched, skipping pages that have no counterpart so `develop/` does not go permanently red. `tests/docs_match_the_code.rs` now scans both books: the prose is translated and the commands are not, so an Indonesian shell fence can name a deleted subcommand exactly as easily as an English one.
+
+- **The manual header carries the mark (#540)**: `theme/siteframe.js` turned `.menu-title` into a link home whose content was the plain string `OMNI`, while the README, the site and the favicon all carried the logo. The mark is read from the `<link rel=icon>` mdBook already emits rather than from a hardcoded filename, because mdBook 0.5 fingerprints theme assets and the hash changes whenever the mark does.
+
 - **A fold now records what it drew on (#533, first step)**: `ledger_lines` says a line was *seen*. It cannot say a marker was ever issued against it, under which scope, or whose bytes it replaced, so the value of cross-agent reuse was unrecoverable from the corpus after the fact. `PROJECT_FLOOR_MULT = 3` prices exactly that case and was calibrated in #448 on cross-session repetition within a single agent, which is to say it has never been checked against the thing it charges for.
 
   `ledger_folds` takes one row per (origin, source agent) per call, so the query that settles the open decision is a `GROUP BY` rather than a replay. `ledger_seen` returns the agent alongside the hash to make the source answerable at all, and `INSERT OR IGNORE` on the line table means that names the agent actually shown the line rather than the last one to repeat it.

--- a/docs/website/build.sh
+++ b/docs/website/build.sh
@@ -25,8 +25,10 @@ cp -R "$here/src/media" "$here/src-id/media"
 
 # The design-system overlay omni-pages drops into src/wl, when there is one. The
 # head.hbs it writes references it from every page of both books.
+# The removal is outside the guard on purpose: a tree that had an overlay once
+# and does not now must not keep rendering the old one.
+rm -rf "$here/src-id/wl"
 if [ -d "$here/src/wl" ]; then
-  rm -rf "$here/src-id/wl"
   cp -R "$here/src/wl" "$here/src-id/wl"
 fi
 

--- a/docs/website/build.sh
+++ b/docs/website/build.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Render both manuals: English into book/, Indonesian into book-id/ (#539).
+#
+# This lives here rather than in omni-pages so there is one description of how
+# the books are built. omni-pages clones this repository during its Vercel build
+# and calls this script, so a change to the Indonesian book's wiring does not
+# need a matching change in the site's repository to take effect.
+#
+# The Indonesian book has no book.toml of its own. mdBook reads config from the
+# environment with `MDBOOK_<section>__<key>`, which is three variables against a
+# second file that would then drift from the first on every theme change.
+#
+#   docs/website/build.sh [path-to-mdbook]
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MDBOOK="${1:-mdbook}"
+
+# The diagrams are shared. mdBook copies non-markdown files only from the src
+# directory it was given, so the Indonesian book needs its own copy of them, and
+# a copy made at build time is one that cannot fall behind the original. The
+# labels inside them are English either way, which is why they are not forked.
+rm -rf "$here/src-id/media"
+cp -R "$here/src/media" "$here/src-id/media"
+
+# The design-system overlay omni-pages drops into src/wl, when there is one. The
+# head.hbs it writes references it from every page of both books.
+if [ -d "$here/src/wl" ]; then
+  rm -rf "$here/src-id/wl"
+  cp -R "$here/src/wl" "$here/src-id/wl"
+fi
+
+"$MDBOOK" build "$here"
+env MDBOOK_book__src=src-id \
+    MDBOOK_book__language=id \
+    MDBOOK_build__build_dir=book-id \
+    "$MDBOOK" build "$here"
+
+# The Indonesian book is served from inside the English one, at /docs/id/, so it
+# is copied in rather than deployed separately. Doing it here means omni-pages
+# copies one tree and does not have to know a second book exists.
+rm -rf "$here/book/id"
+cp -R "$here/book-id" "$here/book/id"
+
+en="$(find "$here/book" -path "$here/book/id" -prune -o -name '*.html' -print | wc -l | tr -d ' ')"
+id="$(find "$here/book/id" -name '*.html' | wc -l | tr -d ' ')"
+echo "docs: ${en} English pages, ${id} Indonesian pages"

--- a/docs/website/build.sh
+++ b/docs/website/build.sh
@@ -31,9 +31,13 @@ if [ -d "$here/src/wl" ]; then
 fi
 
 "$MDBOOK" build "$here"
+# site-url is overridden too, and it is not cosmetic: it is what the 404 page and
+# the search index use to build absolute URLs, so leaving it at /docs/ would send
+# a reader who mistypes an Indonesian path into the English book.
 env MDBOOK_book__src=src-id \
     MDBOOK_book__language=id \
     MDBOOK_build__build_dir=book-id \
+    MDBOOK_output__html__site_url=/docs/id/ \
     "$MDBOOK" build "$here"
 
 # The Indonesian book is served from inside the English one, at /docs/id/, so it

--- a/docs/website/src-id/SUMMARY.md
+++ b/docs/website/src-id/SUMMARY.md
@@ -1,0 +1,46 @@
+# Summary
+
+[Mulai dari sini](index.md)
+
+# Memahami OMNI
+
+- [Apa itu OMNI](concepts/what-it-is.md)
+- [Di mana OMNI membantu](concepts/use-cases.md)
+- [Bagaimana OMNI memutuskan apa yang dipotong](concepts/how-it-decides.md)
+- [Tidak ada yang dihapus](concepts/nothing-is-deleted.md)
+- [Ledger](concepts/the-ledger.md)
+- [Yang tidak pernah disentuh](concepts/format-safety.md)
+- [Berapa ongkosnya](concepts/what-it-costs.md)
+
+# Memakai OMNI
+
+- [Pasang](use/install.md)
+- [Satu jam pertama](use/first-hour.md)
+- [Membaca penanda](use/markers.md)
+- [Melihat berapa yang dihemat](use/seeing-savings.md)
+- [Ingatan antar sesi](use/memory.md)
+- [Kalau ada yang terlihat salah](use/troubleshooting.md)
+
+# Rujukan
+
+- [Perintah](reference/commands.md)
+  - [init](reference/cmd/init.md)
+  - [doctor](reference/cmd/doctor.md)
+  - [stats](reference/cmd/stats.md)
+  - [exec](reference/cmd/exec.md)
+  - [retrieve](reference/cmd/retrieve.md)
+  - [session](reference/cmd/session.md)
+  - [Sisanya](reference/cmd/rest.md)
+- [Variabel lingkungan](reference/environment.md)
+- [Perkakas MCP](reference/mcp-tools.md)
+- [Hook](reference/hooks.md)
+- [Agent yang didukung](reference/agents.md)
+
+# Integrasi
+
+- [Hermes Agent](integrations/hermes.md)
+- [Loop engineering](integrations/loops.md)
+
+# Mengembangkan OMNI
+
+- [Bagian pengembang, dalam bahasa Inggris](develop/index.md)

--- a/docs/website/src-id/concepts/format-safety.md
+++ b/docs/website/src-id/concepts/format-safety.md
@@ -1,0 +1,78 @@
+# Yang tidak pernah disentuh
+
+Sebelum apa pun berjalan, muatannya diklasifikasi dulu. Kalau ia tampak seperti
+sesuatu yang akan diurai langkah berikutnya, seluruh pipeline mundur dan byte-nya
+kembali persis seperti saat datang.
+
+Empat jenis dikenali: **JSON**, **YAML**, **CSV** dan **TSV**. Mengenali salah
+satunya sudah menutup perkara.
+
+Ini tahap yang orang kira kegagalan. `kubectl get pods -o json` yang kembali
+utuh bukan OMNI melewatkan kesempatan, itu OMNI menolak kesempatan.
+
+## Kenapa menolak adalah jawaban yang benar
+
+Dokumen JSON yang disuling bukan dokumen JSON yang lebih kecil. Ia dokumen JSON
+yang rusak. `jq` dua langkah kemudian gagal, agent membaca kegagalan itu, dan
+ongkos bolak-balik tersebut lebih besar daripada apa pun yang bisa dihemat
+kompresinya.
+
+Jadi gerbangnya sengaja dibuat berat sebelah. Masukan yang berkurung tapi tidak
+bisa diurai, JSON terpotong, JSON yang membawa komentar: semuanya diperlakukan
+sebagai terstruktur. Kompresi tidak bisa memperbaiki muatan yang cacat, tapi ia
+jelas bisa memperburuknya.
+
+## Cara ia memutuskan, dan di mana ia pernah salah
+
+**JSON**: satu dokumen utuh yang berhasil diurai. Di atas ambang ukuran
+tertentu, penguraian `serde_json` penuh akan menjebol anggaran latensi, jadi
+bentuk kurungnya saja yang memutuskan. Teks bebas nyaris tidak pernah membawa
+`"key":`, dan itu sinyal murah untuk kasus yang meragukan.
+
+**YAML**: baris berbentuk kunci, ditambah satu aturan yang ada gara-gara
+kegagalan nyata. Block scalar (`config.hcl: |`) menyerahkan sisa bloknya ke apa
+pun kebetulan isinya: HCL Vault, skrip shell, sertifikat PEM. Baris-baris itu
+tidak membawa `key:` dan tidak berbentuk YAML, jadi pengendus yang naif menyebut
+mereka prosa. Satu ConfigMap yang tertanam menenggelamkan seluruh manifes
+`kubectl kustomize` 608 baris dengan cara itu: pengendusnya bilang "bukan YAML",
+gerbangnya mundur, dan manifesnya masuk ke jalur yang membuang data. Baris yang
+diawali indikator blok sekarang dilewati, bukan dinilai.
+
+**CSV dan TSV**: jumlah pemisah yang konsisten sepanjang sejumlah minimum baris.
+Satu baris tidak membuktikan apa pun.
+
+## Mematikannya, dan kapan perlu
+
+```sh
+OMNI_PASSTHROUGH=1 <perintah Anda>
+```
+
+Melewati pipeline sepenuhnya. Pakai ketika Anda sedang menelusuri OMNI itu
+sendiri dan perlu melihat apa yang sebenarnya dicetak sebuah perintah, atau
+ketika membaca berkas yang byte persisnya penting.
+
+Awalan itu bekerja di semua jalur, termasuk di dalam agent, tapi bukan karena
+alasan yang tampak. Sebuah hook adalah proses terpisah yang dijalankan host, jadi
+ia mewarisi lingkungan host dan tidak pernah melihat variabel yang Anda tulis di
+depan sebuah perintah. Yang ia lihat adalah string perintahnya, jadi OMNI membaca
+penugasan variabelnya di situ. Dua akibat yang layak diketahui: hanya penugasan
+**di depan** yang dihitung, posisi yang sama dengan yang akan dipakai shell, dan
+`echo OMNI_PASSTHROUGH=1` menyebut namanya tanpa menyetel apa pun sehingga tetap
+disuling. Meng-export-nya untuk satu sesi penuh bekerja seperti biasa.
+
+Ini variabel lingkungan paling berguna di sini, dan hal pertama yang harus diraih
+ketika Anda curiga OMNI mengubah sesuatu yang seharusnya tidak ia ubah. Kalau
+keluarannya identik dengan dan tanpa variabel itu, OMNI tidak terlibat.
+
+## Hal-hal yang mirip gerbang ini padahal bukan
+
+**Penghematan negatif pada keluaran kecil.** Muatan pendek bisa kembali beberapa
+persen lebih besar, karena penandanya berongkos lebih mahal daripada yang dihemat
+kompresinya. Wajar, bukan cacat.
+
+**Perintah yang keluarannya utuh saja.** Sekitar 97% panggilan tidak menghemat
+apa pun, karena memang tidak ada yang bisa dihemat. Itu pipeline yang bekerja.
+
+**Aliran biner `kubectl`.** SPDY merusak yang itu, ada atau tidak ada OMNI.
+
+**Kutip di shell.** Pemisahan kata itu urusan shell Anda, bukan program ini.

--- a/docs/website/src-id/concepts/how-it-decides.md
+++ b/docs/website/src-id/concepts/how-it-decides.md
@@ -1,0 +1,108 @@
+# Bagaimana OMNI memutuskan apa yang dipotong
+
+Pipeline-nya tetap dan setiap muatan melewati tahapan yang sama:
+
+```
+Read → Guard → Score → Distill → [Collapse] → Ledger → Route → Persist
+```
+
+Tidak satu pun boleh mengarang apa pun, dan masing-masing boleh menolak. Collapse
+ditulis dalam kurung karena ia cadangan, bukan langkah wajib: ia hanya berjalan
+kalau bentuk hasil sulingan gagal melewati ambang pengaman.
+[The pipeline, stage by stage](https://omni.weekndlabs.com/docs/develop/pipeline)
+memuat diagram dan alasannya, dalam bahasa Inggris.
+
+## Guard
+
+Gerbangnya. Ia menjawab satu pertanyaan: apakah muatan ini sesuatu yang akan
+diurai langkah berikutnya? Kalau ya, tidak ada tahap sesudahnya yang berjalan dan
+byte-nya kembali persis seperti saat datang.
+[Yang tidak pernah disentuh](format-safety.md) adalah keseluruhan tahap ini dan
+ia pantas punya halaman sendiri, karena "OMNI tidak melakukan apa-apa" biasanya
+berarti tahap ini bekerja dengan benar, bukan gagal.
+
+## Score
+
+Setiap baris mendapat tingkat relevansi. Penilainya fungsi murni dari teksnya,
+perintah yang menghasilkannya, dan riwayat sesi yang ada.
+
+| tingkat | bobot | apa yang mendarat di sini |
+|---|---|---|
+| Critical | 1,0 | galat, kegagalan, baris vonis, apa pun yang menyebut nama berkas dan nomor baris |
+| Important | 0,7 | peringatan, hitungan, keadaan yang berubah |
+| Noise | 0,1 | progres, waktu, hiasan, basa-basi yang berulang |
+
+Penentuan tingkat terjadi **sebelum** distiller mana pun melihat blok tersebut,
+dan itu penting saat Anda menelusuri kenapa sebuah distiller berperilaku aneh:
+bisa jadi tingkatnya yang sudah menentukan hasilnya, jadi periksa tingkat tiap
+segmen sebelum menulis ulang distiller-nya.
+
+## Distill
+
+Sekarang penyaring khusus per tool berjalan, dipilih dengan mencocokkan
+perintahnya. Distiller `cargo test` menyimpan hitungannya dan setiap kegagalan
+beserta assertion-nya. Distiller `git` menyimpan jalur berkas yang berubah.
+Distiller pencarian menyimpan baris yang cocok beserta nama berkasnya.
+
+Semuanya mengimplementasikan trait yang sama, dan tanda tangannya adalah
+rancangannya:
+
+```rust
+fn distill(&self, segments: &[OutputSegment], input: &str,
+           session: Option<&SessionState>) -> Option<String>;
+```
+
+`Option`, bukan `String`. Distiller yang tidak memahami masukannya mengembalikan
+`None` dan pemanggilnya menyerahkan byte mentah. Itu bedanya antara "saya membaca
+ini dan inilah yang penting" dengan "saya tidak mengenali apa pun dan inilah
+ringkasan yang percaya diri tentangnya", dan itu ditegakkan compiler untuk semua
+12 distiller, bukan oleh masing-masing penulis yang ingat memeriksa.
+
+## Collapse
+
+Deretan baris yang nyaris identik menjadi satu baris yang menyebut jumlahnya. Dua
+puluh baris `Downloading foo v1.2.3` menjadi satu.
+
+Dua hal soal tahap ini mengejutkan orang. Ia berjalan **setelah** distiller dan
+hanya kalau distiller-nya tidak layak dipakai: kedua hook menyuling byte mentah,
+bertanya ke `beats_guardrail`, dan baru meraih bentuk hasil collapse kalau itu
+gagal. Jadi distiller selalu membaca keluaran asli, tidak pernah penanda
+`[N similar lines collapsed]`. Lalu, mode collapse mana yang aktif dipilih
+berdasarkan kekhususan, sehingga perintah `kubectl` yang disalurkan ke `grep`
+bisa mengambil jalur infrastruktur alih-alih jalur log.
+
+## Ledger
+
+Semua yang di atas menilai muatan ini berdiri sendiri. Ledger satu-satunya tahap
+yang menilainya terhadap apa yang sudah pernah ditunjukkan ke agent, mengganti
+deretan baris berulang dengan sebuah penanda dan sebuah handle. Ia sumber
+penghematan tunggal terbesar dan punya halaman sendiri:
+[Ledger](the-ledger.md).
+
+## Persist
+
+Masukan mentahnya diarsipkan, dikunci dengan SHA-256, dan penanda yang dilihat
+agent membawa handle ke arsip itu. Dibahas di
+[Tidak ada yang dihapus](nothing-is-deleted.md).
+
+Pengarsipan tetap terjadi walau proyeksinya tidak menghemat apa pun. Sebuah blok
+layak diingat karena ia mungkin terlihat lagi, bukan karena ia terkompresi hari
+ini.
+
+## Apa yang menentukan urutannya
+
+Kebenaran mengalahkan kompresi di setiap tahap, dan urutan menangnya ditulis:
+
+1. **Jangan pernah mengarang.** Tahap yang tidak mengenali apa pun mengembalikan
+   apa yang ia terima. Perintah yang gagal lewat apa adanya. Muatan terstruktur
+   tidak pernah disentuh.
+2. **Jangan pernah menghilangkan jawaban diam-diam.** Apa pun yang dibuang
+   meninggalkan penanda, dan kalau isinya memungkinkan, sebuah handle yang
+   mengambilnya kembali.
+3. **Baru kompres**, sekeras yang diizinkan dua aturan pertama dan tidak lebih.
+
+Alasan urutan itu ditulis eksplisit adalah karena proyek ini pernah
+melanggarnya. Sebuah tabel `kubectl` pernah keluar sebagai `k8s: 2 pods` karena
+tabel pod adalah pendaftaran yang setiap barisnya sebuah data. Ia melaporkan
+penghematan besar. Tidak ada basa-basi di masukannya untuk dibuang, jadi yang
+dihemat itu jawabannya.

--- a/docs/website/src-id/concepts/nothing-is-deleted.md
+++ b/docs/website/src-id/concepts/nothing-is-deleted.md
@@ -1,0 +1,71 @@
+# Tidak ada yang dihapus
+
+Setiap byte yang dibuang OMNI ditulis dulu ke arsip SQLite lokal, dikunci dengan
+SHA-256 miliknya. Agent menerima penanda yang membawa handle 16 karakter, dan
+handle itu mengembalikan aslinya persis byte demi byte.
+
+```
+[OMNI: 406 lines omitted, omni retrieve 3f7bfd89bc5d7cee for full output]
+```
+
+```sh
+omni retrieve 3f7bfd89bc5d7cee
+```
+
+Itu jalan dari shell mana pun, di sesi mana pun, di host mana pun, dan ia tidak
+menjalankan ulang perintah Anda. Kalau MCP terpasang, agent bisa melakukannya
+sendiri lewat perkakas `omni_retrieve` tanpa bertanya ke Anda.
+
+## Kenapa aturan ini yang menanggung beban
+
+Menyaring keluaran adalah taruhan bahwa bagian yang dibuang tidak penting.
+Arsipnya yang membuat taruhan itu aman untuk kalah. Ia mengubah kasus terburuk
+dari "jawabannya hilang" menjadi "jawabannya berharga satu kali pengambilan", dan
+selisih itulah yang membuat sisa pipeline boleh agresif sama sekali.
+
+Ia juga mengubah arti sebuah bug di sini. Distiller yang memotong terlalu banyak
+adalah pertukaran yang buruk. Handle yang tidak bisa dipanggil adalah janji yang
+diingkari, dan itu satu-satunya cacat yang tidak boleh dimiliki mekanisme ini.
+
+## Satu aturan yang dipaksakan arsip pada semua yang lain
+
+Sebuah run diarsipkan **sebelum** penandanya ditulis, dan pengarsipan yang gagal
+berarti run itu tetap apa adanya.
+
+Urutannya penting. Menulis penanda dulu lalu mengarsipkan belakangan akan
+menghasilkan, pada setiap kegagalan tulis, penanda yang menunjuk isi yang tidak
+pernah tersimpan: keluaran yang tampak bisa dipulihkan padahal tidak. Itu pernah
+terjadi, `store_rewind` mengembalikan kunci bahkan ketika penulisannya gagal, dan
+perbaikannya adalah membuat penanda bergantung pada arsip, bukan sebaliknya.
+
+Jadi ketika Anda melihat sebuah handle, isi di baliknya ada. Itu bukan harapan,
+itu urutan dua pernyataan.
+
+## Berapa ongkosnya
+
+Ruang disk, dan satu penulisan pada setiap penyulingan yang membuang sesuatu.
+
+Arsipnya dibatasi, bukan tanpa batas: mengarsipkan setiap penyulingan yang
+kehilangan data terukur 83,1 MB selama 30 hari, dan membatasi blok yang
+diarsipkan di 64 KB menurunkannya ke 13,3 MB sambil tetap mencakup 3.604 dari
+3.657 baris. Batas itu dipilih dari pengukuran tersebut, bukan dikira-kira.
+
+Jejak yang dipakai untuk benchmark dipangkas terpisah, secara bawaan pada hari
+ketujuh. Pemangkasan itu alasan tidak ada angka yang diterbitkan di sini bisa
+diturunkan ulang setelah seminggu, dan alasan setiap angka di
+[Benchmarks](https://omni.weekndlabs.com/docs/develop/benchmarks) menyebut jendela
+waktu pengukurannya.
+
+## Di mana ia tinggal
+
+`~/.omni/omni.db`, satu berkas SQLite. Ia tidak pernah meninggalkan mesin Anda.
+
+```sh
+omni stats            # apa saja yang sudah ia kerjakan
+omni diff             # perintah terakhir, mentah dibanding hasil sulingan
+omni retrieve <handle>
+```
+
+`omni diff` cara tercepat menumbuhkan kepercayaan pada hal ini: jalankan satu
+perintah yang berisik, lalu lihat persis apa yang diserahkan ke agent sebagai
+gantinya.

--- a/docs/website/src-id/concepts/the-ledger.md
+++ b/docs/website/src-id/concepts/the-ledger.md
@@ -1,0 +1,219 @@
+# Ledger
+
+Setiap distiller menjawab pertanyaan yang sama, satu perintah pada satu waktu:
+dengan keluaran ini, apa yang boleh dibuang.
+
+Ledger menjawab pertanyaan lain: dengan semua yang sudah ditampilkan di sesi ini,
+bagian mana dari keluaran ini yang cuma mengulang.
+
+Keduanya tegak lurus, dan pada korpus nyata yang kedua lebih bernilai. Diputar
+ulang atas 6.656 jejak, **22,9% byte mentah adalah baris yang sudah pernah
+ditunjukkan ke agent, dan 22,4% masih begitu setelah semua distiller berjalan.**
+Penyaringan nyaris tidak menggores pengulangan, karena pengulangan bukan
+kebisingan. Setiap barisnya sinyal yang sangat baik. Ia cuma sinyal yang sudah
+pernah dikirim.
+
+## Apa yang ia lakukan
+
+Deretan baris berurutan yang semuanya pernah dikeluarkan sebelumnya menjadi satu
+penanda yang menyebut jumlahnya dan sebuah handle. Sisanya lewat persis byte demi
+byte.
+
+```
+[OMNI: 40 lines already shown, omni retrieve bc7e821a4340073e]
+```
+
+Ia menjangkau kelas yang tidak bisa dijangkau apa pun. Pembacaan berkas adalah
+kelas terbesar di korpus, dan penyaring menghemat **0,0%** darinya, dan itu
+benar: Anda tidak bisa membuang baris dari berkas yang diminta agent tanpa
+menebak bagian mana yang ia maksud. Ledger mengambil 25,0% dari kelas yang sama
+tanpa menebak apa pun, karena baris-baris itu sudah pernah dikirim sekali.
+
+## Dua cakupan, dua klaim yang berbeda
+
+Keduanya bukan pernyataan yang sama dan penandanya menyebut klaim mana yang
+sedang dibuat.
+
+| asal | penanda | artinya |
+|---|---|---|
+| sesi | `N lines already shown` | agent masih memegang byte ini, jadi handle-nya gratis kecuali ia memilih membaca ulang |
+| proyek | `N lines from an earlier session` | ini pergi ke sesi lain dari proyek ini dan agent ini **belum pernah melihatnya** |
+
+Perbedaan itu keseluruhan alasan cakupan proyek ada. Rancangan sebelumnya
+membatalkannya dengan alasan bahwa handle untuk isi sesi lain adalah kebohongan,
+yang benar soal kalimatnya dan salah soal obatnya: perbaikannya adalah berhenti
+bilang "already shown", bukan berhenti mengingat.
+
+Karena klaim proyek tidak gratis, ia memikul ambang yang lebih tinggi. Deretan
+yang berasal dari sesi harus menghemat 150 byte di atas penandanya; deretan yang
+berasal dari proyek harus menghemat tiga kali lipatnya, sebab agent tidak punya
+pilihan selain membayar satu pengambilan kalau ia butuh isinya.
+
+## Premis yang mendasari semua sisanya
+
+> Agent masih memegang byte ini.
+
+Satu pernyataan itulah yang memberi izin mengganti empat puluh baris dengan
+sebuah handle. Setiap aturan di bawah adalah akibat dari premis itu atau
+pembelaan atas saat premis itu berhenti benar. Kalau Anda mendapati diri bertanya
+kenapa ledger melakukan sesuatu, tanyakan apa yang perlu terjadi supaya premisnya
+salah, dan jawabannya biasanya ada di situ.
+
+Itu juga sebabnya ini persoalan pembatalan cache, bukan sistem ingatan. Ledger
+tidak menyimpan pengetahuan. Ia menyimpan tanda terima.
+
+## Alurnya, satu perintah pada satu waktu
+
+![Empat pertanyaan menentukan satu pelipatan: apakah barisnya menyatakan kegagalan, apakah ia sudah pernah ditampilkan, apakah deretannya menghemat lebih banyak daripada ongkos penandanya, dan apakah penulisan arsipnya berhasil. Satu saja "tidak" membuat baris-baris itu keluar apa adanya.](../media/the-ledger-decision.svg)
+
+Muatan terstruktur tidak pernah sampai sejauh ini: pengendus format yang sama
+yang menjaga collapse juga menjaga tahap ini.
+
+Dua detail mudah terlewat dan keduanya keseluruhan cerita kebenarannya.
+
+Pengarsipan terjadi **sebelum** penandanya, jadi sebuah handle tidak pernah
+menyebut isi yang tidak tersimpan. Dan yang dicatat adalah apa yang **dikirim**,
+bukan apa yang datang: deretan yang berubah jadi penanda tidak pernah sampai ke
+agent, jadi mencatatnya akan membuat kemunculan berikutnya mengklaim
+`already shown` untuk byte yang tidak diterima siapa pun. Itu cacat sungguhan
+([#465](https://github.com/fajarhide/omni/issues/465)) dan ia memotong dua arah,
+karena asal sesi ditagih sepertiga dari asal proyek, sehingga klaim yang salah
+tadi juga membuat ledger tiga kali lebih gampang melipat.
+
+## Bagaimana ia mengingat
+
+Tiga kata kerja, dan masing-masing tabel yang berbeda atau pemicu yang berbeda.
+
+### Simpan
+
+Dua tabel, disengaja.
+
+| | memuat | ukuran |
+|---|---|---|
+| `ledger_lines` | `(scope, line_hash, ts, agent_id)` | 16 byte hash per baris |
+| `rewind_store` | byte asli dari deretan yang dilipat, dikunci dengan SHA-256 miliknya | isinya, sekali per blok berbeda |
+
+Mencatat setiap baris yang dikeluarkan itu murah karena barisnya sendiri tidak
+pernah disimpan, hanya hash-nya. Isinya baru masuk ke arsip ketika sebuah handle
+benar-benar diterbitkan.
+
+Hash-nya diambil dari baris yang sudah **dipangkas spasinya**, jadi baris sama
+yang dicapai lewat `sed -n` dan lewat `cat` adalah satu baris, bukan dua.
+
+**Pencatatan tanpa syarat; pelipatan tidak.** Sebuah blok layak diingat karena ia
+mungkin muncul lagi, bukan karena ia terkompresi hari ini. Jadi perintah yang
+keluarannya sepenuhnya baru tetap menulis baris-barisnya, dan membayar dirinya
+sendiri di kesempatan berikutnya.
+
+### Ambil kembali
+
+```sh
+omni retrieve 3f7bfd89bc5d7cee
+```
+
+Pencarian persis pada alamat isi. Tidak ada himpunan kandidat, tidak ada
+pemeringkatan, tidak ada penggabungan hasil, dan tidak ada pencarian: satu handle
+menyebut satu blok byte. Handle-nya diturunkan dari isinya, jadi keluaran yang
+identik adalah satu baris tabel, berapa pun perintah yang menghasilkannya.
+
+Tidak ada yang ditarik kembali secara otomatis. Penandanya sebuah penunjuk, dan
+agent yang memutuskan apakah isinya sepadan dengan satu pengambilan. Itu
+pertukaran yang jadi tumpuan seluruh rancangan ini: kasus terburuknya bukan
+"jawabannya hilang", melainkan "jawabannya berharga satu kali bolak-balik".
+
+Kalau MCP terpasang, agent memanggil `omni_retrieve` sendiri. Kalau tidak, ia
+menjalankan perintah shell yang dicetak penandanya.
+
+### Lupa
+
+Waktu, ditambah satu peristiwa.
+
+**Saat pemadatan, cakupan sesi dibuang seluruhnya.** Pemadatan adalah momen di
+dalam sesi ketika agent berhenti memegang apa yang ditunjukkan kepadanya,
+sehingga setiap klaim yang bisa dibuat cakupan sesi menjadi salah sekaligus.
+Melupakan berongkos satu pengurangan yang terlewat. Tidak melupakan berarti
+memberi tahu agent bahwa ia punya isi yang tidak lagi ada di konteksnya, dan
+itulah cacatnya, bukan ongkosnya.
+
+**Pada hari ke-30, kedua cakupan dipangkas pada jendela yang sama.** Cakupan sesi
+tidak bisa hidup lebih lama daripada sesinya, jadi jendela retensi biasa sudah
+membatasinya. Cakupan proyek yang bisa tumbuh tanpa batas, dan batas jujurnya
+adalah jendela yang sama: isi yang tidak dihasilkan siapa pun selama sebulan
+adalah isi yang berhenti dikeluarkan proyek ini, dan handle untuknya cuma membeli
+pengambilan sesuatu yang juga tidak akan dikenali agent.
+
+Pengulangan menyegarkan cap waktunya alih-alih diabaikan, jadi keluaran yang
+masih diproduksi tidak menua keluar hanya karena kapan ia pertama terlihat.
+
+Tidak ada penggusuran berdasarkan ukuran, dan itu disengaja. Menggusur
+berdasarkan ukuran membuang baris tertua dari proyek tersibuk lebih dulu, dan di
+situlah justru pengulangannya berada.
+
+## Apa yang dibagi dua agent dalam satu repo
+
+Cakupan sesi milik satu agent, karena id sesi sebuah host milik satu host.
+**Cakupan proyek dikunci pada direktori kerja dan tidak pada apa pun selain
+itu**, jadi dua agent yang berjalan di repositori yang sama menulis ke satu
+riwayat dan membaca darinya.
+
+Itu berbagi sebagai efek samping, bukan karena dirancang. Tidak ada bagian ledger
+yang tahu ia sedang bicara dengan agent yang mana, jadi penanda berasal proyek
+bisa menyerahkan ke agent B sebuah handle untuk baris yang cuma pernah
+ditunjukkan ke agent A. Kalimatnya tetap benar, baris-baris itu memang datang
+dari sesi sebelumnya, dan ambang yang lebih tinggi berarti pertukarannya sudah
+dihargai sebagai satu pengambilan. Tapi `from an earlier session` terbaca sebagai
+sesi *Anda* padahal bisa jadi bukan.
+
+Sejak [#509](https://github.com/fajarhide/omni/issues/509) agent dicatat di setiap
+baris, dan belum ada yang dikunci padanya. Pengukuran yang memutuskan itu:
+mengunci cakupan pada `(proyek, agent)` akan mengakhiri kasus lintas agent
+sekaligus penggunaan ulang di dalamnya yang memang gratis, dan korpus mengatakan
+efeknya saat ini terpendam, bukan aktif. Kolom itu yang membuat pertanyaannya
+bisa diajukan.
+
+## Aturan yang ia warisi
+
+**Hanya menambah di belakang.** Ia hanya memendekkan keluaran perintah yang
+sedang berjalan dan tidak pernah menulis ulang apa pun yang sudah dikirim. Itu
+yang menjaga prompt cache di hulu tetap utuh: cache bekerja pada awalan, jadi
+memendekkan bagian belakang tidak berongkos sementara pemadatan surut akan
+menghancurkannya.
+
+**Deterministik.** Keadaan ledger yang sama menghasilkan keluaran yang identik
+byte demi byte. Handle-nya alamat isi dan tidak membawa cap waktu. Rancangan
+sebelumnya memakai `{timestamp}_{hash}` dan membuat 4 dari 73 masukan berulang
+mengeluarkan byte yang berbeda.
+
+**Tidak ada yang hilang.** Sudah disebut di atas dan ditegakkan oleh urutan dua
+penulisan. Aturan umumnya dan ongkosnya ada di
+[Tidak ada yang dihapus](nothing-is-deleted.md).
+
+**Kegagalan tidak pernah dilipat.** Baris yang menyatakan kegagalan dikecualikan
+sesering apa pun ia sudah ditampilkan. "Anda sudah pernah melihat ini" masuk akal
+untuk baris informasi dan salah untuk kanal galat, tempat pengulangan justru
+sinyalnya: TypeError yang sama pada run ulang berarti bug-nya masih ada.
+Menghilangkannya mengirimkan konteks kode tanpa pernyataan apa yang salah, yang
+wajar dibaca agent sebagai kegagalan yang sudah diperbaiki. Menandai barisnya
+sebagai belum terlihat, alih-alih menyaringnya belakangan, juga memecah deretan
+di sekelilingnya, sehingga bingkai di kedua sisinya tetap terlipat.
+
+**Tidak dikenali berarti tidak disentuh.** Muatan terstruktur sama sekali tidak
+pernah sampai ke ledger.
+
+## Berapa nilainya
+
+Dari pemutaran ulang yang sama, ledger memberi tambahan 12,2 poin di atas
+penyaring OMNI sendiri dan 11,4 poin di atas milik pesaing, dan itu pernyataan
+paling jelas bahwa ia tegak lurus terhadap pola siapa yang berjalan:
+
+| | byte | hemat |
+|---|---|---|
+| omni, penyaring saja | 6.469.047 ke 6.292.856 | 2,7% |
+| rtk `pipe` | 6.469.047 ke 6.067.012 | 6,2% |
+| lean-ctx `compress` | 6.469.047 ke 6.073.757 | 6,1% |
+| omni, dengan ledger | 6.469.047 ke 5.506.627 | **14,9%** |
+| rtk `pipe` + ledger omni | 6.469.047 ke 5.333.483 | 17,6% |
+
+Baris terakhir disengaja. Pembaca yang mau angka sebesar mungkin akan menjalankan
+penyaring mereka dengan ledger kami, dan mengatakannya lebih murah daripada
+ketahuan tidak mengatakannya.

--- a/docs/website/src-id/concepts/use-cases.md
+++ b/docs/website/src-id/concepts/use-cases.md
@@ -1,0 +1,133 @@
+# Di mana OMNI membantu
+
+Enam situasi, masing-masing dengan angka terukurnya. Dua di antaranya kasus
+ketika OMNI tidak melakukan apa-apa, dan keduanya sengaja dimuat di sini:
+perkakas yang mengaku membantu di mana-mana adalah perkakas yang tidak bisa
+ditebak siapa pun.
+
+Setiap angka berasal dari pemutaran ulang 6.656 perintah nyata yang sama seperti
+yang diuraikan di
+[Benchmarks](https://omni.weekndlabs.com/docs/develop/benchmarks), jadi semuanya
+rata-rata atas campuran perintah yang nyata, bukan hari bagus yang dipetik dari
+sebuah log.
+
+## 1. Agent membaca ulang berkas yang sama terus-menerus
+
+**Situasinya.** Anda minta refactor. Agent membaca `auth.rs`, melipir memeriksa
+pemanggilnya, kembali lalu membaca `auth.rs` lagi. Enam giliran kemudian ia
+membacanya untuk ketiga kali. Setiap bacaan ditagih penuh, dan tidak satu pun
+pengulangan itu memberi tahu sesuatu yang belum diberi tahu bacaan pertama.
+
+**Yang OMNI lakukan.** Bacaan kedua kembali sebagai penanda dengan handle.
+Baris-barisnya sudah ada di konteks agent; mengirimnya lagi berarti membayar dua
+kali untuk satu fakta.
+
+**Angkanya: 25,0%** lebih hemat pada pembacaan berkas di seluruh korpus, dan
+sampai **97,2%** pada satu berkas yang dibaca berulang.
+
+Ini kemenangan tunggal terbesar di seluruh produk dan ia tidak terlihat selagi
+bekerja, dan itulah alasan penandanya ada.
+
+## 2. Test gagal dan Anda tidak bisa melihat kenapa
+
+**Situasinya.** 412 test, satu gagal, dan kegagalannya ada di baris 388 keluaran.
+Agent Anda membaca semua 412 baris untuk menemukannya, dan kalau run-nya cukup
+panjang host memotong ekornya, yang justru tempat vonis itu tinggal.
+
+**Yang OMNI lakukan.** Distiller test menyimpan hitungannya dan setiap kegagalan
+lengkap dengan assertion serta posisi berkasnya, lalu membuang baris yang lulus.
+
+**Angkanya: 78,0%** lebih hemat pada keluaran build dan test.
+
+Ini kasus ketika yang bekerja adalah penyaringan, bukan ledger. Keluaran test
+sangat berulang di dalam satu run, jadi ada basa-basi sungguhan untuk dibuang
+bahkan sebelum ada yang terlihat dua kali.
+
+## 3. `git log` dan `git diff` memenuhi layar
+
+**Situasinya.** Satu commit dengan `Author`, `Date` dan badan yang dilipat itu
+lima baris. Lima belas commit jadi satu setengah layar, padahal agent Anda cuma
+mau subjeknya.
+
+**Yang OMNI lakukan.** Setiap commit disimpan, sebagai satu baris
+`hash subject`. Tidak ada yang diringkas hilang dan tidak ada commit yang lenyap;
+yang pergi amplop di sekeliling masing-masing.
+
+**Angkanya: 22,1%** pada `git` dan `gh` di korpus, dan **94%** khusus pada
+`git log -15` yang bertele-tele.
+
+## 4. Sesi Anda mati di batas konteks, berulang kali
+
+**Situasinya.** Sesi debugging panjang, dan sekitar dua jam berjalan percakapan
+dipadatkan. Agent kehilangan alur, membaca ulang berkas yang sudah ia pahami, dan
+Anda menjelaskan ulang tugasnya.
+
+**Yang OMNI lakukan.** Dua hal. Konteks yang terpakai per perintah lebih sedikit
+berarti temboknya datang belakangan. Dan [ingatan antar sesi](../use/memory.md)
+selamat dari pemadatan: pengetahuan proyek, pola galat yang berulang, dan tujuan
+yang Anda pancang dengan `omni goal` ada di SQLite, bukan di jendela konteks.
+
+**Batas jujurnya.** OMNI tidak bisa mencegah pemadatan, dan pada saat pemadatan
+terjadi ia sengaja melupakan apa yang sudah ia tunjukkan, karena izin untuk
+mengganti baris dengan handle adalah bahwa agent masih memegang baris-baris itu,
+dan pemadatan adalah saat hal itu berhenti benar.
+
+## 5. Anda pindah agent, atau pindah mesin, di tengah proyek
+
+**Situasinya.** Anda mulai di Claude Code, pindah ke Codex CLI untuk satu
+perubahan, dan keduanya mulai dari nol.
+
+**Yang OMNI lakukan.** Penyimpanannya satu berkas SQLite yang dikunci pada jalur
+proyek, bukan pada agent. Agent kedua yang bekerja di direktori yang sama membaca
+pengetahuan proyek yang sama, dan cakupan proyek pada ledger akan memberinya
+handle untuk keluaran yang sudah dihasilkan sesi sebelumnya. Penanda itu berbunyi
+`from an earlier session`, bukan `already shown`, karena agent ini memang belum
+pernah melihat byte tersebut dan kalimatnya harus benar.
+
+**Angka jujurnya.** Pengulangan lintas sesi adalah **3,7%** dari byte setelah
+penyaringan, berbanding **19,1%** di dalam satu sesi, jadi nilainya sekitar
+seperlima penghematan dalam sesi. Ia nyata, dan ia bukan judulnya.
+
+**Peringatan jujurnya.** Dua agent dalam satu repositori berbagi riwayat itu
+sebagai efek samping, bukan karena dirancang begitu, dan
+`from an earlier session` bisa terbaca sebagai sesi *Anda* padahal itu sesi orang
+lain. [Ledger](the-ledger.md#apa-yang-dibagi-dua-agent-dalam-satu-repo) berterus
+terang soal apa yang hari ini dikunci pada agent dan apa yang tidak.
+
+## 6. `kubectl get pods -o json | jq`
+
+**Situasinya.** Anda menyalurkan keluaran terstruktur ke sesuatu yang menguraikan
+keluaran itu.
+
+**Yang OMNI lakukan: tidak ada.** JSON, YAML, NDJSON, CSV dan TSV lewat persis
+byte demi byte. Kompresor yang mengubah format muatan yang sebentar lagi diurai
+perintah berikutnya tidak menghemat apa pun untuk Anda, ia merusak pipeline Anda.
+
+**Angkanya: 0%**, memang dirancang begitu. Lihat
+[Yang tidak pernah disentuh](format-safety.md).
+
+## Dan satu lagi yang juga tidak terjadi apa-apa
+
+`kubectl get pods` dengan 35 pod mengembalikan tabel yang setiap barisnya sebuah
+fakta. Tidak ada basa-basi untuk dibuang dan belum ada yang pernah dilihat, jadi
+OMNI mengembalikan seluruh 35 baris dan melaporkan penghematan 0%.
+
+**97,3% dari semua panggilan di korpus seperti ini.** Itu angka yang layak
+diresapi: OMNI bukan barang yang mengecilkan segalanya sedikit, ia barang yang
+tidak berbuat apa-apa hampir sepanjang waktu lalu berbuat banyak sesekali. Angka
+gabungan 14,9% adalah sisa setelah setiap nol tadi ikut dihitung.
+
+## Totalnya jadi apa
+
+| Kelas perintah | Panggilan di korpus | Hemat |
+|---|---|---|
+| build dan test | 69 | 78,0% |
+| pembacaan berkas | 699 | 25,0% |
+| `git`, `gh` | 661 | 22,1% |
+| pencarian (`grep`, `rg`, `find`) | 828 | 13,3% |
+| infra (`kubectl`, `az`, `docker`) | 254 | 8,2% |
+| selebihnya | 4.145 | 6,9% |
+| **semuanya** | **6.656** | **14,9%** |
+
+Jalankan `omni stats` setelah beberapa hari dan Anda mendapat tabel ini untuk
+riwayat Anda sendiri, satu-satunya versi yang menggambarkan pekerjaan Anda.

--- a/docs/website/src-id/concepts/what-it-costs.md
+++ b/docs/website/src-id/concepts/what-it-costs.md
@@ -1,0 +1,89 @@
+# Berapa ongkosnya
+
+Bukan nol. Ini seluruh tagihannya.
+
+## Latensi
+
+Median dari 12 run masing-masing, binary rilis, diukur ujung ke ujung lewat
+post-hook:
+
+| | basis data baru | basis data 205 MB |
+|---|---|---|
+| `git status` (496 B) | **21,1 ms** | **60,7 ms** |
+| `cargo test` (16,5 KB) | **24,5 ms** | **64,5 ms** |
+
+Ukuran muatan hampir tidak berpengaruh. Ukuran basis data berpengaruh, dan itu
+angka yang perlu diawasi seiring arsip Anda tumbuh.
+
+Penyulingannya sendiri berdurasi milidetik satu digit. Nyaris seluruh sisanya
+adalah penulisan arsip. Rilis-rilis sebelumnya terukur 82 ms dan 276 ms di mesin
+yang sama, dan bedanya tiga perbaikan, bukan perangkat keras yang lebih cepat:
+tokenizer yang dimuat per perintah untuk satu kolom laporan, 249 regex penyaring
+baris yang dikompilasi entah penyaringnya cocok atau tidak, dan kolam koneksi
+yang membuka empat handle SQLite dalam proses yang selesai setelah satu muatan.
+
+> Ukur latensi dengan cara mencabut, bukan dengan pewaktu di unit test. Sebuah
+> microbenchmark di suite melaporkan 66 ms untuk pekerjaan yang oleh A/B pada
+> binary rilis dihitung 34,3 ms. Hanya angka jenis kedua yang layak dikutip.
+
+## Memori
+
+Datar. Pipeline-nya bekerja pada aliran, jadi log 20.000 baris tidak memakan
+memori residen lebih banyak daripada log pendek.
+
+## Disk
+
+Satu berkas SQLite di `~/.omni/omni.db`.
+
+Isi yang diarsipkan dibatasi 64 KB per blok. Batas itu datang dari pengukuran:
+mengarsipkan setiap penyulingan yang kehilangan data berongkos 83,1 MB selama 30
+hari, dan batas tersebut menurunkannya ke 13,3 MB sambil tetap mencakup 3.604
+dari 3.657 baris.
+
+Jejak benchmark dipangkas pada hari ketujuh (`OMNI_TRACE_RETENTION_DAYS`).
+Pemangkasan itu alasan tidak ada angka yang diterbitkan bisa diturunkan ulang
+seminggu setelah ia diukur.
+
+## Token
+
+Bagian yang Anda cari, dan versi jujurnya punya dua paruh.
+
+**Yang ia hemat.** Atas 6.656 perintah nyata pada 0.7.3: 14,9% lebih sedikit byte
+di seluruh campuran. Per kelas, sebarannya sangat lebar:
+
+| kelas | penyaring | dengan ledger |
+|---|---|---|
+| build dan test | 76,9% | 78,0% |
+| pembacaan berkas | 0,0% | 25,0% |
+| `git`, `gh` | 4,4% | 22,1% |
+| pencarian | 4,8% | 13,3% |
+| infra | 4,4% | 8,2% |
+| selebihnya | 0,6% | 6,9% |
+
+**Yang ia biayakan.** Setiap penanda adalah byte yang dibayar agent, dan 97,3%
+panggilan tidak menghemat apa pun sambil tetap membayar latensi pipeline. Pada
+keluaran pendek, penandanya bisa melampaui penghematannya.
+
+Ada juga ongkos yang tidak bisa dinyatakan hitungan byte mana pun: satu
+pengambilan. Ketika agent butuh isi di balik sebuah handle, ia membayar satu kali
+bolak-balik yang tidak perlu ia bayar seandainya byte-nya tiba langsung.
+Pelipatan bercakupan proyek memikul ambang keuntungan tiga kali lipat persis
+karena alasan itu.
+
+## Ongkos yang bukan tanggungan OMNI
+
+Pada paket berlangganan tetap, kompresi sama sekali tidak mengurangi tagihan.
+Yang ia beli adalah umur sesi dan lebih sedikit run ulang. Pembacaan prompt cache
+ditagih sekitar sepersepuluh masukan baru, jadi byte yang dihemat sekali bukan
+uang yang dihemat per giliran.
+
+Itu sebabnya ukuran utama proyek ini sendiri adalah tekanan jendela konteks untuk
+pekerjaan yang sama, dan persentase pengurangan adalah alat diagnosis, bukan
+judul. Lihat
+[Where OMNI is going](https://omni.weekndlabs.com/docs/develop/direction).
+
+## Kalau ia panik
+
+Ia gagal terbuka. Keluaran mentahnya lewat dan agent Anda tidak pernah melihat
+galat. Setiap hook berjalan di dalam `catch_unwind`, dan basis data yang tidak
+mau dibuka berongkos konteks sesi, bukan seluruh pipeline.

--- a/docs/website/src-id/concepts/what-it-is.md
+++ b/docs/website/src-id/concepts/what-it-is.md
@@ -1,0 +1,115 @@
+# Apa itu OMNI
+
+**Program kecil di mesin Anda yang menyunting apa yang dibaca agent AI Anda,
+sebelum agent itu membacanya.**
+
+Itu saja idenya. Sisa halaman ini soal aturan yang ia patuhi sambil melakukan
+itu, dan aturannya lebih menarik daripada penyuntingannya.
+
+## Masalah yang jadi alasannya ada
+
+Agent yang bekerja di terminal menghabiskan sebagian besar konteksnya untuk
+keluaran yang tidak seorang pun memilih untuk mengirimnya:
+
+- satu kali test adalah 400 baris `ok` dan satu baris yang penting
+- satu kali build adalah log kompilasi yang membungkus vonis satu kata
+- sebuah berkas dibaca, lalu dibaca lagi tiga giliran kemudian, karena tidak ada
+  yang mengingat bacaan pertama
+
+Semua itu tidak gratis. Ia memenuhi jendela konteks, yang membuat sesi Anda
+selesai lebih cepat, dan Anda membayarnya lagi setiap kali percakapan dipadatkan.
+
+Solusi yang kelihatan jelas semuanya lebih buruk daripada masalahnya:
+
+| Solusinya | Kenapa gagal |
+|---|---|
+| Potong keluaran yang panjang | Yang terpotong bagian akhir, dan vonis justru tinggal di akhir |
+| Minta model meringkas | Satu panggilan inferensi per perintah, dan peringkas bisa salah |
+| Minta agent lebih hati-hati | Berhasil sampai agent-nya sibuk, yaitu selalu |
+
+OMNI adalah opsi keempat: program yang tahu keluaran `cargo test` itu bentuknya
+seperti apa, ingat apa yang sudah pernah ditunjukkan ke agent Anda, dan tidak
+pernah menebak saat ia ragu.
+
+## Di mana ia duduk
+
+Setiap host agent yang serius bisa menjalankan sebuah program ketika sebuah tool
+selesai, lalu memakai apa yang program itu kembalikan. Claude Code menyebutnya
+hook `PostToolUse`, host lain punya nama sendiri untuk ide yang sama. OMNI
+memasang dirinya di sana, dan di slot pasangannya sebelum tool berjalan, yang ia
+pakai hanya untuk menyerahkan perintah yang cocok ke dirinya sendiri. Perintahnya
+tetap berjalan tanpa perubahan; shell tidak pernah tahu.
+
+![OMNI berjalan sebagai dua hook di sekitar satu panggilan tool: pre-hook sebelum perintah, post-hook yang menyuling keluaran sebelum agent membacanya, dan semua yang dibuang diarsipkan ke basis data SQLite lokal yang dibaca kembali oleh omni retrieve.](../media/where-omni-sits.svg)
+
+Dua akibat mengikuti dari posisi itu, dan keduanya alasan bentuk ini dipilih
+ketimbang sebuah proxy.
+
+Ia melihat keluaran, bukan permintaan. API key Anda tidak pernah lewat, tidak ada
+permintaan yang tertunda menunggunya, dan kalau ia mati host tetap jalan dengan
+byte mentah.
+
+Ia tidak bisa membantu di tempat host-nya tidak mengizinkan. Host yang tidak
+menerapkan hasil tulis ulang sebuah hook pada tool shell bawaannya akan
+menunjukkan byte yang sama ke agent, sebagus apa pun penyaringnya. Itu bukan bug
+yang harus diperbaiki di OMNI, itu sifat host tersebut, dan
+[Agent yang didukung](../reference/agents.md) menyebut host mana ada di tingkat
+mana.
+
+## Apa yang ia lakukan pada sebuah perintah
+
+Empat hal, berurutan, dan masing-masing boleh memutuskan untuk tidak berbuat
+apa-apa:
+
+1. **Menolak.** JSON, YAML, base64, terraform plan, apa pun yang akan diurai oleh
+   langkah berikutnya: dikembalikan tanpa disentuh. Lihat
+   [Yang tidak pernah disentuh](format-safety.md).
+2. **Menyaring.** Distiller yang memahami tool ini menyimpan vonis dan
+   kegagalannya lalu membuang basa-basinya. Ada 12 distiller, mencakup build,
+   test, git dan version control lain, pencarian, cloud, basis data, perkakas
+   JavaScript dan TypeScript, pembacaan berkas, pemindai keamanan dan operasi
+   sistem, ditambah satu cadangan generik.
+3. **Melipat baris berulang.** Deretan panjang baris yang nyaris identik menjadi
+   satu baris yang menyebut ada berapa banyak.
+4. **Melipat yang sudah dilihat.** Baris yang sudah pernah ditunjukkan ke agent
+   menjadi sebuah handle, bukan pengulangan. Ini [ledger](the-ledger.md), dan
+   pada korpus nyata ia bekerja lebih banyak daripada para penyaring.
+
+Setelah itu masukan mentahnya masuk ke arsip, dan agent menerima hasilnya
+ditambah penanda yang menyebut apa yang terjadi.
+
+Kalau Anda lebih suka melihat ini sebagai situasi ketimbang sebagai tahapan,
+[Di mana OMNI membantu](use-cases.md) memuat enam situasi lengkap dengan
+penghematan terukurnya.
+
+## Apa yang bukan dia
+
+**Bukan kompresor.** Ia tidak berusaha membuat keluaran menjadi kecil. Ia
+berusaha menghasilkan keluaran yang bisa ditindaklanjuti agent, di samping angka
+yang bisa diperiksa manusia. Keduanya lebih sering tarik-menarik daripada yang
+Anda kira, dan ketika bertabrakan, angkanya yang mengalah.
+
+**Bukan peringkas.** Tidak ada model yang jalan di dalam pipeline. Anggaran waktu
+sebuah hook adalah milidetik satu digit dan tidak ada yang memuat panggilan
+inferensi yang muat di situ.
+
+**Bukan produk ingatan, walau ia punya satu.** `omni remember`, `omni goal` dan
+serah terima sesi ada karena agent yang sama yang membaca terlalu banyak juga
+melupakan segalanya antar sesi. [Ingatan antar sesi](../use/memory.md) membahas
+paruh itu.
+
+## Aturan yang paling ia seriusi
+
+> Tahap yang tidak mengenali apa pun mengembalikan apa yang ia terima.
+
+Kegagalan yang terus-menerus harus diperbaiki proyek ini bukan byte yang hilang.
+Melainkan ringkasan yang percaya diri atas masukan yang tidak pernah diurai:
+`find` yang melaporkan hemat 99% dengan membuang jalur berkas yang justru
+jawabannya, `cargo test` yang bilang `1 passed` untuk sebuah run yang oleh cargo
+sendiri disebut `490 passed`, dev server yang dilaporkan sebagai test suite yang
+lulus.
+
+Semuanya terkompresi dengan indah. Semuanya salah. Maka trait yang
+diimplementasikan setiap distiller mengembalikan `Option<String>`, dan distiller
+yang gagal mengurai mengembalikan `None` lalu pemanggilnya menyerahkan byte
+mentah. Itu ditegakkan oleh tipe data, bukan oleh ingatan penulisnya.

--- a/docs/website/src-id/develop/index.md
+++ b/docs/website/src-id/develop/index.md
@@ -1,0 +1,23 @@
+# Bagian pengembang, dalam bahasa Inggris
+
+Tujuh halaman ini tidak diterjemahkan. Isinya berubah paling sering dan
+pembacanya orang yang akan mengirim patch, jadi salinan Indonesia-nya akan lebih
+sering salah daripada membantu.
+
+- [Architecture](https://omni.weekndlabs.com/docs/develop/architecture)
+  Peta modulnya dan apa yang dimiliki masing-masing.
+- [The pipeline, stage by stage](https://omni.weekndlabs.com/docs/develop/pipeline)
+  Setiap tahap, apa yang boleh ia lakukan, dan apa yang tidak.
+- [Adding a distiller](https://omni.weekndlabs.com/docs/develop/adding-a-distiller)
+  Perubahan yang paling sering dilakukan orang di sini.
+- [Testing](https://omni.weekndlabs.com/docs/develop/testing)
+  Termasuk cara membuktikan sebuah test bisa gagal, yang di repo ini bukan
+  formalitas.
+- [Benchmarks](https://omni.weekndlabs.com/docs/develop/benchmarks)
+  Metode di balik setiap angka di manual ini, dan perintah untuk memutarnya ulang
+  di riwayat Anda sendiri.
+- [Where OMNI is going](https://omni.weekndlabs.com/docs/develop/direction)
+  Termasuk daftar hal yang sengaja tidak dibangun, beserta alasannya.
+- [Releasing](https://omni.weekndlabs.com/docs/develop/releasing)
+  Urutan langkahnya, dan jebakan yang pernah membuat satu rilis tidak
+  menghasilkan binary sama sekali.

--- a/docs/website/src-id/index.md
+++ b/docs/website/src-id/index.md
@@ -1,0 +1,147 @@
+# OMNI
+
+**Agent AI Anda membayar untuk membaca keluaran yang sama berulang kali. OMNI
+menghentikan itu.**
+
+OMNI adalah satu program kecil yang duduk di antara terminal Anda dan agent
+Anda. Jalannya lokal, tidak perlu API key, dan setelah terpasang Anda tidak
+pernah mengetik namanya lagi.
+
+```bash
+brew install fajarhide/tap/omni && omni init
+```
+
+Di dalam Claude Code cukup dua baris, sisanya diurus agent:
+
+```
+/plugin marketplace add fajarhide/omni
+/plugin install omni@omni
+```
+
+## Masalahnya, dalam satu layar
+
+Agent Anda menjalankan test. Empat ratus baris kembali, yang penting satu.
+
+```
+$ cargo test
+    Compiling omni v0.7.4
+     Running unittests src/lib.rs
+running 412 tests
+test pipeline::scorer::tests::scores_errors_critical ... ok
+... 409 baris "ok" lagi ...
+test result: FAILED. 411 passed; 1 failed
+```
+
+Yang dibaca agent Anda adalah ini:
+
+```
+cargo test: 411 passed, 1 failed
+  FAILED ledger::tests::renders_identical_bytes_for_identical_state
+  assertion `left == right` failed at src/ledger/mod.rs:601
+[OMNI: 406 lines omitted, omni retrieve 3f7bfd89bc5d7cee for full output]
+```
+
+Kegagalannya selamat. 406 baris `ok` tidak. Dan handle di baris terakhir itu
+mengembalikan semuanya, persis byte demi byte, kalau suatu saat memang
+diperlukan.
+
+## Bagian yang tidak dikerjakan orang lain
+
+Menyaring keluaran yang tidak dibaca siapa pun adalah bagian yang mudah, dan
+beberapa perkakas sudah melakukannya. Bagian berikut lebih sulit, dan dari
+sanalah sebagian besar penghematan OMNI datang.
+
+Agent Anda membaca sebuah berkas. Tiga giliran kemudian ia membaca berkas yang
+sama lagi, karena tidak ada yang mengingat bacaan pertama. Anda membayar penuh
+dua-duanya.
+
+OMNI ingat. Bacaan kedua kembali sebagai satu baris:
+
+```
+[OMNI: 178 lines already shown, omni retrieve 77a0c474f2e55351]
+```
+
+**Berkas 7,6 KB yang dibaca dua kali berharga 7,6 KB lalu 214 byte. Itu 97,2%
+lebih murah untuk bacaan kedua.** Tidak ada yang dihapus: baris-baris itu sudah
+ada di konteks agent Anda sejak bacaan pertama, jadi mengirimnya lagi tidak
+membeli apa pun. Handle-nya disediakan kalau baris-baris itu sampai tergeser
+keluar.
+
+Ini namanya ledger, dan pada riwayat perintah sungguhan ia bekerja lebih banyak
+daripada semua penyaring digabung.
+
+## Yang Anda dapat
+
+| | |
+|---|---|
+| **Sesi lebih panjang** | Konteks yang tidak habis untuk basa-basi berarti lebih banyak giliran sebelum mentok, dan lebih sedikit pemadatan yang memutus alur kerja Anda. |
+| **Tagihan lebih kecil** | 14,9% lebih sedikit byte pada 6.656 perintah nyata. Pada pembacaan berkas 25,0%. Pada `git` 22,1%. Pada keluaran build dan test 78,0%. |
+| **Tidak ada yang hilang** | Semua yang dibuang diarsipkan secara lokal. `omni retrieve <handle>` mencetaknya kembali. |
+| **Tidak ada yang dikarang** | Kalau OMNI tidak paham sebuah keluaran, keluaran itu dikembalikan apa adanya, bukan ditebak. |
+| **Ingatan antar sesi** | Tutup editor, kembali besok, pindah dari Claude Code ke Codex: konteks proyeknya masih ada. |
+| **Tidak ada yang perlu diubah** | Tanpa proxy, tanpa API key, tanpa perintah yang harus diawali apa pun. Pasang, lalu pakai terminal Anda seperti biasa. |
+
+## Di mana ia benar-benar membantu
+
+[Di mana OMNI membantu](concepts/use-cases.md) membahas enam situasi lengkap
+dengan angkanya, termasuk dua situasi ketika OMNI tidak melakukan apa-apa dan
+kenapa itu memang benar.
+
+## Mulai dari mana
+
+**Cuma ingin ia jalan.** [Pasang](use/install.md) makan waktu sekitar lima
+menit. Setelah itu baca [Membaca penanda](use/markers.md), satu-satunya halaman
+yang sepadan dengan waktu Anda, karena penanda adalah cara OMNI memberi tahu apa
+yang sudah ia lakukan.
+
+**Ingin paham dulu.** [Apa itu OMNI](concepts/what-it-is.md), lalu
+[Ledger](concepts/the-ledger.md).
+
+**Ingin ikut mengerjakannya.**
+[Architecture](https://omni.weekndlabs.com/docs/develop/architecture) dan
+[The pipeline, stage by stage](https://omni.weekndlabs.com/docs/develop/pipeline)
+adalah petanya. Keduanya berbahasa Inggris.
+
+## Tiga hal yang tidak akan ia lakukan
+
+**Tidak mengirim apa pun ke mana pun.** Setiap tahap berjalan di mesin Anda dan
+arsipnya sebuah berkas SQLite di direktori home Anda.
+
+**Tidak berdiri di antara Anda dan model Anda.** Tidak ada proxy dan tidak ada
+API key yang diserahkan ke proses lokal. Itu
+[diputuskan untuk tidak dilakukan](https://omni.weekndlabs.com/docs/develop/direction#non-goals),
+dan alasannya ditulis.
+
+**Tidak menebak diam-diam.** Tahap yang gagal memahami masukannya mengembalikan
+masukan itu tanpa diubah. Data terstruktur seperti JSON dan YAML sama sekali
+tidak disentuh. Apa pun yang dibuang meninggalkan penanda. Ketiga aturan itu
+mengalahkan kompresi, dalam urutan itu, setiap kali bertabrakan.
+
+## Versi jujur dari angka-angkanya
+
+Dari 6.656 perintah nyata, **97,3% panggilan tidak menghemat apa-apa**, karena
+memang tidak ada yang bisa dihemat. `git status` dua baris tidak punya basa-basi
+untuk dibuang dan tidak punya pengulangan untuk dilipat, jadi OMNI
+mengembalikannya langsung alih-alih mengarang penghematan untuk dilaporkan.
+
+Angka 14,9% itu adalah sisa setelah semua nol tadi ikut dihitung. Itu rata-rata
+nyata atas campuran perintah yang nyata, bukan kasus terbaik yang dipetik dari
+hari yang bagus.
+
+Kami juga menerbitkan perbandingan yang kami kalah: pada penyaringan saja, rtk
+dapat 6,2% di korpus itu dan OMNI dapat 2,7%. Yang membuat OMNI unggul secara
+keseluruhan adalah ledger, dan menjalankan penyaring rtk dengan ledger OMNI akan
+mengalahkan keduanya.
+[Benchmarks](https://omni.weekndlabs.com/docs/develop/benchmarks) memuat
+metodenya dan perintah untuk mereproduksi setiap baris di riwayat Anda sendiri.
+
+Kalau Anda ingin angka yang menggambarkan mesin Anda, bukan mesin orang lain,
+jalankan `omni stats` setelah beberapa hari.
+
+## Bertanya di mana
+
+[Discord](https://discord.gg/zHTuvZhF2M) untuk pertanyaan, terutama untuk kasus
+yang paling dipedulikan proyek ini: OMNI menyatakan hasil yang tidak didukung
+masukannya. [Issue tracker](https://github.com/fajarhide/omni/issues) juga bisa.
+Laporan yang memuat keluaran mentah dan keluaran hasil olahan berdampingan akan
+diperbaiki lewat jalur mana pun.

--- a/docs/website/src-id/integrations/hermes.md
+++ b/docs/website/src-id/integrations/hermes.md
@@ -1,0 +1,123 @@
+# Hermes Agent
+
+OMNI menancap ke Hermes dua kali: sebuah plugin di jalur hook, dan server MCP.
+
+| lapisan | mekanisme | apa yang berubah |
+|---|---|---|
+| hook | `~/.hermes/plugins/omni-signal-engine/__init__.py` yang memanggil `omni --pre-hook`, `--post-hook`, `--session-start` | keluaran tool terminal disuling sebelum masuk ke konteks Hermes |
+| MCP | `mcp_servers.omni` yang menjalankan `omni --mcp` | 26 perkakas OMNI menjadi perkakas kelas satu di Hermes |
+
+## Prasyarat
+
+```sh
+brew install fajarhide/tap/omni
+omni --version
+omni doctor
+
+export HERMES_VENV="${HERMES_HOME:-$HOME/.hermes}/hermes-agent/venv"
+export HERMES_PY="$HERMES_VENV/bin/python"
+"$HERMES_PY" --version      # 3.11 atau lebih baru
+```
+
+Python dari venv-nya dibutuhkan karena `hermes plugins enable` berjalan di
+dalamnya.
+
+## Pasang
+
+```sh
+omni init --hermes
+hermes plugins enable omni-signal-engine
+hermes gateway restart
+"$HERMES_PY" -m pip install hermes-omni-plugin
+```
+
+`omni init --hermes` idempoten. Ia memasang kerangka plugin-nya, mendaftarkan
+server MCP di `~/.hermes/config.yaml` kalau belum ada di sana, menyalakan
+kompresi Hermes ketika itu aman, dan menulis nilai bawaan berorientasi Hermes ke
+`~/.omni/config.toml` **tanpa menimpa konfigurasi OMNI yang sudah ada**.
+
+> Pakai salah satu, `hermes-omni-plugin` atau kerangka `omni init --hermes`,
+> jangan keduanya sekaligus, atau Anda akan dapat pendaftaran plugin ganda.
+
+## Konfigurasi
+
+```yaml
+# ~/.hermes/config.yaml
+
+plugins:
+  enabled:
+    - omni-signal-engine
+
+mcp_servers:
+  omni:
+    command: "/opt/homebrew/bin/omni"
+    args: ["--mcp"]
+    env:
+      OMNI_AGENT_ID: "hermes"
+
+compression:
+  enabled: true
+  threshold: 0.50     # kompres pada pemakaian konteks 50%
+  target_ratio: 0.20  # sisakan 20%
+```
+
+Tiga hal harus benar: `plugins.enabled` memuat `omni-signal-engine`,
+`mcp_servers.omni` menunjuk binary yang sebenarnya, dan `compression.enabled`
+menyala supaya pemadatan Hermes sendiri dan peringatan tekanan OMNI sejalan, bukan
+saling berkelahi.
+
+`OMNI_AGENT_ID: "hermes"` lebih penting daripada kelihatannya. Tanpa itu, baris
+milik Hermes bercampur dengan milik semua host lain dan tidak ada angka tentang
+keduanya yang berarti.
+
+## Verifikasi
+
+```sh
+omni doctor
+
+hermes plugins list | grep omni        # harapkan: omni-signal-engine enabled
+hermes tools list | grep mcp_omni_     # harapkan 25 perkakas, setelah restart
+```
+
+Lalu satu pemeriksaan fungsional pada fixture sungguhan:
+
+```sh
+cat tests/fixtures/cargo_test_500.txt | omni --post-hook 2>&1 | head -20
+# baris test yang lulus dibuang, kegagalannya dipertahankan
+```
+
+Untuk uji langsung, jalankan sesuatu yang berisik lewat tool `terminal` milik
+Hermes (`terminal("npm install", timeout=120)`) lalu bandingkan ukuran hasil
+tool-nya dengan keluaran npm mentah. Pastikan dengan `omni stats`.
+
+> Hitung perkakasnya, jangan percaya angka yang tertulis. Versi sebelumnya dari
+> panduan ini menyebut 27, yang datang dari mem-`grep` kode sumber server; salah
+> satu string itu nama penyaring, bukan perkakas. `tools/list` milik server
+> sendiri menjawab 26.
+
+## Di mana OMNI membantu dan di mana tidak
+
+| keluaran | efek OMNI |
+|---|---|
+| `npm install`, `cargo build`, `docker build` | besar, 70% ke atas. Progres, cache hit dan hash layer murni basa-basi. |
+| run test | besar. Vonis dan kegagalannya selamat, baris `ok` tidak. |
+| pembacaan berkas | nol dari penyaringnya, banyak dari ledger saat dibaca ulang |
+| `kubectl -o json`, terraform plan | nol, disengaja. Muatan terstruktur lewat begitu saja. |
+| perintah pendek | nol, atau sedikit negatif. Penandanya berongkos lebih mahal daripada penghematannya. |
+
+Pakai perkakas MCP-nya sebagai kendali Hermes atas semua itu:
+`omni_explain_savings` untuk melihat berapa sebenarnya ongkos sebuah perintah
+terkini, `omni_retrieve` untuk mengambil kembali isi yang terlipat, dan
+`omni_budget` untuk melihat token sesinya pergi ke mana.
+
+## Setelah Hermes di-upgrade
+
+```sh
+hermes plugins list | grep omni
+hermes tools list | grep mcp_omni_
+omni doctor
+```
+
+Sebuah upgrade bisa menyetel ulang `plugins.enabled` atau memindahkan venv-nya.
+Keduanya gagal diam-diam: plugin-nya sekadar berhenti dipanggil, dan tidak ada
+yang mengumumkannya.

--- a/docs/website/src-id/integrations/loops.md
+++ b/docs/website/src-id/integrations/loops.md
@@ -1,0 +1,107 @@
+# Loop engineering
+
+Menjalankan agent dalam sebuah loop, ketika setiap iterasi menambah isi jendela
+konteks yang tidak ikut membesar. Bagian OMNI adalah melacak apa yang sudah
+dihabiskan loop-nya dan membawa ingatan melintasi iterasi yang kalau tidak
+begitu akan direset.
+
+## Menyiapkan sebuah loop
+
+```sh
+export OMNI_LOOP_ID=$(uuidgen)
+export OMNI_LOOP_GOAL="Migrate the billing service off the legacy queue"
+export OMNI_LOOP_BUDGET=100000
+export OMNI_LOOP_ITERATION=0
+```
+
+| variabel | batasan |
+|---|---|
+| `OMNI_LOOP_ID` | alfanumerik dan tanda hubung, 64 karakter |
+| `OMNI_LOOP_GOAL` | 500 karakter, tanpa metakarakter shell |
+| `OMNI_LOOP_BUDGET` | anggaran token per iterasi, sampai 10 juta |
+| `OMNI_LOOP_ITERATION` | iterasi saat ini, bawaannya 0 |
+| `OMNI_SUBAGENT=1` | mode subagent |
+| `OMNI_AGENT_ID` | identitas, supaya jejaknya tetap bisa dipisah |
+
+## Anggaran
+
+Anggarannya adalah perkiraan pemakaian jendela konteks per iterasi, bukan batas
+belanja.
+
+| bentuk loop | anggaran | yang OMNI lakukan |
+|---|---|---|
+| perbaikan cepat, 1 sampai 5 iterasi | 200.000 | pelacakan pasif |
+| pengerjaan fitur, 5 sampai 20 | 100.000 | penyulingan aktif, engram |
+| refactor besar, 20 sampai 100 | 80.000 | penyulingan agresif, peringatan prediktif |
+| maraton, 100 ke atas | 60.000 | kompresi maksimum, ingatan loop yang bertahan |
+
+Peringatan menyala di 65% dan kritis di 82%, bisa disetel dengan
+`OMNI_PRESSURE_WARN` dan `OMNI_PRESSURE_CRITICAL`.
+
+> Jangan setel anggaran di atas 1 juta: peringatannya tidak akan pernah menyala
+> sebelum kehabisan sungguhan. Jangan setel di bawah 30 ribu: agent-nya akan
+> memadatkan terus-menerus dan kehilangan ingatan jangka pendeknya.
+
+String tujuannya juga menggeser tingkat keagresifan penyulingan. Tujuan yang
+memuat "test" mempertahankan detail test, "debug" menyimpan konteks galat,
+"refactor" mengompres lebih keras.
+
+## Perkakas yang dipanggil orkestrator
+
+| perkakas | kapan |
+|---|---|
+| `omni_loop_status` | sekali sebelum tiap iterasi, gambaran lengkap termurah |
+| `omni_budget_status` | sebelum apa pun yang mahal |
+| `omni_set_loop_context` | ketika tujuan atau cakupannya bergeser di tengah loop |
+| `omni_loop_memory` | baca dan tulis ingatan yang selamat dari restart sesi |
+| `omni_verify` | sebagai pemeriksa, untuk menilai pekerjaan terkini si pembuat |
+
+## Pembuat dan pemeriksa
+
+Dua agent, satu lapisan konteks bersama.
+
+```sh
+LOOP_ID=$(uuidgen)
+
+# pembuat
+export OMNI_AGENT_ID=maker OMNI_LOOP_ID=$LOOP_ID
+claude "Implement: $GOAL"
+
+# pemeriksa
+export OMNI_AGENT_ID=checker OMNI_SUBAGENT=1
+RESULT=$(claude "Verify the implementation of: $GOAL. Use the omni_verify tool.")
+
+case "$RESULT" in
+  *PASS*) echo "verification passed" ;;
+  *)      echo "checker found issues" ;;
+esac
+```
+
+Nilai `OMNI_AGENT_ID` yang berbeda itulah yang menjaga keduanya tidak saling
+mengotori. Jejaknya ditandai per agent, jadi `omni_verify` bisa membaca lintas
+sesi sementara penulisannya tetap terisolasi.
+
+Empat hal yang membuatnya bekerja: beri pemeriksanya kriteria yang spesifik dan
+terukur, jaga `last_n_calls` antara 5 dan 20, naikkan ke manusia setelah tiga
+kegagalan pemeriksa berturut-turut, dan ingat bahwa setiap interaksi dicatat
+sehingga jejak auditnya nyata.
+
+## Pemantauan
+
+```sh
+omni stats                 # waktu nyata
+omni stats --detail
+omni stats --json          # untuk dibaca orkestrator
+omni doctor                # kesehatan
+```
+
+`omni handoff` **bukan** subperintah CLI. Ia sudah dihapus. Perkakas MCP
+`omni_handoff` tidak berubah, jadi ekspor sesi bisa dijangkau dari klien MCP,
+bukan dari shell.
+
+## Peringatan soal angkanya
+
+Setiap angka yang dilaporkan sebuah loop dicakup oleh `agent_id`. Kalau
+orkestrator dan para agent berbagi satu id, penghematan si pembuat dan si
+pemeriksa jadi satu angka dan tidak ada yang berarti. Setel id-nya per peran
+sebelum iterasi pertama, bukan setelah Anda menyadarinya.

--- a/docs/website/src-id/reference/agents.md
+++ b/docs/website/src-id/reference/agents.md
@@ -1,0 +1,84 @@
+# Agent yang didukung
+
+Host mana yang Anda jalankan menentukan apa yang bisa dilakukan OMNI, dan
+langit-langitnya milik host, bukan milik pipeline-nya. Halaman ini layak dibaca
+sebelum menilai apakah OMNI layak berada di sana.
+
+## Tingkatannya
+
+| tingkat | host | yang Anda dapat |
+|---|---|---|
+| **Penuh** | Claude Code, Codex CLI, Gemini CLI, Aider (pipa) | Host menerapkan tulis ulang OMNI, jadi model membaca keluaran sulingan dari tool bawaannya sendiri. |
+| **Handoff dulu** | Cursor, Windsurf | Host tidak bisa menulis ulang keluaran tool bawaannya. `omni_run` menyuling apa pun yang dilewatkan melaluinya, dan `omni init --cursor` memasang aturan yang membuat agent meraihnya. |
+| **MCP saja** | Cline, Roo, OpenCode, VS Code, Zed, Copilot, Antigravity, Hermes, Pi | Ingatan, pemanggilan kembali dan keadaan sesi. Tanpa penyulingan shell, dan tanpa klaim soal itu. |
+
+```sh
+omni doctor     # mencetak tingkat untuk setiap host yang terpasang
+```
+
+Penghematan hanya pernah dihitung di tempat model benar-benar menerima lebih
+sedikit. Host yang tidak bisa menerapkan tulis ulangnya tidak akan menggerakkan
+angka penyulingan sebaik apa pun penyaringnya, dan mengaku sebaliknya akan
+menjadi cacat yang sama dengan distiller yang melaporkan penghematan yang tidak
+ia lakukan.
+
+## Memasang untuk masing-masing
+
+```sh
+omni init --claude       omni init --cursor      omni init --zed
+omni init --cline        omni init --roo         omni init --roo-code
+omni init --copilot      omni init --gemini      omni init --opencode
+omni init --codex        omni init --openclaw    omni init --antigravity
+omni init --hermes       omni init --vscode      omni init --pi
+omni init --all
+```
+
+## Catatan khusus per host
+
+**Codex CLI** hanya menjalankan hook yang sudah dinyatakan tepercaya, dan
+melewati sisanya tanpa sepatah kata. Setelah `omni init --codex`, jalankan
+`codex` sekali lalu setujui di bagian "Hooks need review". `omni doctor` gagal
+sampai Anda melakukannya. Ini pernah menggigit: Codex menjalankan nol hook
+selama satu rilis penuh sementara semuanya tampak terpasang dengan benar.
+
+**Cursor** tidak bisa menulis ulang keluaran tool shell bawaannya. Mencegat
+shell-nya dengan menolak eksekusi lalu mengembalikan keluarannya sebagai pesan
+hook secara teknis mungkin dan sudah ditolak: itu memberi tahu agent bahwa
+perintahnya diblokir, menghilangkan kode keluarnya, memindahkan semantik eksekusi
+ke dalam OMNI, dan melewati alur persetujuan host.
+
+**Claude Code** mencocokkan lebih dari sekadar `Bash`. Pencocok post-tool-nya
+`Bash|Read|Grep|WebFetch`, dan itulah yang akhirnya membuat distiller pembacaan
+berkas, pencarian dan pengambilan web berjalan sama sekali. Tiga di antaranya
+sudah ditulis dan diuji sepenuhnya dan tidak pernah sekali pun berjalan di sesi
+sungguhan.
+
+**Hermes** punya halaman integrasinya sendiri:
+[Hermes Agent](../integrations/hermes.md).
+
+**Windows** didukung. Jalur, akhiran baris dan imbuhan `.exe` sudah ditangani,
+dan matriks CI-nya menyertakan `windows-latest`.
+
+## Beberapa agent sekaligus
+
+Beri masing-masing identitasnya sendiri supaya angkanya tetap bisa dipisah:
+
+```sh
+OMNI_AGENT_ID=claude ...
+OMNI_AGENT_ID=cursor ...
+```
+
+`omni_agents` melaporkan agent mana yang sedang aktif di proyeknya. Setiap baris
+penyulingan membawa id-nya, dan angka apa pun yang mencampurnya sedang
+menggambarkan sebuah campuran, bukan sebuah produk.
+
+## Menambahkan sebuah host
+
+Modul agent-nya ada di `src/agents/`, satu berkas per host, dan masing-masing
+menulis format konfigurasi milik host itu di lokasi milik host itu. Polanya kecil
+dan sebagian besar mekanis.
+
+Bagian yang tidak mekanis adalah verifikasinya. "Penyedia tidak bisa dihubungi"
+bukan alasan membiarkan sebuah jalur hook tak terverifikasi: sajikan API-nya, dan
+palsukan modelnya saja. Hook yang tidak pernah berjalan di produksi sudah
+ditemukan di tiga host justru dengan cara itu.

--- a/docs/website/src-id/reference/cmd/doctor.md
+++ b/docs/website/src-id/reference/cmd/doctor.md
@@ -1,0 +1,53 @@
+# `omni doctor`
+
+Memeriksa bahwa pemasangannya sehat, dan memperbaiki yang bisa ia perbaiki.
+
+```sh
+omni doctor
+omni doctor --fix
+```
+
+Ia mencakup versi dan keterjangkauan binary-nya, direktori konfigurasi dan basis
+data, pemasangan hook per host, pendaftaran server MCP, dan pemuatan sinyal.
+
+## Flag
+
+| flag | efeknya |
+|---|---|
+| `--fix` | Perbaiki masalah konfigurasi dan integrasi secara otomatis |
+| `--detail` | Cetak semua baris integrasi, bukan hanya yang perlu perhatian |
+| `--json` | Bisa dibaca mesin |
+| `--help`, `-h` | Bantuan |
+
+## Membaca keluarannya
+
+**Tingkat host.** `doctor` mencetak tingkat untuk setiap host yang terpasang, dan
+tingkat itu adalah langit-langit jujur untuk apa yang bisa dilakukan OMNI di
+sana. Host yang mengutamakan handoff atau hanya MCP tidak bisa menulis ulang
+keluaran tool shell bawaannya, jadi sebanyak apa pun pekerjaan pipeline tidak
+akan menggerakkan angka penyulingannya. Lihat
+[Agent yang didukung](../agents.md).
+
+**`[N UNRELEASED]`.** Build yang dikompilasi dari pohon sumber yang
+`CHANGELOG.md`-nya masih punya entri di bawah `## [Unreleased]` akan
+mengatakannya, dan menyuruh Anda memotong sebuah tag. Pada build rilis tidak ada
+baris seperti itu. Ini ada supaya binary yang ditandai tanpa memindahkan entri
+changelog-nya menuduh dirinya sendiri, bukan terkirim diam-diam.
+
+**Hitungan retensi terkini.** Berapa banyak yang ada di setiap tingkat ingatan
+saat ini.
+
+## Yang tidak ia periksa
+
+Bahwa host-nya benar-benar menerapkan hasil tulis ulangnya. `doctor` memverifikasi
+konfigurasinya ada di tempat host membacanya, dan itu tidak sama dengan host
+menghormatinya. Buktinya adalah sebuah baris penyulingan di basis data di bawah
+`agent_id` host Anda, atau transkrip sesi host itu sendiri.
+
+Di Claude Code, muatan hook yang ditolak host dicatat sebagai lampiran yang tidak
+pernah sampai ke model, jadi agent bisa yakin semuanya baik-baik saja sementara
+terminal Anda penuh peringatan:
+
+```sh
+grep -c hook_error_during_execution ~/.claude/projects/<proyek>/<sesi>.jsonl
+```

--- a/docs/website/src-id/reference/cmd/exec.md
+++ b/docs/website/src-id/reference/cmd/exec.md
@@ -1,0 +1,63 @@
+# `omni exec`
+
+Menjalankan satu perintah lewat seluruh pipeline lalu mencetak hasilnya, dengan
+catatan kaki yang menunjukkan berapa ongkosnya.
+
+```sh
+omni exec cargo test
+```
+
+```
+cargo test: 411 passed, 1 failed
+  FAILED ledger::tests::renders_identical_bytes_for_identical_state
+[OMNI Active] ⏺ 93.7% reduction (2.3 KB → 147 B) 3ms
+```
+
+Ini harness yang diminta dipakai setiap laporan bug di proyek ini, karena ia
+mengeluarkan host dari gambar. Kalau sebuah kerusakan tetap muncul lewat
+`omni exec`, itu OMNI.
+
+## Bentuk argumennya persis
+
+```sh
+omni exec cargo test          # benar
+omni exec -- cargo test       # gagal: No such file or directory
+omni exec 'cargo test'        # jalan, bentuk string tunggal
+omni exec sh -c 'a; b'        # jalan, bentuk argv terpisah
+```
+
+Bentuk `--` justru yang orang raih dan justru yang tidak bekerja.
+
+## Flag
+
+| flag | efeknya |
+|---|---|
+| `--session <id>` | Teruskan id sesi host, dan itulah yang menentukan cakupan ledger |
+| `--agent <id>` | Catat run-nya di bawah `agent_id` tertentu |
+| `--help`, `-h` | Bantuan |
+
+Keduanya yang dipakai pre-hook ketika ia menulis ulang sebuah perintah menjadi
+`omni exec`.
+
+`--session` layak diketahui ketika Anda sedang menyelidiki perilaku ledger: ia
+satu-satunya cara menjalankan dua sesi berbeda dengan tangan lalu melihat beda
+antara pelipatan `already shown` dan pelipatan `from an earlier session`.
+
+## Isolasi basis datanya saat menyelidik
+
+Keluarannya tidak deterministik terhadap basis data yang hangat, karena riwayat
+sesi memberi masukan ke penilainya. Beri setiap penyelidikan basis datanya
+sendiri:
+
+```sh
+OMNI_DB_PATH=/tmp/probe.db omni exec <perintah>
+```
+
+Basis data bersama yang hangat juga membuat penulisan berbaris antre, dan itu
+alasan biasa `omni exec` tampak menggantung.
+
+## Terkait
+
+`omni diff` menunjukkan sebelum dan sesudah yang sama untuk perintah
+**terakhir** yang diproses hook, dan itu yang Anda butuhkan ketika perintah yang
+menarik sudah terlanjur berjalan.

--- a/docs/website/src-id/reference/cmd/init.md
+++ b/docs/website/src-id/reference/cmd/init.md
@@ -1,0 +1,82 @@
+# `omni init`
+
+Memasang OMNI ke sebuah agent: menulis konfigurasi hook di tempat host itu
+membacanya, dan mendaftarkan server MCP.
+
+```sh
+omni init              # menu interaktif, atau host saat ini kalau tidak ada terminal
+omni init --claude
+omni init --all
+```
+
+Idempoten. Menjalankannya lagi setelah upgrade adalah langkah yang benar, bukan
+risiko.
+
+## Tanpa flag
+
+Di terminal, sebuah menu. Tanpa terminal, yang memang begitulah agent
+menjalankannya, menunya tidak bisa digambar, jadi `omni init` menyetel host
+tempat ia berjalan lalu mencetak host mana itu. Host yang tidak bisa ia sebut
+dari lingkungannya, termasuk shell biasa, mendapat galat berisi daftar flag,
+bukan tebakan: memasang ke host yang tidak diminta siapa pun adalah yang lebih
+buruk dari dua kegagalan itu.
+
+## Host
+
+Satu flag per host. Masing-masing menulis format konfigurasi milik host itu di
+lokasi milik host itu.
+
+| flag | host |
+|---|---|
+| `--claude` | Claude Code (Anthropic) |
+| `--cursor` | Cursor |
+| `--zed` | Zed |
+| `--cline` | Cline |
+| `--roo`, `--roo-code` | Roo Code |
+| `--copilot` | GitHub Copilot CLI |
+| `--gemini` | Gemini CLI |
+| `--opencode` | OpenCode |
+| `--codex` | Codex CLI |
+| `--openclaw` | OpenClaw |
+| `--antigravity` | Antigravity IDE, dan webhook generik |
+| `--hermes` | Hermes Agent |
+| `--vscode` | VS Code (MCP) |
+| `--pi` | Pi Agent |
+
+Apa yang sebenarnya diizinkan masing-masing host untuk dilakukan OMNI berbeda
+jauh. Lihat [Agent yang didukung](../agents.md) sebelum menganggap sebuah flag
+otomatis membeli penyulingan shell.
+
+## Mode
+
+| flag | efeknya |
+|---|---|
+| `--all` | Semua host di atas. Juga menulis `.vscode/mcp.json` di direktori saat ini. |
+| `--hook` | Hook saja, tanpa pendaftaran MCP |
+| `--mcp` | Pendaftaran MCP saja, tanpa hook |
+| `--status` | Laporkan apa yang saat ini terpasang, tanpa mengubah apa pun |
+| `--uninstall` | Cabut hook dan server MCP milik OMNI |
+| `--help`, `-h` | Bantuan |
+
+## Setelah menjalankannya
+
+```sh
+omni doctor
+```
+
+Selalu. `init` melaporkan apa yang ia tulis; `doctor` melaporkan apakah host-nya
+membacanya.
+
+**Codex CLI butuh satu langkah lagi.** Ia hanya menjalankan hook yang sudah
+dinyatakan tepercaya dan melewati sisanya tanpa sepatah kata. Jalankan `codex`
+sekali lalu setujui di bagian "Hooks need review". `omni doctor` gagal sampai
+Anda melakukannya.
+
+## Catatan
+
+`--all` satu-satunya flag yang menulis ke direktori saat ini. Selebihnya hanya
+menyentuh konfigurasi di direktori home Anda.
+
+Flag host yang tidak dikenali tidak selalu gagal dengan berisik: flag yang salah
+ketik pernah menjalankan mode interaktif bawaan lalu keluar dengan status 0
+sementara tidak memasang apa pun yang diminta. Baca apa yang ia cetak.

--- a/docs/website/src-id/reference/cmd/rest.md
+++ b/docs/website/src-id/reference/cmd/rest.md
@@ -1,0 +1,126 @@
+# Sisanya
+
+Perintah yang cukup butuh satu paragraf ketimbang satu halaman.
+
+## `update`
+
+```sh
+omni update
+```
+
+Mengambil rilis terbaru dari GitHub lalu memperbarui. Untuk saat ini hanya
+pemasangan lewat Homebrew; cara pemasangan lain diperbarui lewat kanalnya
+sendiri.
+
+Jalankan ulang `omni init` sesudahnya kalau catatan rilisnya menyebut kontrak
+hook berubah.
+
+## `reset`
+
+```sh
+omni reset            # menu interaktif
+omni reset --all      # semua integrasi, dan menawarkan menghapus omni.db
+omni reset --claude   # satu host
+```
+
+Flag per host mencerminkan [`init`](init.md): `--claude`, `--cursor`, `--zed`,
+`--cline`, `--roo` / `--roo-code`, `--copilot`, `--gemini`, `--opencode`,
+`--codex`, `--antigravity`, `--hermes`, `--pi`.
+
+`--all` satu-satunya yang menawarkan menghapus basis data Anda, dan ia bertanya
+lebih dulu. Ia menyimpan cadangan konfigurasi yang ia cabut.
+
+## `dashboard`
+
+```sh
+omni dashboard
+omni dashboard --port 8080     # bawaannya 7717
+```
+
+Angka yang sama dengan yang dicetak `omni stats`, di peramban. Hanya baca,
+membaca basis data yang sama, dan mengikat `127.0.0.1` dan tidak yang lain.
+Ctrl-C menghentikannya.
+
+## `diff`
+
+```sh
+omni diff
+```
+
+Keluaran perintah terakhir, mentah dibanding hasil sulingan. Cara tercepat
+menumbuhkan kepercayaan pada apa yang dikerjakan OMNI, dan hal pertama yang
+dijalankan ketika sebuah hasil terlihat salah.
+
+## `query`
+
+```sh
+omni query errors in last 5 commands
+omni query warnings from cargo
+omni query context for src/main.rs
+omni query timeline today
+omni query timeline today --json
+```
+
+Bahasa kueri kecil yang tetap atas riwayat penyulingan, bukan teks bebas. Empat
+bentuk didukung dan itulah keempatnya di atas. `--json` untuk keluaran yang bisa
+dibaca mesin.
+
+## `patterns`
+
+```sh
+omni patterns
+omni patterns --tool cargo
+```
+
+Galat yang terus kembali lintas sesi. `--tool <nama>` membatasinya ke satu tool.
+
+Berguna untuk pertanyaan "apakah saya pernah kena ini", pertanyaan yang tidak
+bisa dijawab sendiri oleh sesi yang baru.
+
+## `remember`
+
+```sh
+omni remember 'The staging database ignores migrations run outside the deploy job'
+```
+
+Menyimpan sebuah fakta di ingatan permanen, bisa diambil kembali lewat
+`omni_recall` atau lewat suntikan konteks sesi.
+
+Layak disimpan: sebuah keputusan dan alasannya, sebuah jebakan, sebuah batasan
+yang tidak disebut berkas mana pun. Tidak layak disimpan: apa pun yang sudah
+dicatat repositorinya.
+
+## `engram`
+
+```sh
+omni engram
+omni engram --json
+```
+
+Ringkasan subtugas yang selesai, ditulis seiring pekerjaan rampung.
+
+## `goal`
+
+```sh
+omni goal set 'Migrate the billing service off the legacy queue'
+omni goal show
+omni goal clear
+```
+
+Memancang sebuah tujuan utama. Penilainya mengutamakan keluaran yang berkaitan
+dengannya, dan agent diingatkan padanya alih-alih melantur sepanjang sesi yang
+panjang. Ingatan tujuan menghormati `ttl_days` miliknya sendiri, bukan tingkat
+retensi standar.
+
+`set` adalah subperintah bawaannya, jadi `omni goal 'sebuah teks'` juga bekerja.
+
+## `version`
+
+```sh
+omni version
+omni version --json
+```
+
+Rincian versi dan lingkungan: tanggal build, hash git, dan jalur yang diputuskan
+OMNI untuk konfigurasi dan basis datanya. Layak disertakan di laporan bug mana
+pun.

--- a/docs/website/src-id/reference/cmd/retrieve.md
+++ b/docs/website/src-id/reference/cmd/retrieve.md
@@ -1,0 +1,42 @@
+# `omni retrieve`
+
+Mencetak isi yang diarsipkan sebuah penanda.
+
+```sh
+omni retrieve 3f7bfd89bc5d7cee
+```
+
+Handle-nya adalah 16 karakter di dalam sebuah penanda:
+
+```
+[OMNI: 406 lines omitted, omni retrieve 3f7bfd89bc5d7cee for full output]
+[OMNI: 40 lines already shown, omni retrieve bc7e821a4340073e]
+```
+
+Ia mengembalikan byte aslinya. Bukan ringkasan, bukan menjalankan ulang perintah
+Anda, dan bukan perkiraan.
+
+Bekerja di semua host, di sesi mana pun, dengan atau tanpa MCP terpasang. Agent
+yang server MCP-nya terdaftar memanggil `omni_retrieve` sebagai gantinya dan
+tidak pernah perlu bertanya ke Anda.
+
+## Apa yang bisa salah
+
+**Handle-nya tidak ketemu.** Arsipnya jendela bergulir 30 hari, jadi isi yang
+lebih tua dari itu sudah hilang. Jejak eksekusi apa adanya dipangkas lebih awal
+lagi, pada hari ketujuh.
+
+Handle yang gagal ditemukan di dalam jendela itu adalah bug serius, bukan sekadar
+merepotkan, karena penanda yang menjanjikan isi bisa diambil kembali adalah satu
+hal yang tidak boleh salah pada mekanisme ini. Laporkan.
+
+**Anda mengetik teks penandanya, bukan handle-nya.** Hanya heksanya, tanpa kurung
+siku, tanpa awalan.
+
+## Kenapa ia bisa menjanjikan ini
+
+Sebuah run diarsipkan **sebelum** penandanya ditulis, dan pengarsipan yang gagal
+membuat run itu tetap apa adanya alih-alih menghasilkan sebuah penanda. Jadi
+handle yang bisa Anda lihat adalah handle yang isinya ada. Urutan itu sebuah
+perbaikan, bukan rancangan awalnya: versi sebelumnya mengembalikan kunci bahkan
+ketika penulisannya gagal.

--- a/docs/website/src-id/reference/cmd/session.md
+++ b/docs/website/src-id/reference/cmd/session.md
@@ -1,0 +1,55 @@
+# `omni session`
+
+Keadaan sesi: apa yang sudah dihabiskan sesi ini, untuk apa, dan cara membawanya
+melewati sebuah restart.
+
+```sh
+omni session --status
+```
+
+## Flag
+
+| flag | efeknya |
+|---|---|
+| `--status` | Status sesi saat ini |
+| `--history` | Riwayat sesi terkini |
+| `--health` | Dasbor kesehatan sesi secara visual |
+| `--transcript` | Transkrip sesi terkini |
+| `--clear` | Setel ulang sesi saat ini |
+| `--continue` | Lanjutkan sesi yang basi |
+| `--resume` | Lanjutkan sesi yang terputus |
+| `--inject` | Keluarkan konteks sesi untuk dikonsumsi sebuah agent |
+| `--json` | Bisa dibaca mesin |
+| `--help`, `-h` | Bantuan |
+
+`omni sessions` diterima sebagai alias.
+
+## Apa itu sesi di sini
+
+Kunci cakupannya adalah id sesi milik **host**, bukan cap waktu internal.
+Perbedaan itu pernah jadi cacat sungguhan: sebuah id berbasis jam dinding
+internal pernah mencakup 16 proyek dalam satu nilai, yang akan membuat ledger
+memberi tahu satu sesi bahwa ia sudah ditunjukkan keluaran yang sebenarnya pergi
+ke sesi lain.
+
+Itu juga alasan `omni exec` menerima `--session`: tanpa id host yang diteruskan
+tidak ada cakupan ledger, dan karena itu untuk beberapa waktu jalur exec sama
+sekali tidak menjalankan ledger.
+
+## Kesinambungan melewati restart
+
+Konteks sesi disuntikkan saat sesi dimulai, jadi agent baru tahu berkas mana yang
+sedang panas dan apa galat aktif terakhirnya. Memulai ulang editor Anda atau
+berganti host tidak menghilangkan konteks proyeknya.
+
+`--inject` adalah bentuk manual dari itu, untuk host yang disambungkan untuk
+mengonsumsinya.
+
+Untuk menyeberang ke mesin yang tidak berbagi basis data, pakai perkakas MCP
+`omni_handoff`, yang mengekspor keadaannya sebagai markdown yang bisa dibawa.
+Subperintah CLI dengan nama itu sudah dihapus; perkakas MCP-nya tidak berubah.
+
+## Retensi
+
+Sesi ada di tingkat kerja 30 hari. Transkrip apa adanya ada di tingkat 7 hari,
+karena ia dua orde besaran lebih berat per baris.

--- a/docs/website/src-id/reference/cmd/stats.md
+++ b/docs/website/src-id/reference/cmd/stats.md
@@ -1,0 +1,55 @@
+# `omni stats`
+
+Analitik penghematan token, dibaca dari basis data Anda sendiri.
+
+```sh
+omni stats
+```
+
+Memimpin dengan **umur sesi**, berapa perintah yang dibawa sebuah sesi sebelum
+host menutupnya. Persentase penyulingan di bawahnya adalah alat diagnosis untuk
+pipeline satu host, bukan klaim produk.
+
+## Flag
+
+| flag | efeknya |
+|---|---|
+| `--detail` | Rincian penuh: perintah, rute, sesi, agent |
+| `--hour`, `-H` | Batasi ke 60 menit terakhir |
+| `--day`, `--today`, `-d` | Hari ini saja |
+| `--week`, `-w` | 7 hari terakhir |
+| `--month`, `-m` | 30 hari terakhir, bawaannya |
+| `--all-commands` | Semua perintah, bukan cuma yang teratas |
+| `--project` | Pecah per jalur proyek |
+| `--context` | Sinyal komposisi konteks |
+| `--rerun` | Distiller mana yang berongkos satu run ulang |
+| `--share` | Ringkasan siap tempel dari penghematan terukur Anda |
+| `--card` | Tulis ringkasan itu sebagai gambar, berukuran untuk unggahan media sosial |
+| `--json` | Bisa dibaca mesin |
+| `--help`, `-h` | Bantuan |
+
+## `--rerun` yang wajib diketahui
+
+Persentase pengurangan tidak bisa memberi tahu apakah sebuah distiller membuang
+sesuatu yang lalu harus diambil ulang agent. Kalau iya, pengurangannya sebuah
+penundaan, bukan penghematan. Flag ini pemeriksaan yang tidak bisa dilakukan
+persentase.
+
+## Jebakan
+
+**Baris terminal bukan token.** Keluaran yang ditulis ke TTY dibaca manusia,
+bukan model. Pada satu pemasangan, baris seperti itu 73% dari seluruh byte yang
+diklaim OMNI sudah dihemat. `stats` sekarang mengecualikannya, begitu juga
+harness benchmark-nya, tapi siapa pun yang mengueri `~/.omni/omni.db` langsung
+harus menyaring `agent_id` sendiri.
+
+**Angka tinggi pantas dicurigai.** Cacat terburuk di proyek ini melaporkan
+pengurangan paling besar, karena menghapus jawabannya terkompresi dengan sangat
+baik. Sandingkan angka mana pun dengan `omni diff` pada perintah sungguhan.
+
+**Angka rendah biasanya benar.** Sekitar 97% panggilan tidak menghemat apa pun
+karena memang tidak ada yang bisa dihemat.
+
+**`--share` dan `--card` tidak mungkin berbeda dari laporannya.** Keduanya
+membaca agregasi yang sama dengan `omni stats` sendiri, sebuah pilihan yang
+disengaja setelah versi sebelumnya menghitungnya terpisah.

--- a/docs/website/src-id/reference/commands.md
+++ b/docs/website/src-id/reference/commands.md
@@ -1,0 +1,68 @@
+# Perintah
+
+Semua subperintah, dikelompokkan seperti `omni --help` mengelompokkannya:
+menurut apa yang sedang Anda coba lakukan, bukan menurut abjad.
+
+```
+omni <COMMAND> [FLAGS]
+cmd | omni                # suling keluaran perintah apa pun lewat pipa
+```
+
+## Pemasangan
+
+| perintah | apa yang ia lakukan |
+|---|---|
+| [`init`](cmd/init.md) | Pasang OMNI ke agent Anda, hook dan MCP |
+| [`doctor`](cmd/doctor.md) | Periksa pemasangannya sehat, dan perbaiki yang tidak |
+| [`update`](cmd/rest.md#update) | Naikkan ke rilis terbaru |
+| [`reset`](cmd/rest.md#reset) | Cabut dengan bersih, sambil menyimpan cadangan konfigurasi Anda |
+
+## Melihat berapa yang dihemat
+
+| perintah | apa yang ia lakukan |
+|---|---|
+| [`stats`](cmd/stats.md) | Berapa token yang dipotong, dan dari perintah mana |
+| [`retrieve`](cmd/retrieve.md) | Cetak isi yang diarsipkan sebuah penanda, lewat handle-nya |
+| [`dashboard`](cmd/rest.md#dashboard) | Angka yang sama di peramban, di 127.0.0.1 |
+| [`diff`](cmd/rest.md#diff) | Keluaran perintah terakhir, sebelum dibanding sesudah |
+| [`session`](cmd/session.md) | Apa yang sudah dihabiskan sesi ini, dan untuk apa |
+
+## Menyetelnya
+
+| perintah | apa yang ia lakukan |
+|---|---|
+| [`exec`](cmd/exec.md) | Jalankan satu perintah lewat OMNI, untuk melihat apa yang akan ia lakukan |
+| [`query`](cmd/rest.md#query) | Cari penyulingan yang sudah lewat |
+| [`patterns`](cmd/rest.md#patterns) | Galat yang terus kembali |
+
+## Ingatan
+
+| perintah | apa yang ia lakukan |
+|---|---|
+| [`remember`](cmd/rest.md#remember) | Simpan sebuah fakta untuk sesi berikutnya |
+| [`engram`](cmd/rest.md#engram) | Ringkasan subtugas yang selesai |
+| [`goal`](cmd/rest.md#goal) | Pancang tujuan utama supaya penilaiannya mengutamakannya |
+| [`version`](cmd/rest.md#version) | Rincian versi dan lingkungan |
+
+## Titik masuk hook
+
+Bukan untuk diketik. Ini yang dipanggil host agent, dan didokumentasikan di
+[Hook](hooks.md).
+
+```
+omni --pre-hook      omni --post-hook     omni --hook
+omni --session-start omni --session-end   omni --pre-compact
+omni --mcp
+```
+
+## Catatan soal cara flag diurai
+
+Kecocokan pada argumen pertama menentukan rute subperintahnya lalu menyerahkan
+`env::args()` mentah ke modulnya, jadi setiap modul mengurai flag-nya sendiri dan
+menyatakan himpunan flag yang ia terima. `cli::check_flags` menolak apa pun di
+luar himpunan itu, dan itulah yang mencegah `omni stats --detial` mencetak
+ikhtisar bawaan lalu keluar dengan status 0.
+
+Bantuan per perintah itu nyata dan layak dibaca: `omni <perintah> --help`. Kalau
+rujukan ini dan bantuannya berbeda, yang tercatat di sini adalah apa yang
+diterima kode sumbernya.

--- a/docs/website/src-id/reference/environment.md
+++ b/docs/website/src-id/reference/environment.md
@@ -1,0 +1,128 @@
+# Variabel lingkungan
+
+Semua variabel `OMNI_*` yang dibaca binary-nya. Dikelompokkan menurut alasan Anda
+akan meraihnya.
+
+## Yang benar-benar akan Anda pakai
+
+| variabel | efeknya |
+|---|---|
+| `OMNI_PASSTHROUGH=1` | Lewati pipeline sepenuhnya. Keluaran mentah, setiap kali. |
+
+Ini hal pertama yang harus diraih ketika Anda curiga OMNI mengubah sesuatu yang
+seharusnya tidak ia ubah, dan hal yang perlu disetel ketika Anda butuh byte yang
+persis dari berkas yang dibaca lewat shell Anda. Keluaran yang identik dengan dan
+tanpa variabel itu berarti OMNI tidak terlibat.
+
+## Di mana segala sesuatu tinggal
+
+| variabel | efeknya |
+|---|---|
+| `OMNI_HOME` | Menaruh seluruh pohonnya, konfigurasi dan data, di satu direktori |
+| `OMNI_CONFIG_HOME` | Direktori konfigurasi, kalau Anda mau ia terpisah dari data |
+| `OMNI_DATA_HOME` | Direktori data, begitu juga |
+| `OMNI_DB_PATH` | Jalur ke basis data SQLite |
+| `OMNI_TRANSCRIPT_DIR` | Tempat transkrip sesi ditulis |
+
+`OMNI_DB_PATH` pantas mendapat catatan sendiri. Arahkan ia ke berkas coretan
+setiap kali Anda menyelidiki perilaku OMNI dengan tangan:
+
+```sh
+OMNI_DB_PATH=/tmp/probe.db omni exec <perintah>
+```
+
+Keluarannya tidak deterministik terhadap basis data yang hangat, karena riwayat
+sesi memberi masukan ke penilainya, dan basis data bersama yang hangat membuat
+penulisan berbaris antre, yang biasanya jadi alasan `omni exec` tampak
+menggantung. Ia juga wajib ketika menjalankan test suite terhadap pemasangan yang
+hidup.
+
+## Retensi
+
+| variabel | efeknya |
+|---|---|
+| `OMNI_TRACE_RETENTION_DAYS` | Berapa hari jejak eksekusi apa adanya disimpan. Bawaannya 7. |
+| `OMNI_SESSION_TTL` | Umur sesi, dalam menit |
+
+Tahan jendela jejaknya tetap terbuka selagi sebuah pengukuran berjalan:
+
+```sh
+OMNI_TRACE_RETENTION_DAYS=90 ...
+```
+
+Tujuh hari itu alasan tidak ada angka benchmark yang diterbitkan bisa diturunkan
+ulang seminggu setelah ia diukur, termasuk oleh orang yang menerbitkannya.
+Naikkan sebelum Anda mulai, bukan sesudah.
+
+## Tekanan konteks
+
+| variabel | efeknya |
+|---|---|
+| `OMNI_CONTEXT_WINDOW` | Petunjuk ukuran jendela konteks, dalam token |
+| `OMNI_PRESSURE_WARN` | Ambang peringatan, sebagai bagian dari jendelanya |
+| `OMNI_PRESSURE_CRITICAL` | Ambang kritis |
+
+OMNI memperkirakan seberapa penuh konteks sesinya lalu menyuntikkan peringatan
+setelah ambang-ambang ini. Setel jendelanya agar cocok dengan model yang
+sebenarnya Anda jalankan.
+
+## Perilaku sesi
+
+| variabel | efeknya |
+|---|---|
+| `OMNI_FRESH` | Paksa sesi baru alih-alih melanjutkan yang ada |
+| `OMNI_CONTINUE` | Disetel secara internal oleh dispatcher untuk menandai sesi lanjutan |
+| `OMNI_SUBAGENT=1` | Mode subagent |
+| `OMNI_AGENT_ID` | Identitas agent, dicatat di setiap baris |
+
+`OMNI_AGENT_ID` yang perlu dipahami sebelum mengutip angka apa pun. Setiap baris
+penyulingan membawanya, dan baris yang tercatat di bawah `terminal` adalah byte
+TTY yang tidak pernah dibaca model mana pun. Mencampur baris itu dengan baris
+hook pernah membuat 73% penghematan yang diterbitkan menjadi fiksi. Ketika
+beberapa agent berjalan berdampingan, beri masing-masing id-nya sendiri.
+
+## Loop
+
+| variabel | efeknya |
+|---|---|
+| `OMNI_LOOP_ID` | Pengenal loop. Alfanumerik dan tanda hubung, 64 karakter. |
+| `OMNI_LOOP_GOAL` | String tujuan, 500 karakter, tanpa metakarakter shell |
+| `OMNI_LOOP_BUDGET` | Anggaran token per iterasi, sampai 10 juta |
+| `OMNI_LOOP_ITERATION` | Nomor iterasi saat ini. Bawaannya 0. |
+
+Lihat [Loop engineering](../integrations/loops.md).
+
+## Keluaran
+
+| variabel | efeknya |
+|---|---|
+| `OMNI_QUIET=1` | Redam baris statistik di stderr pada mode pipa |
+| `OMNI_OUTPUT_JSON` | Keluaran JSON dari jalur pipa |
+| `OMNI_EXPORT_CSV` | Ekspor data sesi sebagai CSV saat sesi berakhir |
+
+## Build dan internal
+
+Bukan untuk disetel dengan tangan. Didaftar supaya melihat salah satunya di stack
+trace atau di konfigurasi yang dihasilkan bukan lagi misteri.
+
+| variabel | disetel oleh |
+|---|---|
+| `OMNI_BIN` | Ditulis ke dalam plugin Hermes yang dihasilkan, menyebut jalur binary-nya |
+| `OMNI_CMD` | Perintah yang sedang diproses, jatuh ke `CMD` kalau kosong |
+| `OMNI_GIT_HASH`, `OMNI_BUILD_DATE` | Dicap saat build, dilaporkan `omni version` |
+| `OMNI_UNRELEASED_ENTRIES` | Dihitung `build.rs` dari `CHANGELOG.md`, jadi binary yang dibangun dari pohon tanpa tag mengatakannya di `omni doctor` |
+| `OMNI_PI_PACKAGE_SOURCE` | Sumber paket untuk integrasi agent Pi |
+| `OMNI_DATA_HOME_UNSET_FOR_TEST` | Hanya untuk fixture test |
+
+## Benchmark
+
+| variabel | efeknya |
+|---|---|
+| `OMNI_BENCH_DB` | Basis data yang diputar ulang |
+| `OMNI_BENCH_ALL=1` | Putar ulang populasi yang lebih luas termasuk keluaran terminal |
+| `OMNI_BENCH_RTK` | Jalur ke binary `rtk`, menambahkan lengan adu langsung |
+
+`OMNI_BENCH_ALL` ada supaya harness-nya bisa menyebut populasi mana yang ia ukur,
+bukan membiarkannya disimpulkan sendiri. Menyertakan keluaran terminal mencetak
+79,1% sementara populasi yang menghadap model mencetak 43,3%, atas data yang
+sama.

--- a/docs/website/src-id/reference/hooks.md
+++ b/docs/website/src-id/reference/hooks.md
@@ -1,0 +1,112 @@
+# Hook
+
+Titik masuk yang dipanggil host agent. Anda tidak pernah mengetik ini;
+`omni init` menuliskannya ke konfigurasi host.
+
+| titik masuk | kapan host memanggilnya |
+|---|---|
+| `omni --pre-hook` | Sebelum sebuah tool berjalan |
+| `omni --post-hook` | Setelah sebuah tool menghasilkan keluaran |
+| `omni --hook` | Dispatcher universal, untuk host dengan satu slot hook |
+| `omni --session-start` | Sesi dimulai |
+| `omni --session-end` | Sesi berakhir |
+| `omni --pre-compact` | Sebelum host memadatkan percakapan |
+| `omni --mcp` | Jalan sebagai server MCP lewat stdio |
+| `cmd \| omni` | Mode pipa, tanpa host sama sekali |
+
+## Satu panggilan, dua hook
+
+![Satu panggilan tool Bash melewati OMNI dua kali: pre-hook boleh menulis ulang perintahnya sebelum shell menjalankannya, dan post-hook menyuling keluarannya sesudahnya, membaca basis data lokal untuk baris yang sudah ditampilkan dan mengarsipkan apa yang ia buang.](../media/hook-lifecycle.svg)
+
+Shell menjalankan apa pun yang diserahkan pre-hook dan tidak pernah tahu OMNI
+ada. Hanya jawabannya yang ditulis ulang, dan itu sebabnya tidak ada apa pun di
+sini yang bisa mengubah apa yang dilakukan perintah Anda.
+
+## Apa yang dilakukan masing-masing
+
+**Pre-tool** memutuskan apakah sebuah perintah perlu dilewatkan OMNI sama sekali,
+dan bisa menulis ulangnya menjadi `omni exec`. Tulis ulang itu membungkus
+**seluruh** string perintahnya, termasuk pengalihan keluaran, dan itu sebabnya
+berkas log di disk dari sebuah perintah yang cocok bisa ternyata versi
+sulingannya. Patahkan awalannya (`env cargo test`) ketika Anda butuh log
+mentahnya.
+
+**Post-tool** acara utamanya: keluaran mentah datang, pipeline berjalan, dan
+hasil sulingannya diserahkan kembali untuk disubstitusi host.
+
+**Post-tool-failure** ada karena perintah yang gagal harus lewat apa adanya, dan
+para host sangat tidak sepakat soal bagaimana mereka menyatakan sebuah perintah
+gagal. Claude Code mengirim string biasa, `Error: Exit code N`. Yang lain membawa
+penanda galat terstruktur. Membaca satu bentuk saja adalah bug yang pernah
+dimiliki proyek ini.
+
+**Session start** menyuntikkan konteks proyek: berkas yang sedang panas, galat
+aktif terakhir, pengetahuan yang tersimpan, tujuan yang dipancang.
+
+**Session end** menulis ringkasannya dan bisa mengekspor CSV.
+
+**Pre-compact** adalah peringatan dari host bahwa percakapannya sebentar lagi
+dipendekkan.
+
+## Dua pintu menuju satu pipeline
+
+`post_tool` dan `pipe` adalah titik masuk terpisah yang menjalankan tahapan yang
+sama, dan menjaga keduanya seiring sudah berulang kali jadi sumber bug. Tiga
+perbaikan terpisah masing-masing membetulkan satu salinan dan meninggalkan yang
+lain. Tahap ledger sempat ada di `post_tool` selama satu rilis sebelum `pipe`
+memilikinya sama sekali, jadi perintah yang ditulis ulang pre-hook menjadi
+`omni exec` mendapat penyaringnya dan tidak lebih.
+
+Kalau Anda mengubah perilaku pipeline, ubah keduanya, atau periksa kenapa tidak.
+
+## Kenapa ia tidak pernah membuat agent Anda mati
+
+Setiap hook berjalan di dalam `catch_unwind`, di titik masuk tertinggi. Panik di
+satu tahap berongkos satu penyulingan, bukan satu sesi. Basis data yang tidak mau
+dibuka berongkos konteks sesi, bukan pipeline-nya.
+
+Itu aturan **gagal terbuka**, dan ia punya satu sisi tajam yang layak disebut:
+gagal terbuka berarti menyerahkan kembali byte mentahnya. Ia tidak berarti
+mengeluarkan ringkasan yang riang. Distiller yang tidak mengurai apa pun lalu
+mengembalikan `0 tests passed` sedang gagal **tertutup**, dan dengan percaya
+diri.
+
+## Apa yang harus dilakukan sebuah host supaya semua ini berarti
+
+Mendaftarkan hook-nya, lalu menghormati apa yang ia kembalikan.
+
+Paruh kedua tidak dijamin. OMNI pernah mengeluarkan hasil sulingannya di bawah
+kunci yang diabaikan Claude Code, jadi tidak ada yang diterapkan di jalur itu
+selama dua rilis sementara OMNI mencatat sebuah penghematan dan mencetak catatan
+kaki untuk masing-masingnya. Perbaikannya membetulkan kuncinya dan meninggalkan
+bentuk nilainya tetap salah, dan gejalanya bertahan tanpa disadari.
+
+Dua hal yang diajarkannya, keduanya tidak kentara:
+
+- Tulis ulangnya divalidasi terhadap **skema keluaran milik tool host itu
+  sendiri**, satu bentuk per tool. Tidak ada bentuk universal.
+- Bidangnya saling bebas. Tulis ulang yang ditolak tetap meloloskan pesan
+  konteksnya, jadi catatan kaki penghematan tercetak untuk penyulingan yang
+  dibatalkan.
+
+Jadi bukti sebuah hook bekerja bukan catatan kakinya dan bukan `omni stats`.
+Buktinya adalah transkrip sesi milik host sendiri:
+
+```sh
+grep -c hook_error_during_execution ~/.claude/projects/<proyek>/<sesi>.jsonl
+```
+
+Peringatan yang bisa Anda lihat bukan peringatan yang bisa dilihat agent. Lampiran
+seperti itu tidak pernah masuk ke konteks model, jadi sebuah agent bisa bilang
+hook-nya baik-baik saja sementara terminal Anda penuh penolakan.
+
+## Menguji sebuah hook dengan tangan
+
+Beri ia muatan secara langsung ketimbang menebak jalur mana yang berjalan:
+
+```sh
+echo '<json muatan host>' | omni --post-hook
+```
+
+`omni exec` dan post-hook memilih rute yang berbeda, jadi hasil dari yang satu
+bukan bukti tentang yang lain.

--- a/docs/website/src-id/reference/mcp-tools.md
+++ b/docs/website/src-id/reference/mcp-tools.md
@@ -1,0 +1,95 @@
+# Perkakas MCP
+
+`omni init` mendaftarkan OMNI sebagai server MCP, yang memberi agent **25
+perkakas** yang bisa ia panggil sendiri tanpa lewat Anda.
+
+Pastikan daftarnya terhadap binary Anda sendiri, bukan terhadap halaman ini:
+
+```sh
+{ echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"p","version":"1"}}}'
+  echo '{"jsonrpc":"2.0","method":"notifications/initialized"}'
+  echo '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'; } \
+| omni --mcp | tail -1 | jq -r '.result.tools[].name'
+```
+
+## Mengambil isi kembali
+
+| perkakas | apa yang ia lakukan |
+|---|---|
+| `omni_retrieve` | Ambil isi lengkap yang dihilangkan sebuah penanda, lewat handle-nya |
+| `omni_run` | Jalankan perintah shell lalu kembalikan keluaran sulingannya |
+| `omni_signal_extract` | Tarik sinyal dari teks mentah, tanpa pipeline hook |
+
+`omni_run` paling penting di host yang tidak bisa menulis ulang tool shell
+bawaannya. Di sana, ia satu-satunya jalan menuju keluaran sulingan, dan itu
+sebabnya `omni init --cursor` memasang sebuah aturan yang menyuruh agent
+mengutamakannya.
+
+## Memahami apa yang dikerjakan OMNI
+
+| perkakas | apa yang ia lakukan |
+|---|---|
+| `omni_explain_savings` | Rute, penyaring, byte masuk dan keluar, persentase hemat per perintah terkini |
+| `omni_history` | Penyulingan terkini beserta penghematan dan rasio per panggilan |
+| `omni_context_breakdown` | Rincian token menurut sumbernya untuk giliran saat ini |
+| `omni_density` | Seberapa banyak sinyal dibanding kebisingan dalam sepotong teks |
+| `omni_budget` | Pemakaian anggaran token dan efisiensi kompresi untuk sesi ini |
+
+Keempat ini jawaban yang tepat untuk "apakah OMNI membantu di sini". Tarik
+angkanya, jangan membentuk kesan.
+
+## Ingatan
+
+| perkakas | apa yang ia lakukan |
+|---|---|
+| `omni_remember` | Simpan sebuah keputusan, jebakan atau batasan |
+| `omni_recall` | Pencarian semantik lintas engram, pengetahuan dan riwayat penyulingan |
+| `omni_knowledge` | Kueri atau simpan pengetahuan proyek lintas sesi |
+| `omni_insight` | Persoalan dan pola galat berulang teratas di seluruh proyek |
+| `omni_adaptive_insights` | Pola pengambilan kembali, sebagai penilaian atas keefektifan penyulingan |
+| `omni_handoff` | Ekspor keadaan sesi sebagai markdown yang bisa dibawa, tanpa perlu jaringan |
+
+`omni_handoff` hanya ada di MCP. Subperintah CLI dengan nama itu sudah dihapus.
+
+## Sesi dan pencarian
+
+| perkakas | apa yang ia lakukan |
+|---|---|
+| `omni_session` | Keadaan sesi: status, konteks, bersihkan |
+| `omni_search` | Cari di riwayat sesi ini |
+| `omni_query` | Kueri riwayat penyulingan dengan bentuk kueri yang tetap |
+| `omni_context` | Konteks dependensi ringan untuk sebuah berkas |
+| `omni_agents` | Agent lain yang sedang aktif di proyek ini |
+
+## Penyetelan
+
+| perkakas | apa yang ia lakukan |
+|---|---|
+| `omni_find_noise` | Analisis jejak mentah terkini untuk mencari kebisingan yang berulang |
+
+> Sifatnya saran saja, dan pembelajarnya memperlakukan "berulang" sebagai
+> "kebisingan". Ia pernah menyarankan membuang `^metadata:`, `^spec:`, pagar blok
+> kode dan `^\[stderr\]`, yang justru struktur dan kanal galat. Jangan pernah
+> menempelkan keluarannya ke mana pun tanpa membacanya baris demi baris.
+
+## Loop
+
+| perkakas | apa yang ia lakukan |
+|---|---|
+| `omni_loop_status` | Cek status sekali panggil untuk orkestrator sebelum tiap iterasi |
+| `omni_loop_memory` | Baca dan tulis ingatan loop yang selamat dari restart sesi |
+| `omni_set_loop_context` | Perbarui konteks loop secara dinamis |
+| `omni_budget_status` | Status anggaran untuk iterasi ini. Panggil sebelum pekerjaan mahal. |
+| `omni_verify` | Sebagai subagent pemeriksa, nilai pekerjaan terkini agent pembuat |
+
+Lihat [Loop engineering](../integrations/loops.md).
+
+## Satu perkakas yang bukan perkakas
+
+`omni_auto_noise` muncul sebagai sebuah string di kode sumber server dan
+**bukan** sebuah perkakas. Ia nama penyaring yang diteruskan ke pembangkit TOML.
+Memanggilnya mengembalikan `-32602 tool not found`.
+
+Ia pernah salah hitung: `grep` atas kode sumber untuk `"omni_*"` mengembalikan
+27, jadi 27 salah di mana pun ia muncul. `tools/list` milik server sendiri
+menyebut 26.

--- a/docs/website/src-id/use/first-hour.md
+++ b/docs/website/src-id/use/first-hour.md
@@ -1,0 +1,99 @@
+# Satu jam pertama
+
+Diasumsikan `omni init` dan `omni doctor` sudah dijalankan. Tidak ada di sini
+yang mengubah konfigurasi; semuanya soal belajar membaca apa yang sedang
+dikerjakan OMNI supaya Anda bisa menilainya.
+
+## Lihat satu penyulingan terjadi
+
+Minta agent Anda menjalankan sesuatu yang berisik. Test atau build paling pas.
+
+Lalu, di shell Anda sendiri:
+
+```sh
+omni diff
+```
+
+Mentah di satu sisi, hasil sulingan di sisi lain, untuk perintah terakhir. Ini
+cara tercepat menumbuhkan kepercayaan atau kecurigaan, dan keduanya berguna.
+
+## Coba satu dengan tangan
+
+```sh
+omni exec cargo test
+```
+
+`omni exec` menjalankan sebuah perintah lewat seluruh pipeline lalu mencetak
+hasilnya dengan catatan kaki. Ia harness yang diminta dipakai setiap laporan bug
+di proyek ini, karena ia mengeluarkan host dari gambar.
+
+Bentuk argumennya persis: `omni exec cargo test`, **bukan**
+`omni exec -- cargo test` dan bukan string yang dikutip. Keduanya gagal dengan
+"No such file or directory".
+
+## Lihat angkanya
+
+```sh
+omni stats
+```
+
+Ia memimpin dengan umur sesi, berapa perintah yang dibawa sebuah sesi sebelum
+host menutupnya, karena itulah yang sebenarnya dibebankan jendela konteks kepada
+Anda. Persentase penyulingan di bawahnya adalah alat diagnosis untuk pipeline
+satu host.
+
+```sh
+omni stats --detail        # per perintah, per rute, per sesi, per agent
+omni stats --rerun         # distiller mana yang berongkos satu run ulang
+omni dashboard             # angka yang sama di peramban, hanya di 127.0.0.1
+```
+
+`--rerun` yang menarik. Persentase pengurangan tidak bisa memberi tahu apakah
+sebuah distiller membuang sesuatu yang lalu harus diambil ulang agent; yang ini
+bisa.
+
+## Pancang apa yang sedang Anda kerjakan
+
+```sh
+omni goal set 'Migrate the billing service off the legacy queue'
+```
+
+Penilainya mengutamakan keluaran yang berkaitan dengan tujuan itu, dan agent
+diingatkan padanya alih-alih melantur. `omni goal show` untuk memeriksa,
+`omni goal clear` untuk melepasnya.
+
+## Matikan untuk satu perintah
+
+```sh
+OMNI_PASSTHROUGH=1 kubectl get pods -o yaml
+```
+
+Hal pertama yang harus diraih ketika Anda curiga OMNI mengubah sesuatu yang
+seharusnya tidak ia ubah. Kalau keluarannya identik dengan dan tanpa variabel
+itu, OMNI tidak terlibat.
+
+## Hal yang layak diketahui sebelum ia menggigit
+
+**Membaca berkas lewat shell Anda bisa tiba dalam bentuk sulingan.** Karena
+hook-nya memang benar-benar menulis ulang keluaran Bash, `cat` atau `sed` atas
+sebuah berkas sumber bisa kembali terlipat. Pakai perkakas pembaca berkas milik
+agent Anda, atau `OMNI_PASSTHROUGH=1`, ketika Anda butuh byte yang persis.
+
+**Perintah yang cocok bisa ditulis ulang sebelum ia berjalan.** Pre-hook mengubah
+sebagian perintah menjadi `omni exec`, termasuk pengalihan keluarannya, sehingga
+berkas log yang kemudian Anda baca adalah yang sudah disuling. Patahkan awalannya
+(`env cargo test`, atau `true && cargo test`) ketika Anda butuh log mentah di
+disk.
+
+**Jangan menilai OMNI dari keluaran yang Anda baca lewat OMNI.** Sebuah
+`cargo test` yang dibaca lewat hook pernah melaporkan "1 failed" untuk suite yang
+hijau dengan 398 lulus. Alihkan ke sebuah berkas dengan passthrough menyala
+sebelum membuat klaim apa pun tentang sebuah hasil.
+
+## Kapan minta bantuan
+
+Kalau keluaran terlihat lebih pendek daripada seharusnya, kalau ada baris yang
+hilang, atau kalau OMNI melaporkan sukses untuk sesuatu yang gagal, itu layak
+dilaporkan. Reproduksi dulu dengan `omni exec`, dan baca **seluruh** keluaran
+sulingannya, bukan hasil `grep` atasnya: mem-`grep` menyembunyikan judul yang
+sering justru membuat keluaran itu ternyata tidak kehilangan apa pun.

--- a/docs/website/src-id/use/install.md
+++ b/docs/website/src-id/use/install.md
@@ -1,0 +1,119 @@
+# Pasang
+
+## Ambil binary-nya
+
+**macOS dan Linux, lewat Homebrew:**
+
+```sh
+brew install fajarhide/tap/omni
+```
+
+**macOS, Linux, WSL:**
+
+```sh
+curl -fsSL omni.weekndlabs.com/install | bash
+```
+
+**Windows, PowerShell:**
+
+```powershell
+irm omni.weekndlabs.com/install.ps1 | iex
+```
+
+**Dari sumber**, yang butuh toolchain sesuai pin di `rust-toolchain.toml`:
+
+```sh
+git clone https://github.com/fajarhide/omni
+cd omni
+cargo build --release
+```
+
+**Dari dalam Claude Code**, kalau Anda lebih suka agent yang mengurus sisanya:
+
+```
+/plugin marketplace add fajarhide/omni
+/plugin install omni@omni
+```
+
+Itu memasang sebuah skill, bukan binary-nya. Skill tersebut membawa perintah
+pemasangan di bawah, langkah verifikasinya, dan cara membaca penanda, supaya
+agent berhenti menebak-nebak ketiganya. Semua di halaman ini tetap berlaku;
+plugin hanya berarti ada orang lain yang mengetiknya.
+
+## Sambungkan ke agent Anda
+
+```sh
+omni init            # host tempat Anda berjalan, atau sebuah menu kalau Anda punya terminal
+omni init --claude   # atau --cursor, --codex, --gemini, dan 11 lainnya
+omni init --all      # semua host, plus .vscode/mcp.json di direktori saat ini
+```
+
+`omni init` menulis hook dan mendaftarkan server MCP. Ia idempoten, jadi
+menjalankannya lagi setelah upgrade adalah langkah yang benar, bukan risiko.
+
+Tanpa terminal untuk bertanya, yang memang begitulah cara agent menjalankannya,
+`omni init` menyetel host tempat ia berjalan alih-alih gagal karena menunya tidak
+ada. Ia menyebut host mana yang ia pilih. Kalau ia tidak bisa menyebut host-nya,
+misalnya di shell biasa, ia berhenti dan meminta sebuah flag ketimbang memasang
+ke tempat yang tidak diminta siapa pun.
+
+Semua flag yang didukung ada di [init](../reference/cmd/init.md). Host mana dapat
+apa ada di [Agent yang didukung](../reference/agents.md), dan halaman itu lebih
+penting daripada kedengarannya: host yang tidak bisa menulis ulang keluaran tool
+shell-nya sendiri tidak akan menunjukkan byte hasil sulingan ke agent, sebaik apa
+pun pipeline-nya bekerja.
+
+## Verifikasi
+
+```sh
+omni doctor
+```
+
+Ini bukan seremoni opsional. Ia memeriksa binary-nya ada di `PATH`, basis datanya
+bisa dibuka, hook-nya benar-benar terpasang di tempat host membacanya, dan server
+MCP-nya terdaftar. `omni doctor --fix` memperbaiki yang bisa ia perbaiki.
+
+**Codex CLI butuh satu langkah tambahan.** Ia hanya menjalankan hook yang sudah
+dinyatakan tepercaya dan melewati sisanya diam-diam. Setelah `omni init --codex`,
+jalankan `codex` sekali lalu setujui hook-nya di bagian "Hooks need review".
+`omni doctor` akan terus gagal sampai Anda melakukannya.
+
+## Pastikan ia benar-benar jalan
+
+`omni doctor` bilang sambungannya benar. Yang berikut bilang sambungannya sedang
+dipakai:
+
+```sh
+cat berkas-panjang.txt     # lewat agent Anda, bukan shell ini
+omni diff                  # mentah dibanding hasil sulingan, untuk perintah terakhir
+omni stats
+```
+
+Kalau `omni stats` menampilkan baris dan `omni diff` menampilkan perbedaan,
+hook-nya hidup.
+
+Satu jebakan yang lebih baik diketahui sekarang daripada nanti: angka di
+`omni stats` dipisah menurut `agent_id`, dan baris yang tercatat di bawah
+`terminal` adalah keluaran TTY yang tidak pernah dibaca model mana pun. Ketika
+Anda menilai apakah OMNI layak berada di sana, lihat baris untuk host Anda yang
+sebenarnya.
+
+## Perbarui
+
+```sh
+omni update      # untuk pemasangan Homebrew
+brew upgrade omni
+```
+
+Jalankan ulang `omni init` sesudahnya kalau sebuah rilis mengubah kontrak
+hook-nya. Changelog menyebut kapan itu terjadi.
+
+## Cabut
+
+```sh
+omni init --uninstall   # hook dan pendaftaran MCP untuk satu host
+omni reset --all        # semua integrasi, dan menawarkan menghapus omni.db
+```
+
+`omni reset` tanpa flag memberi menu interaktif. Keduanya tidak menyentuh
+konfigurasi shell Anda, karena OMNI memang tidak pernah menulis apa pun di sana.

--- a/docs/website/src-id/use/markers.md
+++ b/docs/website/src-id/use/markers.md
@@ -1,0 +1,106 @@
+# Membaca penanda
+
+Penanda adalah cara OMNI memberi tahu apa yang ia lakukan. Bentuknya hanya
+beberapa, dan mengenalinya adalah beda antara memercayai perkakas ini dan
+mencurigainya.
+
+## Bentuk-bentuknya
+
+```
+[OMNI: 406 lines omitted, omni retrieve 3f7bfd89bc5d7cee for full output]
+```
+
+Ada isi yang dipotong dan diarsipkan. Enam belas karakter itu sebuah handle:
+`omni retrieve 3f7bfd89bc5d7cee` mencetak aslinya kembali, persis byte demi byte,
+dari shell mana pun di sesi mana pun.
+
+```
+[OMNI: 40 lines already shown, omni retrieve bc7e821a4340073e]
+```
+
+Ledger. Baris-baris ini sudah dikeluarkan sebelumnya **di sesi ini**, jadi
+klaimnya adalah agent masih memegangnya dan handle-nya tidak berongkos kecuali ia
+memang mau membaca ulang.
+
+```
+[OMNI: 40 lines from an earlier session, omni retrieve bc7e821a4340073e]
+```
+
+Ledger juga, klaim berbeda. Baris-baris ini pergi ke **sesi lain** dari proyek
+ini, dan agent ini belum pernah melihatnya. Kalimatnya sengaja bukan "already
+shown", karena itu akan salah. Melipatnya adalah taruhan bahwa agent tidak akan
+membutuhkannya, dan karena itu ia memikul ambang keuntungan tiga kali lipat.
+
+Sesi lain itu bisa jadi juga agent yang lain. Riwayat proyek dikunci pada
+direktorinya, jadi apa pun yang berjalan di repositori ini ikut menyumbang. Lihat
+[apa yang dibagi dua agent](../concepts/the-ledger.md#apa-yang-dibagi-dua-agent-dalam-satu-repo).
+
+```
+[OMNI: identical to the 40 lines already shown, omni retrieve bc7e821a4340073e]
+[OMNI: identical to 40 lines from an earlier session, omni retrieve bc7e821a4340073e]
+```
+
+Dua klaim yang sama, untuk jawaban yang terulang **seluruhnya**. Ketika
+pelipatannya mencakup setiap baris, penandanya adalah seluruh keluaran, bukan
+sebuah lubang di dalamnya, jadi ia berbunyi `identical to` dan Anda mendapat satu
+baris di tempat run ulang akan mencetak ratusan baris yang sama. Apa pun yang
+kurang dari seluruh jawaban memakai kalimat di atasnya.
+
+```
+[N similar lines collapsed]
+```
+
+Collapse. Deretan baris yang nyaris identik, diganti sebuah hitungan.
+
+```
+[OMNI Active] ⏺ 93.7% reduction (2.3 KB → 147 B) 3ms
+```
+
+Catatan kaki, pada `omni exec` dan mode pipa. Ukuran masukan, ukuran keluaran,
+dan berapa lama pipeline-nya berjalan.
+
+```
+[Partial signal]
+```
+
+Pipeline mengenali sebagian keluarannya, tapi tidak semuanya.
+
+## Membaca persentase dengan benar
+
+Bug-bug terburuk dalam sejarah proyek ini melaporkan pengurangan **paling
+besar**. Distiller yang menghapus jawabannya terkompresi dengan indah.
+
+Jadi angka besar bukan kabar baik dengan sendirinya. `omni diff` adalah
+pemeriksanya:
+
+```sh
+omni diff     # perintah terakhir, mentah dibanding hasil sulingan
+```
+
+Kalau penghematan 99% ternyata membuang jalur berkas yang justru jawabannya, itu
+bug yang layak dilaporkan, dan itu persis kelas yang paling dipedulikan proyek
+ini.
+
+## Ketika sama sekali tidak ada penanda
+
+Sering. Sekitar 97% panggilan tidak menghemat apa pun dan mengembalikan
+keluarannya langsung. Itu pipeline yang bekerja, bukan gagal. Itu terjadi ketika:
+
+- Muatannya JSON, YAML, CSV atau TSV. Tidak pernah disentuh, memang disengaja.
+- Perintahnya gagal. Keluar dengan status bukan nol lewat apa adanya.
+- Tidak ada basa-basi untuk dibuang. Tabel `kubectl get pods` adalah pendaftaran
+  yang setiap barisnya sebuah data.
+- Keluarannya terlalu pendek untuk pantas diberi penanda.
+
+## Mengambil isinya kembali
+
+```sh
+omni retrieve 3f7bfd89bc5d7cee
+```
+
+Bekerja di semua host, dengan atau tanpa MCP. Agent yang server MCP-nya terpasang
+bisa memanggil `omni_retrieve` sendiri tanpa bertanya ke Anda.
+
+Satu batas yang tidak bisa dijanjikan sebuah handle: arsipnya jendela bergulir 30
+hari, jadi `omni retrieve` atas isi yang lebih tua dari itu tidak akan ketemu.
+Jejak apa adanya bahkan lebih pendek, tujuh hari.

--- a/docs/website/src-id/use/memory.md
+++ b/docs/website/src-id/use/memory.md
@@ -1,0 +1,98 @@
+# Ingatan antar sesi
+
+Agent yang sama yang membaca terlalu banyak juga melupakan segalanya begitu Anda
+memulainya ulang. OMNI membawa tiga jenis ingatan, dan ketiganya disimpan dengan
+lama yang berbeda secara sengaja.
+
+## Apa yang disimpan, dan berapa lama
+
+| tingkat | apa | disimpan |
+|---|---|---|
+| **Permanen** | pengetahuan proyek, pola galat yang berulang, engram, ingatan tujuan | sampai Anda menghapusnya, kecuali ingatan tujuan yang menghormati `ttl_days` miliknya sendiri |
+| **Kerja, 30 hari** | sesi, baris penyulingan, berkas yang sering disentuh, arsip, indeks peristiwa, ledger | jendela bergulir |
+| **Apa adanya, 7 hari** | jejak eksekusi dan transkrip sesi | sengaja lebih pendek, dua orde besaran lebih berat per baris |
+
+Jawaban singkat untuk "apakah OMNI masih akan tahu proyek saya setelah sebulan
+ditinggal" adalah ya untuk kesimpulannya dan tidak untuk byte mentahnya. Batas
+yang penting dalam praktik: `omni retrieve` atas isi yang diarsipkan lebih dari
+30 hari lalu tidak akan ketemu.
+
+Ledger punya satu cara melupakan lagi yang tidak berdasarkan jam. **Saat
+pemadatan, paruh sesinya dibuang seluruhnya**, karena pemadatan adalah tempat
+agent berhenti memegang apa yang ditunjukkan kepadanya, dan setiap klaim "already
+shown" menjadi salah pada saat yang sama. Kalau pelipatan tampak berhenti setelah
+sesi panjang dipadatkan, itu hal ini, sedang bekerja. Paruh proyeknya selamat,
+dan [Ledger](../concepts/the-ledger.md#lupa) menjelaskan pembagiannya.
+
+## Memancang sebuah tujuan
+
+```sh
+omni goal set 'Migrate the billing service off the legacy queue'
+omni goal show
+omni goal clear
+```
+
+Penilainya mengutamakan keluaran yang berkaitan dengan tujuan itu, dan agent
+diingatkan padanya di setiap prompt alih-alih melantur dari tugasnya sepanjang
+sesi yang panjang.
+
+## Fakta yang layak disimpan
+
+```sh
+omni remember 'The staging database ignores migrations run outside the deploy job'
+```
+
+Agent yang MCP-nya terpasang memanggil `omni_remember` sendiri, dan menarik fakta
+kembali dengan `omni_recall`, sebuah pencarian semantik lintas engram,
+pengetahuan tersimpan dan riwayat penyulingan.
+
+Simpan yang tidak bisa diturunkan dari kodenya: sebuah keputusan dan alasannya,
+sebuah jebakan, sebuah batasan yang tidak disebut berkas mana pun. Jangan simpan
+yang sudah dicatat repositorinya.
+
+## Membawa satu sesi melewati restart
+
+Konteks sesi disuntikkan saat sesi dimulai, jadi agent baru tahu berkas mana yang
+sedang panas dan apa galat aktif terakhirnya. Kalau host-nya tertutup atau Anda
+berganti perkakas, konteks proyeknya masih ada.
+
+```sh
+omni session --status
+omni session --history
+omni session --resume        # lanjutkan sesi yang terputus
+omni session --transcript
+omni session --health
+```
+
+Untuk pindah ke mesin atau host yang tidak berbagi basis data, `omni_handoff`
+mengekspor keadaan sesi saat ini sebagai markdown yang bisa dibawa dan ditempel
+ke sesi baru. Ia hanya perkakas MCP; subperintah CLI-nya sudah dihapus.
+
+## Engram
+
+Ringkasan subtugas yang selesai, ditulis seiring pekerjaan rampung, bukan
+disusun ulang belakangan.
+
+```sh
+omni engram
+omni engram --json
+```
+
+## Pengetahuan yang hidup lebih lama daripada satu sesi
+
+```sh
+omni query errors in last 5 commands
+omni patterns                # galat yang terus kembali lintas sesi
+```
+
+`omni_insight` memeringkat persoalan berulang yang sama untuk seluruh proyek, dan
+ia perkakas MCP tanpa padanan CLI. Ia sempat dicantumkan di blok di atas seolah
+Anda bisa menjalankannya.
+
+## Yang tidak bisa ia lakukan
+
+Ia per mesin. Tidak ada sinkronisasi, tidak ada server, dan tidak ada penyimpanan
+bersama antar orang. `~/.omni/omni.db` adalah keseluruhannya, dan arsip jarak
+jauh
+[secara eksplisit tidak dibangun](https://omni.weekndlabs.com/docs/develop/direction#non-goals),
+bukan sekadar belum dibangun.

--- a/docs/website/src-id/use/seeing-savings.md
+++ b/docs/website/src-id/use/seeing-savings.md
@@ -1,0 +1,97 @@
+# Melihat berapa yang dihemat
+
+```sh
+omni stats
+```
+
+Semua yang ada di halaman ini membaca agregasi yang sama, jadi angka di kartu
+bagikan tidak mungkin berbeda dari angka di laporannya.
+
+## Laporannya
+
+```sh
+omni stats                 # 30 hari terakhir, bawaannya
+omni stats --today         # atau --hour, --week, --month
+omni stats --detail        # perintah, rute, sesi, agent
+omni stats --all-commands  # semua perintah, bukan cuma yang teratas
+omni stats --project       # dipecah per jalur proyek
+omni stats --json          # bisa dibaca mesin
+```
+
+Ia memimpin dengan **umur sesi**: berapa perintah yang dibawa sebuah sesi sebelum
+host menutupnya. Itu meteran yang benar-benar diperhatikan pengguna. Persentase
+penyulingan di bawahnya adalah alat diagnosis untuk pipeline satu host, bukan
+klaim produk.
+
+## Membacanya tanpa membodohi diri sendiri
+
+**Pisahkan menurut `agent_id` sebelum mengutip apa pun.** Baris yang tercatat di
+bawah `terminal` adalah byte TTY yang tidak pernah dibaca model mana pun. Pada
+satu pemasangan, baris seperti itu 73% dari seluruh byte yang diklaim OMNI sudah
+dihemat. `omni stats` sekarang mengecualikannya, tapi jebakan yang sama menunggu
+siapa pun yang mengueri basis datanya langsung.
+
+**Persentase tinggi tidak otomatis bagus.** Cacat terburuk dalam sejarah proyek
+ini melaporkan pengurangan paling besar, karena menghapus jawabannya terkompresi
+dengan sangat baik. Sandingkan angka mana pun dengan `omni diff` pada perintah
+sungguhan.
+
+**Persentase rendah biasanya benar.** Sekitar 97% panggilan tidak menghemat apa
+pun karena memang tidak ada yang bisa dihemat. Muatan terstruktur, perintah yang
+gagal dan pendaftaran semuanya lewat begitu saja, memang dirancang begitu.
+
+## Pemeriksaan yang tidak bisa dilakukan persentase
+
+```sh
+omni stats --rerun
+```
+
+Distiller mana yang berongkos satu run ulang. Kalau sebuah distiller membuang
+sesuatu yang lalu harus diambil ulang agent, pengurangannya bukan penghematan,
+melainkan penundaan. Tidak ada hitungan byte yang bisa melihat itu.
+
+## Membagikannya
+
+```sh
+omni stats --share     # ringkasan siap tempel dari penghematan terukur Anda sendiri
+omni stats --card      # ringkasan yang sama, ditulis sebagai gambar
+```
+
+Keduanya datang dari basis data Anda sendiri, dan itulah maksudnya. Klaim rasio
+di README orang lain tidak bisa diverifikasi sebelum dipasang.
+
+## Di peramban
+
+```sh
+omni dashboard             # http://127.0.0.1:7717
+omni dashboard --port 8080
+```
+
+Hanya baca, basis data yang sama, mengikat loopback dan tidak yang lain.
+
+## Menggali lebih jauh
+
+```sh
+omni stats --detail              # rincian per perintah dan per rute
+omni query errors in last 5 commands
+omni query warnings from cargo
+omni query timeline today
+omni patterns                    # galat yang terus kembali
+omni patterns --tool cargo
+```
+
+`omni_history` memberi baris per panggilan yang sama ke klien MCP. Tidak ada
+subperintah `omni history`; halaman ini sempat mencantumkannya sampai 0.7.4.
+
+`omni query` berbicara dalam bahasa kueri kecil yang tetap, bukan teks bebas.
+Bentuk yang didukung ada di bantuannya sendiri.
+
+## Mengueri basis datanya langsung
+
+`~/.omni/omni.db` adalah SQLite biasa dan tidak ada yang melarang Anda.
+
+> Jangan pernah membaca keluaran `sqlite3` lewat hook Bash saat sedang
+> menyelidiki OMNI. Pipeline-nya bisa melipat baris yang sedang Anda hitung, dan
+> filter `LIKE` yang menangkap baris keliru sudah pernah memasukkan angka salah
+> ke sebuah issue yang terbit. Daftarkan barisnya sebelum mengutip agregat apa
+> pun atasnya, dan setel `OMNI_PASSTHROUGH=1`.

--- a/docs/website/src-id/use/troubleshooting.md
+++ b/docs/website/src-id/use/troubleshooting.md
@@ -1,0 +1,126 @@
+# Kalau ada yang terlihat salah
+
+Kerjakan halaman ini berurutan. Tiga bagian pertama menyingkirkan yang mirip-mirip
+saja, dan di situlah kecurigaan biasanya berakhir.
+
+## Pertama, apakah OMNI memang terlibat
+
+```sh
+OMNI_PASSTHROUGH=1 <perintahnya>
+```
+
+Keluaran yang identik dengan dan tanpa variabel itu berarti OMNI tidak melakukan
+apa-apa. Itu akhir penyelidikannya, dan itu menyelesaikan lebih banyak kasus
+daripada apa pun di halaman ini.
+
+Lalu periksa jalur mana yang berjalan, karena keduanya tidak sama:
+
+```sh
+omni --version && ls -la "$(which omni)"   # binary yang terpasang, bukan checkout Anda
+omni doctor
+```
+
+Issue yang sudah ditutup tetap menggigit kalau perbaikannya belum dirilis.
+
+## Hal yang mirip bug padahal bukan
+
+**Muatan terstruktur tidak disentuh.** JSON, YAML, CSV, TSV, base64, terraform
+plan dan apa pun yang ditujukan ke `jq` lewat begitu saja, memang dirancang
+begitu. Bukan kesempatan yang terlewat.
+
+**Penghematan negatif pada keluaran kecil**, kira-kira `-1%` sampai `-4%`.
+Penandanya berongkos lebih mahal daripada yang dihemat kompresinya pada muatan
+pendek.
+
+**97% panggilan tidak menghemat apa pun.** Wajar. Memang tidak ada yang bisa
+dihemat.
+
+**Pembacaan berkas menunjukkan nol penghematan token di sesi yang membaca banyak
+berkas.** Permukaan OMNI di sebagian besar host adalah keluaran shell. Perkakas
+pembaca berkas milik agent Anda, berkas skill dan system prompt ada di luarnya.
+
+**Aliran biner `kubectl` rusak.** SPDY melakukan itu, ada atau tidak ada OMNI.
+
+**Pemisahan kata dan kutip di shell.** Itu shell Anda.
+
+## Jebakan yang menghasilkan kesimpulan salah
+
+**Jangan menilai OMNI dari keluaran yang Anda baca lewat OMNI.** Sebuah
+`cargo test` yang dibaca lewat hook pernah melaporkan "1 failed" untuk suite yang
+oleh cargo sendiri disebut 398 lulus. Alihkan ke sebuah berkas dengan
+`OMNI_PASSTHROUGH=1` sebelum membuat klaim apa pun tentang sebuah hasil.
+
+**Jangan mem-`grep` keluaran sulingannya.** Mem-`grep` menyembunyikan judul grup
+yang sering justru membuat keluarannya ternyata tidak kehilangan apa pun. Hasil
+pencarian 116 baris tampak seperti sudah membuang setiap nama berkas sampai
+muatan penuhnya menunjukkan satu judul nama berkas per grup dengan kecocokannya
+menjorok di bawahnya. Baca semuanya.
+
+**Keluarannya tidak deterministik terhadap basis data yang hangat.** Riwayat sesi
+memberi masukan ke penilainya, jadi perintah yang sama bisa disuling berbeda di
+dua run. Isolasi:
+
+```sh
+OMNI_DB_PATH=/tmp/probe.db omni exec <perintah>
+```
+
+**Reproduksi yang gagal bukan sebuah vonis.** Kalau sebuah bug tidak muncul lagi,
+baca jalur pengirimannya di kode sumber sebelum menyimpulkan apa pun. Sebuah pipa
+yang tampak dibuang ternyata adalah pre-hook yang membungkus seluruh string
+perintahnya, sehingga penyulingannya mendarat di hulu `tail` milik pemanggil.
+Tiga reproduksi yang dibuat tangan sudah lebih dulu kembali bersih.
+
+## Masalah yang umum
+
+**Hook-nya terpasang tapi tidak ada yang disuling.**
+`omni doctor` memeriksa sambungannya. Lalu periksa tingkat host-nya: host yang
+mengutamakan handoff atau hanya MCP sama sekali tidak bisa menulis ulang keluaran
+tool shell bawaannya. Lihat [Agent yang didukung](../reference/agents.md).
+
+**Codex CLI tidak melakukan apa-apa setelah `omni init --codex`.**
+Ia hanya menjalankan hook yang sudah dinyatakan tepercaya dan melewati sisanya
+diam-diam. Jalankan `codex` sekali lalu setujui di bagian "Hooks need review".
+
+**Peringatan di terminal yang tidak pernah disinggung agent.**
+Penolakan hook dicatat host sebagai lampiran yang tidak pernah masuk ke konteks
+model. Agent bisa sungguh-sungguh yakin hook-nya baik-baik saja sementara layar
+Anda penuh peringatan. Di Claude Code:
+
+```sh
+grep -c hook_error_during_execution ~/.claude/projects/<proyek>/<sesi>.jsonl
+```
+
+Lampiran itu membawa alasan host apa adanya.
+
+**Perintah terasa lambat.**
+Wajar, dan ia tumbuh mengikuti ukuran basis data, bukan ukuran muatan: sekitar 21
+ms terhadap basis data yang baru dan 61 ms terhadap yang 205 MB.
+
+**`omni exec` tampak menggantung.**
+Basis data bersama yang hangat membuat penulisan berbaris antre. Beri ia miliknya
+sendiri dengan `OMNI_DB_PATH`.
+
+## Melaporkannya
+
+Yang layak dilaporkan, dalam urutan kepentingan ini:
+
+1. **Klaim palsu.** OMNI menyatakan hasil yang tidak didukung masukannya: sukses
+   dilaporkan untuk sebuah kegagalan, hitungan yang tidak cocok dengan hitungan
+   runner-nya sendiri.
+2. **Sinyal yang hilang.** Sesuatu yang dibutuhkan dibuang tanpa penanda yang
+   menyebutnya.
+3. **Kebisingan.** Bertele-tele tapi tidak berbahaya.
+
+Laporan yang baik membawa keluaran mentah dan keluaran sulingan berdampingan,
+termasuk catatan kaki `[OMNI Active]`, perintah `omni exec` yang persis, dan
+`omni --version`. Catatan kakinya sering justru intinya: bug terburuk di sini
+melaporkan pengurangan paling besar.
+
+Reproduksi pada perintah sintetis kalau bisa, supaya tidak ada yang perlu
+disamarkan. Keluaran terminal sungguhan membawa nama host, id akun dan alamat
+internal lebih sering daripada dugaan orang.
+
+Tracker: <https://github.com/fajarhide/omni/issues>
+
+Discord: <https://discord.gg/zHTuvZhF2M>, kalau Anda lebih suka bertanya sebelum
+melapor.

--- a/docs/website/theme/omni.css
+++ b/docs/website/theme/omni.css
@@ -473,9 +473,34 @@ blockquote p:last-child { margin-bottom: 0; }
   color: inherit;
   text-decoration: none;
   border-bottom: 1px solid transparent;
+  /* inline-flex, not inline: the mark and the wordmark share one baseline-free
+     row so the underline on hover runs under both rather than stepping. */
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45em;
 }
 #mdbook-menu-bar .menu-title .site-home:hover {
   border-bottom-color: currentColor;
+}
+
+/* Sized in em so it tracks the wordmark through the menu bar's own font-size
+   changes at narrow widths, rather than needing a second media query. */
+#mdbook-menu-bar .site-mark {
+  display: block;
+  height: 1.4em;
+  width: 1.4em;
+}
+
+/* The translation notice on every Indonesian page (#539), injected by
+   theme/siteframe.js. Quiet on purpose: it is a provenance note, not a warning,
+   and a reader who wanted the English page would have opened it. */
+.translation-note {
+  font-size: 0.85em;
+  line-height: 1.5;
+  color: var(--wl-muted-foreground, #6b7280);
+  border-left: 2px solid var(--wl-border, #d8dbe0);
+  padding: 0 0 0 0.85rem;
+  margin: 0 0 2rem;
 }
 
 .site-links {

--- a/docs/website/theme/siteframe.js
+++ b/docs/website/theme/siteframe.js
@@ -20,24 +20,27 @@
 
   // Where a reader of the manual actually goes next. Deliberately short: the
   // sidebar is the navigation, this is the way out.
+  // Relative to the site root, which is one more level up from the Indonesian
+  // book than from the English one. `siteRoot()` is what knows the difference.
   var LINKS = [
-    { href: '../', text: 'Site' },
-    { href: '../releases', text: 'Releases' },
-    { href: '../blog', text: 'Journal' },
+    { href: '', text: 'Site' },
+    { href: 'releases', text: 'Releases' },
+    { href: 'blog', text: 'Journal' },
     { href: 'https://discord.gg/zHTuvZhF2M', text: 'Discord', external: true },
   ];
 
-  // The manual is English only, and the README is not. A reader who arrived
-  // through the Indonesian or Japanese README used to land here with no way back
-  // to their own language, so this points at the translations that already exist
-  // and are already maintained rather than pretending 35 pages are translated.
+  // A reader who arrived through a translated README used to land here with no
+  // way back to their own language. The four that are still README-only point at
+  // GitHub with absolute URLs: those files live in the omni repository, not in
+  // the site, so no relative path from /docs/ reaches them.
   //
-  // Absolute GitHub URLs on purpose. These files live in the omni repository, not
-  // in the site, so there is no relative path from /docs/ that reaches them.
+  // English and Indonesian are the exception since #539: both are real books, so
+  // their entries stay inside the manual and `manual: true` marks them as the two
+  // that do not leave for GitHub.
   var REPO = 'https://github.com/fajarhide/omni/blob/main/';
   var LANGS = [
-    { code: 'EN', label: 'English', href: REPO + 'README.md' },
-    { code: 'ID', label: 'Bahasa Indonesia', href: REPO + 'i18n/README-id.md' },
+    { code: 'EN', label: 'English', manual: true },
+    { code: 'ID', label: 'Bahasa Indonesia', manual: true },
     { code: 'JA', label: '日本語', href: REPO + 'i18n/README-ja.md' },
     { code: 'ZH', label: '简体中文', href: REPO + 'i18n/README-zh.md' },
     { code: 'KO', label: '한국어', href: REPO + 'i18n/README-ko.md' },
@@ -63,20 +66,33 @@
     return typeof path_to_root === 'string' ? path_to_root : '';
   }
 
+  /// The Indonesian manual (#539) is a second mdBook rendered into `id/` under
+  /// the English one, so every path this file builds is one level deeper there.
+  /// mdBook stamps the book's `language` onto `<html lang>`, which is the only
+  /// signal available that does not assume where the book is being served from.
+  function translated() {
+    return document.documentElement.lang === 'id';
+  }
+
   function build() {
     var bar = document.querySelector('.right-buttons');
     var title = document.querySelector('.menu-title');
     if (!bar && !title) return;
 
     var root = depth();
+    var site = root + (translated() ? '../../' : '../');
+
+    banner(root);
 
     // The wordmark is the way home on every site that has one, so make it one
     // here too rather than adding a fifth link that says Home.
     if (title && !title.querySelector('a')) {
       var home = document.createElement('a');
-      home.href = root + '../';
-      home.textContent = title.textContent.trim();
+      home.href = site;
       home.className = 'site-home';
+      var mark = markImage();
+      if (mark) home.appendChild(mark);
+      home.appendChild(document.createTextNode(title.textContent.trim()));
       title.textContent = '';
       title.appendChild(home);
     }
@@ -87,7 +103,7 @@
     nav.setAttribute('aria-label', 'Site');
     LINKS.forEach(function (l) {
       var a = document.createElement('a');
-      a.href = l.external ? l.href : root + l.href;
+      a.href = l.external ? l.href : site + l.href;
       a.textContent = l.text;
       if (l.external) {
         a.target = '_blank';
@@ -98,7 +114,61 @@
     // Before mdBook's icon buttons, so print/repo/edit stay where a returning
     // reader expects them at the far right.
     bar.insertBefore(nav, bar.firstChild);
-    bar.insertBefore(languageMenu(), nav.nextSibling);
+    bar.insertBefore(languageMenu(root), nav.nextSibling);
+  }
+
+  /// Says on every Indonesian page that it is a translation, and links the
+  /// English original (#539).
+  ///
+  /// Injected rather than written into all 28 files: the sentence is identical
+  /// everywhere and only the link differs, so 28 copies would be 28 chances for
+  /// one of them to fall out of step with the others.
+  ///
+  /// The English page is the same path with the book's own `id/` level removed.
+  /// Derived from `path_to_root` rather than by string-replacing `/id/` out of
+  /// the URL, because a reader whose own directory is called `id` should not have
+  /// their path rewritten under them.
+  function banner(root) {
+    if (!translated()) return;
+    var host = document.querySelector('#mdbook-content main') ||
+               document.querySelector('#mdbook-content');
+    if (!host) return;
+
+    var bookRoot = new URL(root || './', location.href);
+    var here = location.pathname.slice(bookRoot.pathname.length);
+
+    var note = document.createElement('div');
+    note.className = 'translation-note';
+    note.appendChild(document.createTextNode('Halaman ini terjemahan. '));
+
+    var a = document.createElement('a');
+    a.href = new URL('../' + here, bookRoot).href;
+    a.textContent = 'Versi Inggrisnya';
+    note.appendChild(a);
+    note.appendChild(document.createTextNode(
+      ' adalah sumbernya, dan bisa lebih baru daripada halaman ini.'));
+
+    host.insertBefore(note, host.firstChild);
+  }
+
+  /// The mark beside the wordmark (#540), taken from the page's own favicon.
+  ///
+  /// Not a hardcoded `favicon.svg`: mdBook 0.5 fingerprints theme assets, so the
+  /// file is served as `favicon-8856102b.svg` and the hash changes whenever the
+  /// mark does. Reading the `<link rel=icon>` mdBook already emits means the
+  /// name is never ours to keep in sync, and the path is already correct for the
+  /// page's depth.
+  ///
+  /// `alt=""` because the wordmark next to it is the accessible name. Alt text
+  /// here would make the one link read as "OMNI OMNI".
+  function markImage() {
+    var icon = document.querySelector('link[rel~="icon"][href$=".svg"]');
+    if (!icon) return null;
+    var img = document.createElement('img');
+    img.src = icon.href;
+    img.alt = '';
+    img.className = 'site-mark';
+    return img;
   }
 
   /// A `<details>` rather than a scripted dropdown.
@@ -108,24 +178,32 @@
   /// them is a line that can get the accessibility wrong. The only script here is
   /// closing it after a choice, which a plain `<details>` does not do because the
   /// link navigates away in a new tab.
-  function languageMenu() {
+  function languageMenu(root) {
+    var id = translated();
+    var manuals = { EN: id ? root + '../' : root, ID: id ? root : root + 'id/' };
+
     var details = document.createElement('details');
     details.className = 'lang-menu';
 
     var summary = document.createElement('summary');
     summary.setAttribute('aria-label', 'Choose a language');
-    summary.title = 'Read the introduction in another language';
-    summary.textContent = 'EN';
+    summary.title = 'Read this manual in another language';
+    summary.textContent = id ? 'ID' : 'EN';
     details.appendChild(summary);
 
     var list = document.createElement('div');
     list.className = 'lang-list';
     LANGS.forEach(function (l) {
       var a = document.createElement('a');
-      a.href = l.href;
+      a.href = l.manual ? manuals[l.code] : l.href;
       a.textContent = l.label;
-      a.target = '_blank';
-      a.rel = 'noopener noreferrer';
+      // Only the README links leave the site, and only those get a new tab.
+      // Opening one manual from the other in a new tab would strand the reader
+      // with two copies of the same page.
+      if (!l.manual) {
+        a.target = '_blank';
+        a.rel = 'noopener noreferrer';
+      }
       a.addEventListener('click', function () {
         details.open = false;
       });

--- a/scripts/check_translations.sh
+++ b/scripts/check_translations.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Fail when an English manual page changes and its Indonesian counterpart does
+# not (#539).
+#
+# A translation nobody is told to update is a translation that quietly starts
+# lying, and the reader has no way to tell how far behind it is. This does not
+# ask for the prose to be translated in the same commit: touching the file is
+# enough, whether that means translating the change, or adding a line saying the
+# page is behind. What it stops is the change landing with nobody having looked.
+#
+# Pages with no Indonesian counterpart are skipped, not flagged, which is what
+# keeps `develop/` deliberately untranslated rather than permanently red.
+#
+#   scripts/check_translations.sh [base-ref]
+#
+# base-ref defaults to origin/main. Compares the merge base, so a stale branch is
+# judged on what it changed rather than on what main did meanwhile.
+set -euo pipefail
+
+EN="docs/website/src"
+ID="docs/website/src-id"
+base="${1:-origin/main}"
+
+git rev-parse --verify --quiet "$base" >/dev/null || {
+  echo "check_translations: no such ref: $base" >&2
+  exit 2
+}
+
+changed="$(git diff --name-only "$base"...HEAD -- "$EN" "$ID")"
+[ -n "$changed" ] || { echo "check_translations: no manual pages changed"; exit 0; }
+
+stale=""
+while IFS= read -r file; do
+  case "$file" in "$EN"/*.md) ;; *) continue ;; esac
+  counterpart="$ID/${file#"$EN"/}"
+  [ -f "$counterpart" ] || continue
+  printf '%s\n' "$changed" | grep -qxF "$counterpart" || stale="$stale  $file -> $counterpart"$'\n'
+done <<< "$changed"
+
+if [ -n "$stale" ]; then
+  echo "check_translations: English pages changed without their Indonesian counterpart:" >&2
+  printf '%s' "$stale" >&2
+  echo >&2
+  echo "Update the page on the right, or note in it that it is behind." >&2
+  exit 1
+fi
+
+echo "check_translations: every changed page has its counterpart in this diff"

--- a/tests/docs_match_the_code.rs
+++ b/tests/docs_match_the_code.rs
@@ -26,8 +26,12 @@ fn repo_root() -> PathBuf {
 /// Every markdown file the manual and the README are made of.
 fn doc_files() -> Vec<PathBuf> {
     let root = repo_root();
-    let mut out: Vec<PathBuf> = walkdir::WalkDir::new(root.join("docs/website/src"))
-        .into_iter()
+    // Both books (#539). The prose is translated and the commands are not, so a
+    // shell fence in the Indonesian manual can name a deleted subcommand exactly
+    // as easily as the English one, and nothing else looks at those files.
+    let mut out: Vec<PathBuf> = ["docs/website/src", "docs/website/src-id"]
+        .iter()
+        .flat_map(|dir| walkdir::WalkDir::new(root.join(dir)).into_iter())
         .filter_map(Result::ok)
         .filter(|e| e.path().extension().is_some_and(|x| x == "md"))
         .map(|e| e.path().to_path_buf())


### PR DESCRIPTION
The language switcher #513 added advertised seven languages and delivered a
GitHub README in each, because the manual was English only. 27 pages plus a
`SUMMARY` are now translated and served at `/docs/id/`, and the `ID` entry
points at the manual instead of the README.

`develop/` stays English behind one Indonesian page that says why and links the
seven originals. Those pages change fastest and are read by people about to send
a patch.

No second `book.toml` and no new dependency: `docs/website/build.sh` renders the
same book twice through mdBook's environment config, then copies the result into
`book/id` so the site keeps copying one tree. The header mark (#540) is read
from the `<link rel=icon>` mdBook already emits, since mdBook 0.5 fingerprints
theme assets and a hardcoded `favicon.svg` would 404.

Drift is the risk, so the check has teeth three ways:

```
$ scripts/check_translations.sh HEAD~1          # English page touched alone
check_translations: English pages changed without their Indonesian counterpart:
  docs/website/src/concepts/the-ledger.md -> docs/website/src-id/concepts/the-ledger.md
rc=1
$ scripts/check_translations.sh HEAD~2          # both touched
check_translations: every changed page has its counterpart in this diff
rc=0
$ scripts/check_translations.sh HEAD~1          # develop/, no counterpart
check_translations: every changed page has its counterpart in this diff
rc=0
```

`tests/docs_match_the_code.rs` now scans both books. Breaking one Indonesian
fence proves it reaches them:

```
  docs/website/src-id/use/install.md:122  omni bogus
test result: FAILED. 3 passed; 1 failed
```

Rendered end to end through the site's own build script against this branch:

```
docs: 38 English pages, 32 Indonesian pages
docs: 70 pages rendered into public/docs from docs/id-manual
```

The matching change in the site is weekndlabs/omni-pages#34, and it falls back
to an English-only render for a `DOCS_REF` older than `build.sh`, so the two can
merge in either order.

Two things found while doing this and filed rather than fixed here: #541 (three
sentences say the MCP server has 26 tools, `tools/list` says 25) and
weekndlabs/omni-pages#35 (the site build overwrites `head.hbs`, so the share
card from #527 has never shipped).

Closes #539
Closes #540

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds an Indonesian mdBook manual and renders it beside the English manual while preserving a single deployable output tree.
- Adds translated manual pages and navigation under `src-id`.
- Builds both languages and places the Indonesian output at `/docs/id/`.
- Adds translation-drift CI and expands documentation command checks to both books.
- Adds the project mark to the rendered manual header.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/website/build.sh | Builds both manuals, refreshes generated shared assets and overlays, and nests the Indonesian output beneath the English book. |
| scripts/check_translations.sh | Enforces paired English and Indonesian manual updates while excluding pages without translated counterparts. |
| .github/workflows/ci.yml | Adds a pull-request-only translation consistency job with full history available for merge-base comparison. |
| tests/docs_match_the_code.rs | Extends documentation command validation across both language source trees. |
| docs/website/theme/siteframe.js | Adds language-aware manual framing and uses mdBook’s emitted favicon asset for the header mark. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[English source] --> B[mdBook English build]
    C[Indonesian source] --> D[mdBook Indonesian build]
    E[Shared media and optional overlay] --> C
    B --> F[book]
    D --> G[book-id]
    G --> H[book/id]
    F --> I[Single deployable documentation tree]
    H --> I
```
</details>

<sub>Reviews (2): Last reviewed commit: ["build(docs): clear the Indonesian overla..."](https://github.com/fajarhide/omni/commit/7787b974016dd6dfe63f458b7f7ad437026c3d73) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53208137)</sub>

<!-- /greptile_comment -->