### PR TITLE
fix(docs): the MCP tool count reads 25, and the guard reaches the files that state it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   The reporter's `git --version` case is not explained by any of these: it writes about 25 bytes to stdout and nothing to stderr. That half of the report is still open.
 
+- **The MCP tool count read 26 in six places and the guard could not see one of them (#541)**: `tools/list` answers 25 on 0.7.4. `CONTRIBUTING.md` said `26 tools`, and both books repeated it in the one paragraph whose whole point is to count rather than trust a written number.
+
+  `every_documented_count_matches_the_code` was already checking counts and passed on all six, for two reasons that are about reach and not about the number. `doc_files()` walks the two books and `README.md`, so `CONTRIBUTING.md` was the only prose file with a count in it that nothing read. And the claim pattern matches the English noun, so every count in the Indonesian manual went unchecked, including the two that were right.
+
+  The self-contradicting sentences now name the command instead of a number, in both languages, so there is nothing left there to drift. The counts a reader wants up front stay, and all of them are inside the guard now: `CONTRIBUTING.md` is scanned, and the pattern reads `perkakas` as well as `tools`.
+
 ## [0.7.4] - 2026-08-13
 
 A release about claims that were not true: a documented escape hatch that did

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ src/
 ├── guard/           safety, limits, trust bounds, env hygiene
 ├── hooks/           entry points and the dispatcher
 ├── ledger/          cross-turn line dedup
-├── mcp/             MCP server, 26 tools
+├── mcp/             MCP server, 25 tools
 ├── pipeline/        scorer, collapse, registry, format gate
 ├── session/         tracking, noise detection
 ├── store/           SQLite and transcripts

--- a/docs/website/src-id/integrations/hermes.md
+++ b/docs/website/src-id/integrations/hermes.md
@@ -5,7 +5,7 @@ OMNI menancap ke Hermes dua kali: sebuah plugin di jalur hook, dan server MCP.
 | lapisan | mekanisme | apa yang berubah |
 |---|---|---|
 | hook | `~/.hermes/plugins/omni-signal-engine/__init__.py` yang memanggil `omni --pre-hook`, `--post-hook`, `--session-start` | keluaran tool terminal disuling sebelum masuk ke konteks Hermes |
-| MCP | `mcp_servers.omni` yang menjalankan `omni --mcp` | 26 perkakas OMNI menjadi perkakas kelas satu di Hermes |
+| MCP | `mcp_servers.omni` yang menjalankan `omni --mcp` | perkakas MCP OMNI menjadi perkakas kelas satu di Hermes |
 
 ## Prasyarat
 
@@ -92,8 +92,8 @@ tool-nya dengan keluaran npm mentah. Pastikan dengan `omni stats`.
 
 > Hitung perkakasnya, jangan percaya angka yang tertulis. Versi sebelumnya dari
 > panduan ini menyebut 27, yang datang dari mem-`grep` kode sumber server; salah
-> satu string itu nama penyaring, bukan perkakas. `tools/list` milik server
-> sendiri menjawab 26.
+> satu string itu nama penyaring, bukan perkakas. `hermes tools list` di atas
+> yang menjadi hitungannya.
 
 ## Di mana OMNI membantu dan di mana tidak
 

--- a/docs/website/src-id/reference/mcp-tools.md
+++ b/docs/website/src-id/reference/mcp-tools.md
@@ -1,7 +1,7 @@
 # Perkakas MCP
 
-`omni init` mendaftarkan OMNI sebagai server MCP, yang memberi agent **25
-perkakas** yang bisa ia panggil sendiri tanpa lewat Anda.
+`omni init` mendaftarkan OMNI sebagai server MCP, yang memberi agent
+**25 perkakas** yang bisa ia panggil sendiri tanpa lewat Anda.
 
 Pastikan daftarnya terhadap binary Anda sendiri, bukan terhadap halaman ini:
 
@@ -91,5 +91,5 @@ Lihat [Loop engineering](../integrations/loops.md).
 Memanggilnya mengembalikan `-32602 tool not found`.
 
 Ia pernah salah hitung: `grep` atas kode sumber untuk `"omni_*"` mengembalikan
-27, jadi 27 salah di mana pun ia muncul. `tools/list` milik server sendiri
-menyebut 26.
+27, jadi 27 salah di mana pun ia muncul. Jalankan panggilan `tools/list` di atas
+untuk hitungannya.

--- a/docs/website/src/integrations/hermes.md
+++ b/docs/website/src/integrations/hermes.md
@@ -5,7 +5,7 @@ OMNI plugs into Hermes twice: a plugin on the hook path, and the MCP server.
 | layer | mechanism | what changes |
 |---|---|---|
 | hooks | `~/.hermes/plugins/omni-signal-engine/__init__.py` calling `omni --pre-hook`, `--post-hook`, `--session-start` | terminal tool output is distilled before it enters Hermes' context |
-| MCP | `mcp_servers.omni` running `omni --mcp` | the 26 OMNI tools become first-class Hermes tools |
+| MCP | `mcp_servers.omni` running `omni --mcp` | OMNI's MCP tools become first-class Hermes tools |
 
 ## Prerequisites
 
@@ -89,7 +89,7 @@ npm output. Confirm with `omni stats`.
 
 > Count the tools rather than trusting a number written down. Earlier versions of this
 > guide said 27, which came from grepping the server source; one of those strings is a
-> filter name, not a tool. The server's own `tools/list` answers 26.
+> filter name, not a tool. The `hermes tools list` above is the count.
 
 ## Where OMNI helps and where it does not
 

--- a/docs/website/src/reference/mcp-tools.md
+++ b/docs/website/src/reference/mcp-tools.md
@@ -89,4 +89,4 @@ See [Loop engineering](../integrations/loops.md).
 a filter name passed to the TOML generator. Calling it returns `-32602 tool not found`.
 
 It has been miscounted before: a source grep for `"omni_*"` returns 27, and 27 is
-therefore wrong wherever it appears. The server's own `tools/list` says 26.
+therefore wrong wherever it appears. Run the `tools/list` call above for the count.

--- a/tests/docs_match_the_code.rs
+++ b/tests/docs_match_the_code.rs
@@ -23,7 +23,7 @@ fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 }
 
-/// Every markdown file the manual and the README are made of.
+/// Every markdown file the manual, the README and CONTRIBUTING are made of.
 fn doc_files() -> Vec<PathBuf> {
     let root = repo_root();
     // Both books (#539). The prose is translated and the commands are not, so a
@@ -37,6 +37,10 @@ fn doc_files() -> Vec<PathBuf> {
         .map(|e| e.path().to_path_buf())
         .collect();
     out.push(root.join("README.md"));
+    // CONTRIBUTING.md was the one prose file with a count in it that nothing
+    // read, and it held `26 tools` for two releases after the number became 25
+    // (#541). It is not part of either book, so the walk above never sees it.
+    out.push(root.join("CONTRIBUTING.md"));
     out.sort();
     out
 }
@@ -151,7 +155,13 @@ fn every_documented_count_matches_the_code() {
 
     // (regex, what the number has to equal, what it is counting)
     let claims = [
-        (r"(\d+)\s+(?:MCP\s+)?tools", tools.len(), "MCP tools"),
+        // `perkakas` because the Indonesian book states the same counts and the
+        // English noun never appears in it, so every count in it was unchecked.
+        (
+            r"(\d+)\s+(?:MCP\s+)?(?:tools|perkakas)",
+            tools.len(),
+            "MCP tools",
+        ),
         (r"(\d+)\s+content filters", distillers, "distillers"),
     ];
 
@@ -240,6 +250,10 @@ fn the_scan_reaches_the_manual_and_the_readme() {
     assert!(
         files.iter().any(|p| p.ends_with("README.md")),
         "the README is not being scanned"
+    );
+    assert!(
+        files.iter().any(|p| p.ends_with("CONTRIBUTING.md")),
+        "CONTRIBUTING is not being scanned"
     );
     assert!(
         commands_in_shell_blocks().len() > 10,


### PR DESCRIPTION
`tools/list` answers 25 on 0.7.4. Six lines said 26: `CONTRIBUTING.md:98`, and
both books repeating it in the one paragraph that tells the reader to count
rather than trust a written number.

`every_documented_count_matches_the_code` already exists for this and passed on
all six, for two reasons that are about reach and not about the number.
`doc_files()` walks the two books and `README.md`, so `CONTRIBUTING.md` was the
only prose file with a count in it that nothing read. And the claim pattern
matches the English noun, so every count in the Indonesian manual went
unchecked, including the two that were right.

The self-contradicting sentences now name the command instead of a number, in
both languages. The counts a reader wants up front stay, and all of them are
inside the guard now.

Proved the guard has teeth by putting both 26s back:

```
the manual states counts the code disagrees with.
  CONTRIBUTING.md:98  says 26 MCP tools, the code has 25
  docs/website/src-id/integrations/hermes.md:79  says 26 MCP tools, the code has 25
test result: FAILED. 3 passed; 1 failed
```

`make ci` green, 44/44 smoke.

Closes #541

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR corrects stale MCP tool-count documentation and expands the documentation consistency guard to cover CONTRIBUTING.md and Indonesian count claims.
- Replaces stale numeric claims with commands that report the current tool list.
- Updates the remaining documented MCP count from 26 to 25.
- Extends documentation tests to scan CONTRIBUTING.md and recognize the Indonesian noun “perkakas.”
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tests/docs_match_the_code.rs | Extends documentation discovery and count matching so CONTRIBUTING.md and Indonesian MCP tool claims are checked. |
| CONTRIBUTING.md | Corrects the project-layout MCP tool count from 26 to 25. |
| docs/website/src/integrations/hermes.md | Removes stale hard-coded tool counts from the English Hermes guide and directs readers to the live listing. |
| docs/website/src-id/integrations/hermes.md | Applies the equivalent stale-count correction to the Indonesian Hermes guide. |
| docs/website/src/reference/mcp-tools.md | Replaces the stale English tools/list count with instructions to obtain the count from the server. |
| docs/website/src-id/reference/mcp-tools.md | Applies the equivalent live-count guidance to the Indonesian MCP reference. |
| CHANGELOG.md | Documents the corrected count and the expanded reach of the consistency guard. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(docs): the MCP tool count reads 25, ..."](https://github.com/fajarhide/omni/commit/ef9757106dca55d3df30c4a259f9f55e6b655fb5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53296287)</sub>

<!-- /greptile_comment -->