### PR TITLE
docs: name the install URL that has a directory page, in every README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   **The decision the rows are for is deliberately not taken here.** Whether the project scope stays shared or becomes `(repo, agent)` is a choice between two unmeasured options until the corpus has run, and choosing early is what this project keeps refusing to do. Deletion ships in the same commit as the schema, pruned in the same window as the lines it describes, because `passthrough_events` shipped with no cleanup and grew unbounded.
 
+### Changed
+- **The skill's install line names `fajarhide/skills` (#547)**: one skill answered to two URLs. `npx skills add fajarhide/omni` is what the README and both manuals printed, `npx skills add fajarhide/skills --skill omni` is what the directory page prints. Both pull the same file, since `fajarhide/skills/skills/omni/SKILL.md` is synced daily from `plugins/claude-code/skills/omni/SKILL.md`, so the two could only ever disagree on which URL a reader learned.
+
+  The one now documented is the one with a page behind it. `https://www.skills.sh/fajarhide/omni` answers 200 and renders a 404 body with no `<title>`; `https://www.skills.sh/fajarhide/skills/omni` is a real listing, and the four files now link it. `fajarhide/omni` still installs and is simply no longer advertised. The short form was run into an empty directory before it was published: `rc=0`, `Installed 1 skill`.
+
+  **Six of the seven READMEs documented neither install path.** `ja`, `zh`, `ko`, `vi` and `ar` carried no plugin and no skills block, and `id` carried the skills block without the plugin one, so the block English readers have had since #546 reached nobody else. All six now carry both, in their own language.
+
 ### Fixed
 - **`omni_run` could hang until the host gave up (#544)**: reported on Windows in Cursor, where some Git commands returned `MCP error -32001: Request timed out` after 120 seconds while the same command took 397 ms in PowerShell. Three separate defects in one spawn, none of them Windows-only.
 

--- a/README.md
+++ b/README.md
@@ -183,9 +183,10 @@ irm omni.weekndlabs.com/install.ps1 | iex
 /plugin install omni@omni
 ```
 
-**Any agent that reads skills:**
+**Any agent that reads skills**, listed at
+[skills.sh/fajarhide/skills/omni](https://www.skills.sh/fajarhide/skills/omni):
 ```bash
-npx skills add fajarhide/omni
+npx skills add fajarhide/skills --skill omni
 ```
 
 Both install a skill, not the binary. The skill is what tells the agent how to get

--- a/docs/website/src-id/use/install.md
+++ b/docs/website/src-id/use/install.md
@@ -36,10 +36,11 @@ cargo build --release
 ```
 
 **Di agent mana pun yang membaca skill**, skill yang sama bisa dipasang lewat CLI
-direktori skill:
+direktori skill, dan terdaftar di
+[skills.sh/fajarhide/skills/omni](https://www.skills.sh/fajarhide/skills/omni):
 
 ```sh
-npx skills add fajarhide/omni
+npx skills add fajarhide/skills --skill omni
 ```
 
 Lewat jalur mana pun, yang terpasang adalah sebuah skill, bukan binary-nya. Skill

--- a/docs/website/src/use/install.md
+++ b/docs/website/src/use/install.md
@@ -36,10 +36,11 @@ cargo build --release
 ```
 
 **On any agent that reads skills**, the same skill installs through the skills
-directory CLI:
+directory CLI, and is listed at
+[skills.sh/fajarhide/skills/omni](https://www.skills.sh/fajarhide/skills/omni):
 
 ```sh
-npx skills add fajarhide/omni
+npx skills add fajarhide/skills --skill omni
 ```
 
 Either way that installs a skill, not the binary. The skill carries the install

--- a/i18n/README-ar.md
+++ b/i18n/README-ar.md
@@ -214,6 +214,25 @@ curl -fsSL omni.weekndlabs.com/install | bash
 irm omni.weekndlabs.com/install.ps1 | iex
 ```
 
+**Claude Code، من داخل الجلسة:**
+```
+/plugin marketplace add fajarhide/omni
+/plugin install omni@omni
+```
+
+**أي وكيل يقرأ المهارات**، ومُدرَجة على
+[skills.sh/fajarhide/skills/omni](https://www.skills.sh/fajarhide/skills/omni):
+```bash
+npx skills add fajarhide/skills --skill omni
+```
+
+<div dir="rtl">
+
+كلتا الطريقتين تثبّت مهارة، لا الملف التنفيذي. المهارة هي ما يخبر الوكيل بكيفية جلب
+الملف التنفيذي، والتحقق منه، وقراءة العلامات التي يتركها OMNI عندما يختصر المخرجات.
+
+</div>
+
 ---
 
 ---

--- a/i18n/README-id.md
+++ b/i18n/README-id.md
@@ -185,9 +185,16 @@ omni init --status
 curl -fsSL omni.weekndlabs.com/install | bash
 ```
 
-**Di agent mana pun yang membaca skill:**
+**Claude Code, dari dalam sesi:**
+```
+/plugin marketplace add fajarhide/omni
+/plugin install omni@omni
+```
+
+**Di agent mana pun yang membaca skill**, terdaftar di
+[skills.sh/fajarhide/skills/omni](https://www.skills.sh/fajarhide/skills/omni):
 ```bash
-npx skills add fajarhide/omni
+npx skills add fajarhide/skills --skill omni
 ```
 Yang terpasang skill-nya, bukan binary-nya. Skill itu yang memberi tahu agent cara
 mengambil binary-nya, memverifikasinya, dan membaca penanda yang ditinggalkan OMNI

--- a/i18n/README-ja.md
+++ b/i18n/README-ja.md
@@ -187,6 +187,21 @@ curl -fsSL omni.weekndlabs.com/install | bash
 irm omni.weekndlabs.com/install.ps1 | iex
 ```
 
+**Claude Code のセッション内から:**
+```
+/plugin marketplace add fajarhide/omni
+/plugin install omni@omni
+```
+
+**スキルを読むエージェントなら何でも** ([skills.sh/fajarhide/skills/omni](https://www.skills.sh/fajarhide/skills/omni) に掲載):
+```bash
+npx skills add fajarhide/skills --skill omni
+```
+
+どちらもインストールされるのはスキルであってバイナリではありません。スキルは、バイナリの
+入手方法、その検証方法、そして OMNI が出力を短くしたときに残すマーカーの読み方を
+エージェントに伝えます。
+
 ---
 
 ---

--- a/i18n/README-ko.md
+++ b/i18n/README-ko.md
@@ -187,6 +187,21 @@ curl -fsSL omni.weekndlabs.com/install | bash
 irm omni.weekndlabs.com/install.ps1 | iex
 ```
 
+**Claude Code 세션 안에서:**
+```
+/plugin marketplace add fajarhide/omni
+/plugin install omni@omni
+```
+
+**스킬을 읽는 모든 에이전트**, [skills.sh/fajarhide/skills/omni](https://www.skills.sh/fajarhide/skills/omni) 에 등록되어 있습니다:
+```bash
+npx skills add fajarhide/skills --skill omni
+```
+
+둘 다 설치되는 것은 바이너리가 아니라 스킬입니다. 그 스킬이 바이너리를 받는 방법,
+검증하는 방법, 그리고 OMNI가 출력을 줄일 때 남기는 표시를 읽는 방법을 에이전트에게
+알려 줍니다.
+
 ---
 
 ---

--- a/i18n/README-vi.md
+++ b/i18n/README-vi.md
@@ -190,6 +190,21 @@ curl -fsSL omni.weekndlabs.com/install | bash
 irm omni.weekndlabs.com/install.ps1 | iex
 ```
 
+**Từ trong phiên Claude Code:**
+```
+/plugin marketplace add fajarhide/omni
+/plugin install omni@omni
+```
+
+**Trên bất kỳ agent nào đọc được skill**, đã có trên
+[skills.sh/fajarhide/skills/omni](https://www.skills.sh/fajarhide/skills/omni):
+```bash
+npx skills add fajarhide/skills --skill omni
+```
+
+Cả hai cách đều cài một skill, không phải binary. Skill đó là thứ cho agent biết cách
+lấy binary, cách kiểm chứng nó, và cách đọc các dấu OMNI để lại khi nó rút gọn đầu ra.
+
 ---
 
 ---

--- a/i18n/README-zh.md
+++ b/i18n/README-zh.md
@@ -177,6 +177,20 @@ curl -fsSL omni.weekndlabs.com/install | bash
 irm omni.weekndlabs.com/install.ps1 | iex
 ```
 
+**在 Claude Code 会话内:**
+```
+/plugin marketplace add fajarhide/omni
+/plugin install omni@omni
+```
+
+**任何会读取 skill 的 agent**，已收录于 [skills.sh/fajarhide/skills/omni](https://www.skills.sh/fajarhide/skills/omni)：
+```bash
+npx skills add fajarhide/skills --skill omni
+```
+
+两种方式装的都是 skill，不是二进制文件。skill 负责告诉 agent 怎么获取二进制文件、怎么
+验证它，以及怎么读 OMNI 缩短输出时留下的标记。
+
 ---
 
 ---


### PR DESCRIPTION
`npx skills add fajarhide/omni` and `npx skills add fajarhide/skills --skill omni`
install the same bytes: `fajarhide/skills/skills/omni/SKILL.md` is synced daily from
`plugins/claude-code/skills/omni/SKILL.md`. They can only differ in which URL a reader
learns, and only one of them leads to a page.

```
$ curl -sL -o pg.html -w '%{http_code}\n' https://www.skills.sh/fajarhide/omni
200
$ grep -c '<title>' pg.html
0
$ grep -o '404' pg.html | head -1
404
```

`https://www.skills.sh/fajarhide/skills/omni` is a real listing with a title. So the
four files that printed the first URL now print the second and link the page.
`fajarhide/omni` still installs and is simply no longer advertised.

The short form was run before it was published, since the directory page itself prints
the long `https://github.com/fajarhide/skills` form:

```
$ cd "$(mktemp -d)" && npx -y skills@latest add fajarhide/skills --skill omni
✓ ./.agents/skills/omni
  universal: Amp, Antigravity, Codex, Cursor, Gemini CLI +12 more
```

Six of the seven READMEs documented neither install path. `ja`, `zh`, `ko`, `vi` and
`ar` carried no plugin and no skills block at all, and `id` carried the skills block
without the plugin one, so what English readers got in #546 reached nobody else. All
six now carry both, in their own language.

```
$ cargo test --test docs_match_the_code
test result: ok. 4 passed; 0 failed; 0 ignored
```

No Rust changed. `CHANGELOG.md` will conflict with #548 and with the #544 branch, which
all append under `## [Unreleased]`; the resolution is keep both sides.

Closes #547

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR standardizes the documented skills installation path on the directory-backed `fajarhide/skills` listing and extends the plugin and skills instructions across translated READMEs.
- Replaces `npx skills add fajarhide/omni` with `npx skills add fajarhide/skills --skill omni`.
- Links the corresponding skills.sh directory page from the primary README and both manuals.
- Adds localized Claude Code plugin and skills installation blocks to six translated READMEs.
- Records the documentation update in the changelog.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Updates the skills installation command and links the valid directory listing. |
| docs/website/src/use/install.md | Applies the same install-command and directory-link update to the English manual. |
| docs/website/src-id/use/install.md | Applies the same install-command and directory-link update to the Indonesian manual. |
| i18n/README-ar.md | Adds localized Claude Code plugin and skills installation instructions. |
| i18n/README-id.md | Adds the missing plugin instructions and updates the existing skills installation path. |
| i18n/README-ja.md | Adds localized Claude Code plugin and skills installation instructions. |
| i18n/README-ko.md | Adds localized Claude Code plugin and skills installation instructions. |
| i18n/README-vi.md | Adds localized Claude Code plugin and skills installation instructions. |
| i18n/README-zh.md | Adds localized Claude Code plugin and skills installation instructions. |
| CHANGELOG.md | Documents the standardized installation URL and expanded translated guidance. |

</details>

<sub>Reviews (2): Last reviewed commit: ["docs: name the install URL that has a di..."](https://github.com/fajarhide/omni/commit/3150c5eebcd268f78d610a865ff1db2601d2ce04) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53296509)</sub>

<!-- /greptile_comment -->