### PR TITLE
fix(mcp): bound omni_run, and stop it deadlocking on stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   **The decision the rows are for is deliberately not taken here.** Whether the project scope stays shared or becomes `(repo, agent)` is a choice between two unmeasured options until the corpus has run, and choosing early is what this project keeps refusing to do. Deletion ships in the same commit as the schema, pruned in the same window as the lines it describes, because `passthrough_events` shipped with no cleanup and grew unbounded.
 
+### Fixed
+- **`omni_run` could hang until the host gave up (#544)**: reported on Windows in Cursor, where some Git commands returned `MCP error -32001: Request timed out` after 120 seconds while the same command took 397 ms in PowerShell. Three separate defects in one spawn, none of them Windows-only.
+
+  **stdout was drained to EOF and only then stderr.** A child that fills the stderr pipe buffer before closing stdout blocks forever, and the reader blocks with it. Reproduced on macOS with 200 KB of stderr; the buffer is 64 KB there and around 4 KB on Windows, which is why it was reported there first. `wait_with_output` drains both at once, which also deletes the hand-rolled read. `omni exec` never had this because it inherits stderr rather than piping it.
+
+  **The child inherited the server's stdin, which is the JSON-RPC pipe to the host.** One byte read from it breaks the framing for the rest of the session, so every later call fails no matter what it asks for. The child gets `Stdio::null()`.
+
+  **Nothing bounded the child, and the blocking call ran on a runtime worker.** One hung command took the thread that was serving everything else, which is the shape of a report where three calls succeed and everything after them times out. There is a 60 s deadline now, `OMNI_RUN_TIMEOUT_SECS` raises it for a build that legitimately outlasts it, and the work moved to `spawn_blocking`. A timeout returns a sentence naming the command that stalled rather than the host's opaque error code.
+
+  The reporter's `git --version` case is not explained by any of these: it writes about 25 bytes to stdout and nothing to stderr. That half of the report is still open.
+
 ## [0.7.4] - 2026-08-13
 
 A release about claims that were not true: a documented escape hatch that did

--- a/docs/website/src-id/reference/environment.md
+++ b/docs/website/src-id/reference/environment.md
@@ -37,6 +37,18 @@ penulisan berbaris antre, yang biasanya jadi alasan `omni exec` tampak
 menggantung. Ia juga wajib ketika menjalankan test suite terhadap pemasangan yang
 hidup.
 
+## Perintah yang dijalankan lewat server MCP
+
+| variabel | efeknya |
+|---|---|
+| `OMNI_RUN_TIMEOUT_SECS` | Berapa lama `omni_run` menunggu sebuah perintah. Bawaannya 60. |
+
+Bawaannya ada di bawah semua batas waktu MCP host yang kami tahu, jadi perintah yang
+macet kembali sebagai satu kalimat yang menyebut dirinya sendiri, bukan galat idle
+timeout milik host. Naikkan kalau sebuah build memang butuh lebih lama, dan ingat host
+punya batasnya sendiri: milik Cursor 120 detik, dan tidak ada yang bisa OMNI lakukan
+untuk memperpanjangnya.
+
 ## Retensi
 
 | variabel | efeknya |

--- a/docs/website/src/reference/environment.md
+++ b/docs/website/src/reference/environment.md
@@ -34,6 +34,17 @@ scorer, and a shared warm database serialises writes, which is the usual reason
 `omni exec` looks like it has hung. It is also required when running the test suite
 against a live installation.
 
+## Commands run through the MCP server
+
+| variable | effect |
+|---|---|
+| `OMNI_RUN_TIMEOUT_SECS` | How long `omni_run` waits for a command. Default 60. |
+
+The default sits below every host MCP timeout we know of, so a stalled command comes
+back as a sentence naming itself rather than the host's idle-timeout error. Raise it
+when a build legitimately takes longer, and remember the host has a deadline of its own:
+Cursor's is 120 seconds, and nothing OMNI does can extend it.
+
 ## Retention
 
 | variable | effect |

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1576,12 +1576,7 @@ mod tests {
         let dir = tempdir().unwrap();
         let store = Arc::new(Store::open_path(&dir.path().join("omni.db")).unwrap());
 
-        let out = run_with_timeout(
-            "sleep 30",
-            store,
-            None,
-            std::time::Duration::from_secs(1),
-        );
+        let out = run_with_timeout("sleep 30", store, None, std::time::Duration::from_secs(1));
 
         assert!(
             out.contains("did not finish within 1s") && out.contains("sleep 30"),

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -17,6 +17,22 @@ use std::sync::{Arc, Mutex};
 /// emits; anything below this is that command's content (#266).
 const MIN_COMMANDS_FOR_NOISE: usize = 2;
 
+/// How long `omni_run` waits for a command before abandoning it.
+///
+/// Below every host MCP timeout we know of (Cursor's is 120s) so the model reads
+/// which command stalled instead of an opaque `-32001` (#544). Overridable
+/// because a real build can outlast it and there is no other escape hatch.
+const RUN_TIMEOUT_SECS: u64 = 60;
+
+fn run_timeout() -> std::time::Duration {
+    let secs = std::env::var("OMNI_RUN_TIMEOUT_SECS")
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .filter(|s| *s > 0)
+        .unwrap_or(RUN_TIMEOUT_SECS);
+    std::time::Duration::from_secs(secs)
+}
+
 /// Runs `command` and returns what the model should read: the distilled output
 /// on success, the raw output on failure.
 ///
@@ -33,7 +49,19 @@ pub(crate) fn run_and_distill(
     store: Arc<Store>,
     session: Option<Arc<Mutex<SessionState>>>,
 ) -> String {
-    use std::io::Read;
+    run_with_timeout(command, store, session, run_timeout())
+}
+
+/// The body of `run_and_distill`, with the deadline passed in so a test can
+/// drive it without setting `OMNI_RUN_TIMEOUT_SECS` on the whole process. Cargo
+/// runs tests in parallel, and an env var one test writes is an env var every
+/// other test reads.
+fn run_with_timeout(
+    command: &str,
+    store: Arc<Store>,
+    session: Option<Arc<Mutex<SessionState>>>,
+    timeout: std::time::Duration,
+) -> String {
     use std::process::{Command, Stdio};
 
     #[cfg(target_family = "windows")]
@@ -46,31 +74,49 @@ pub(crate) fn run_and_distill(
         .arg(command)
         .env_clear()
         .envs(crate::guard::env::sanitize_env())
+        // The server's stdin is the JSON-RPC pipe to the host. A child that reads
+        // a byte of it breaks the framing for the rest of the session, so it gets
+        // EOF instead of the transport.
+        .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn();
 
-    let mut child = match spawned {
+    let child = match spawned {
         Ok(c) => c,
         Err(e) => return format!("omni_run: failed to start `{command}`: {e}"),
     };
 
-    let mut raw = Vec::new();
-    if let Some(mut out) = child.stdout.take() {
-        let _ = out.read_to_end(&mut raw);
-    }
-    let mut errbuf = Vec::new();
-    if let Some(mut err) = child.stderr.take() {
-        let _ = err.read_to_end(&mut errbuf);
-    }
-    let status = child.wait();
+    // `wait_with_output` drains both pipes at once. Draining stdout to EOF and
+    // only then stderr deadlocks on any child that fills the stderr pipe buffer
+    // before closing stdout: 64 KB on macOS, around 4 KB on Windows (#544).
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = tx.send(child.wait_with_output());
+    });
 
+    let output = match rx.recv_timeout(timeout) {
+        Ok(Ok(o)) => o,
+        Ok(Err(e)) => return format!("omni_run: `{command}` could not be waited on: {e}"),
+        // ponytail: the reader thread owns the child, so a timed-out command is
+        // abandoned rather than killed. The case that gets us here is a
+        // grandchild holding the pipe open, which killing the shell would not
+        // reach anyway. Revisit if orphaned shells show up in the wild.
+        Err(_) => {
+            return format!(
+                "omni_run: `{command}` did not finish within {}s and was abandoned. \
+                 Run it outside OMNI, or set OMNI_RUN_TIMEOUT_SECS higher.",
+                timeout.as_secs()
+            );
+        }
+    };
+
+    let raw = output.stdout;
     let raw_text = String::from_utf8_lossy(&raw).to_string();
-    let err_text = String::from_utf8_lossy(&errbuf).to_string();
+    let err_text = String::from_utf8_lossy(&output.stderr).to_string();
 
-    let succeeded = matches!(&status, Ok(s) if s.success());
-    if !succeeded {
-        let code = status.as_ref().ok().and_then(|s| s.code()).unwrap_or(-1);
+    if !output.status.success() {
+        let code = output.status.code().unwrap_or(-1);
         return format!("{raw_text}{err_text}\n[exit {code}]");
     }
 
@@ -872,11 +918,15 @@ impl OmniServer {
         description = "Run a shell command and return its distilled output. Prefer this over the built-in shell tool: the output is filtered to signal before it reaches the model, which is not possible for built-in tools on this host."
     )]
     pub async fn omni_run(&self, params: Parameters<OmniRunParams>) -> String {
-        run_and_distill(
-            &params.0.command,
-            self.store.clone(),
-            Some(self.session.clone()),
-        )
+        let command = params.0.command;
+        let store = self.store.clone();
+        let session = Some(self.session.clone());
+        // Running a command blocks for as long as the command takes. On a runtime
+        // worker that stalls whatever else the server was serving, which is how
+        // one hung command turned into every later call timing out (#544).
+        tokio::task::spawn_blocking(move || run_and_distill(&command, store, session))
+            .await
+            .unwrap_or_else(|e| format!("omni_run: could not run the command: {e}"))
     }
 
     #[tool(
@@ -1484,6 +1534,58 @@ mod tests {
         assert!(
             out.contains("[exit 7]"),
             "and must carry its exit code:\n{out}"
+        );
+    }
+
+    /// #544: stdout was drained to EOF and only then stderr, so a child that
+    /// filled the stderr pipe buffer before closing stdout blocked forever. The
+    /// buffer is 64 KB here and around 4 KB on Windows, which is why it surfaced
+    /// there first, as a 120s MCP idle timeout with no clue which command hung.
+    ///
+    /// The call is fenced off in a thread so the regression fails this test
+    /// rather than hanging the suite.
+    #[cfg(unix)]
+    #[test]
+    fn omni_run_survives_a_command_that_floods_stderr() {
+        let dir = tempdir().unwrap();
+        let store = Arc::new(Store::open_path(&dir.path().join("omni.db")).unwrap());
+
+        // 200 KB of stderr, past any pipe buffer, with stdout written only after.
+        let cmd = "yes ERRLINE | head -c 200000 1>&2; echo done-stdout";
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = tx.send(run_and_distill(cmd, store, None));
+        });
+        let out = rx
+            .recv_timeout(std::time::Duration::from_secs(20))
+            .expect("run_and_distill deadlocked: it drained stderr after stdout");
+
+        assert!(out.contains("done-stdout"), "stdout must survive:\n{out}");
+        assert!(
+            out.contains("ERRLINE"),
+            "and stderr must reach the model too"
+        );
+    }
+
+    /// A command that never finishes must come back as a sentence naming itself,
+    /// not as the host's opaque idle timeout (#544).
+    #[cfg(unix)]
+    #[test]
+    fn omni_run_gives_up_on_a_command_that_never_finishes() {
+        let dir = tempdir().unwrap();
+        let store = Arc::new(Store::open_path(&dir.path().join("omni.db")).unwrap());
+
+        let out = run_with_timeout(
+            "sleep 30",
+            store,
+            None,
+            std::time::Duration::from_secs(1),
+        );
+
+        assert!(
+            out.contains("did not finish within 1s") && out.contains("sleep 30"),
+            "a timeout must name the command that stalled:\n{out}"
         );
     }
 


### PR DESCRIPTION
Reported on Windows in Cursor: some Git commands sat until Cursor's 120s MCP timeout while the same command took 397 ms natively. Three defects in `run_and_distill`'s spawn, none of them Windows-only, all of which present as the same opaque `-32001`.

**stdout was drained to EOF and only then stderr.** A child that fills the stderr pipe buffer before closing stdout blocks, and the reader blocks with it. The buffer is 64 KB on macOS and around 4 KB on Windows, which is why it was reported there first. `wait_with_output` drains both and deletes the hand-rolled read. `omni exec` never had this because it inherits stderr rather than piping it, which is consistent with the reporter's passthrough run completing while emitting a Git warning.

**The child inherited the server's stdin, which is the JSON-RPC pipe to the host.** One byte read from it breaks the framing for the rest of the session. `Stdio::null()` now.

**Nothing bounded the child, and the blocking call ran on a runtime worker.** One hung command took the thread serving everything else, which is the shape of a report where three calls succeed and everything after them times out. 60s deadline, `OMNI_RUN_TIMEOUT_SECS` to raise it, work moved to `spawn_blocking`, and a timeout returns a sentence naming the command instead of the host's error code.

**Not fixed:** the reporter's `git --version` case. It writes about 25 bytes to stdout and nothing to stderr, so none of the above explains it. #544 stays open on that half.

## Verified

Both new tests proved able to fail. Restoring the sequential drain:

```
test mcp::server::tests::omni_run_survives_a_command_that_floods_stderr ... FAILED
panicked at src/mcp/server.rs:1576:14:
run_and_distill deadlocked: it drained stderr after stdout: Timeout
test result: FAILED. 3 passed; 1 failed
```

Restored, then the full gate on macOS, rustc 1.97.0:

```
cargo fmt --check          rc=0
cargo clippy --all-targets -- -D warnings   rc=0
cargo test                 rc=0, 0 failed
make security              rc=0
make binary-check          rc=0, smoke 44/44
```

The timeout test drives a `run_with_timeout` that takes the deadline as an argument rather than setting `OMNI_RUN_TIMEOUT_SECS` on the process: cargo runs tests in parallel and an env var one test writes is an env var every other test reads.

Refs #544. Deliberately not `Closes`: the `git --version` half is unexplained, and the reporter's own environment is the only place this can be confirmed. Close it when they verify on the next release, or split the remainder into its own issue.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR hardens `omni_run` against blocked pipe reads, inherited transport input, and unbounded runtime while documenting the new timeout override.
- Drains stdout and stderr concurrently through `wait_with_output`.
- Isolates command execution from the MCP runtime worker and server stdin.
- Adds a configurable 60-second deadline and timeout diagnostics.
- Documents `OMNI_RUN_TIMEOUT_SECS` in both environment-variable references.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/mcp/server.rs | Adds concurrent output draining, isolated stdin, blocking-task execution, configurable timeout handling, and regression tests for the MCP command path. |
| docs/website/src/reference/environment.md | Documents the timeout override, its default, and the independent host deadline, fully addressing the previous review thread. |
| docs/website/src-id/reference/environment.md | Adds the equivalent timeout documentation to the Indonesian reference. |
| CHANGELOG.md | Records the three addressed `omni_run` failure modes and clearly identifies the remaining unexplained report. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[omni_run request] --> B[spawn_blocking]
    B --> C[Spawn shell with null stdin]
    C --> D[wait_with_output drains stdout and stderr]
    D --> E{Finished before deadline?}
    E -->|Yes| F{Exit successful?}
    F -->|Yes| G[Distill stdout and append stderr]
    F -->|No| H[Return raw output and exit code]
    E -->|No| I[Return command-specific timeout message]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["docs(reference): name OMNI\_RUN\_TIMEOUT\_S..."](https://github.com/fajarhide/omni/commit/a3a4a99954115548bb734c937ee69e2f4dee08b4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53296585)</sub>

<!-- /greptile_comment -->