### PR TITLE
docs(manual): document the two ledger floors, and guard all three numbers

### DIFF
--- a/changelog.d/555.fixed.md
+++ b/changelog.d/555.fixed.md
@@ -16,8 +16,15 @@
   out of the source. Each claim carries enough of its sentence to belong to one floor and
   nothing else, and a claim that matches no document at all now fails too, because a
   pattern reworded past its sentence is a check that quietly stopped checking, which is
-  what #541 was. Five wrong numbers and one reworded sentence were each proved to turn
-  the test red, two of them in the Indonesian manual.
+  what #541 was.
+
+  **Coverage is counted per book, not once across the tree.** One shared counter would let
+  the English page keep a claim alive while the Indonesian one stopped stating it, which
+  is #541's reach problem again, one dimension out: the count is right, the guard is
+  green, and one language is no longer being checked. Every wrong number and every
+  single-language reword was proved to turn the test red, in both directions, and so was
+  dropping the tool count from both Indonesian pages that carry it, which nothing caught
+  before this change.
 
   `ledger_folds` was missing from the database table list, which is the one table #533
   added and the only one that records why a marker was issued.

--- a/changelog.d/555.fixed.md
+++ b/changelog.d/555.fixed.md
@@ -1,0 +1,32 @@
+- **The manual described 0.7.4 after 0.7.5 shipped (#555)**: three behaviour changes
+  landed in the release and reached no page a reader sees. The ledger page gave the two
+  fold bars, 150 bytes for a session-origin run and three times that for a project-origin
+  one, and stopped there, so the floor #543 added was invisible: a fold covering the whole
+  output needs 1024 bytes of input or the run stays verbatim. That is the bar a reader
+  meets first, because a short command whose entire output repeats is the common case. The
+  264-byte input floor was undocumented too, and between them the two explain most of the
+  reports that OMNI did nothing. Both are now on the ledger page in English and
+  Indonesian, with the measurement that set them.
+
+  **The three floors are now guarded rather than written down.** #541 was a count in
+  prose that nothing read, and putting two more numbers on a page would have rebuilt it,
+  so `every_documented_count_matches_the_code` reads `MIN_LEDGER_RUN_GAIN`,
+  `MIN_LEDGER_INPUT` and `MIN_WHOLE_OUTPUT_FOLD` out of `guard/limits.rs` and checks every
+  statement of them in both books. Each of the four claims was broken deliberately and
+  each turned the test red, including the Indonesian one, which is the half #541 showed
+  the pattern could not see.
+
+  `ledger_folds` was missing from the database table list, which is the one table #533
+  added and the only one that records why a marker was issued.
+
+  **The release page told the reader to verify a tag by a label that lies for four
+  hours.** `guard::update::get_status` caches the newest known release for 14400 seconds,
+  so a machine that ran `omni doctor` before the tag reports `[AHEAD/RC]` whatever it is
+  running, which is what 0.7.5 did on a fresh install. The reliable half is the absence of
+  the `UNRELEASED` line, computed by `build.rs` from the tree with no cache. The same page
+  forecast a manual tidy on the first fragment cut; that happened on 0.7.5, two heading
+  pairs merged by hand, and the page now says to verify a cut by word count rather than by
+  eye.
+
+  Two samples named old versions: the build transcript on both manual front pages said
+  `Compiling omni v0.7.4`, and the plugin skill's `omni doctor` sample said `v0.7.3`.

--- a/changelog.d/555.fixed.md
+++ b/changelog.d/555.fixed.md
@@ -12,9 +12,12 @@
   prose that nothing read, and putting two more numbers on a page would have rebuilt it,
   so `every_documented_count_matches_the_code` reads `MIN_LEDGER_RUN_GAIN`,
   `MIN_LEDGER_INPUT` and `MIN_WHOLE_OUTPUT_FOLD` out of `guard/limits.rs` and checks every
-  statement of them in both books. Each of the four claims was broken deliberately and
-  each turned the test red, including the Indonesian one, which is the half #541 showed
-  the pattern could not see.
+  statement of them in both books, importing the constants rather than parsing them back
+  out of the source. Each claim carries enough of its sentence to belong to one floor and
+  nothing else, and a claim that matches no document at all now fails too, because a
+  pattern reworded past its sentence is a check that quietly stopped checking, which is
+  what #541 was. Five wrong numbers and one reworded sentence were each proved to turn
+  the test red, two of them in the Indonesian manual.
 
   `ledger_folds` was missing from the database table list, which is the one table #533
   added and the only one that records why a marker was issued.

--- a/docs/website/src-id/concepts/the-ledger.md
+++ b/docs/website/src-id/concepts/the-ledger.md
@@ -49,6 +49,29 @@ yang berasal dari sesi harus menghemat 150 byte di atas penandanya; deretan yang
 berasal dari proyek harus menghemat tiga kali lipatnya, sebab agent tidak punya
 pilihan selain membayar satu pengambilan kalau ia butuh isinya.
 
+## Dua lantai yang memutuskan tidak ada yang dilipat sama sekali
+
+Kedua ambang di atas menanyakan apakah sebuah deretan lebih besar daripada penanda
+yang menggantikannya. Ada dua lantai yang diperiksa sebelum keduanya, dan berdua
+mereka menjelaskan sebagian besar kasus di mana keluaran kembali utuh dan terlihat
+seolah ledger-nya mati.
+
+**Keluaran di bawah 264 byte tidak pernah sampai ke ledger.** Di bawah itu tidak ada
+deretan yang cukup panjang untuk pantas dapat handle, jadi tahap ini dilewati.
+
+**Lipatan yang menutupi seluruh keluaran butuh 1024 byte.** Kedua ambang tadi
+mengandaikan agent masih memegang sisa keluaran di samping penandanya dan bisa
+memutuskan apakah handle itu layak dibelanjakan. Kalau lipatannya menutupi semuanya,
+tidak ada apa pun di sampingnya, jadi membutuhkan sepotong saja dari isinya berarti
+satu pengambilan yang agent tidak punya suara di dalamnya. Setiap lipatan
+seluruh-keluaran yang tercatat di mesin ini ada di bawah 1 KB, dan empat dari empat
+diambil kembali dalam sembilan detik, melawan angka pengambilan 0,85% atas seluruh
+5.178 distilasi di penyimpanan yang sama. Semuanya menghemat 2.680 byte, lalu
+membelanjakan 319 byte penanda ditambah empat panggilan tool tambahan untuk
+menyerahkan 2.999 byte yang sama. Lantainya adalah puncak rentang yang terukur itu,
+bukan sebuah titik belok, sebab di atasnya tidak ada yang teramati ke arah mana pun.
+n=4, satu mesin.
+
 ## Premis yang mendasari semua sisanya
 
 > Agent masih memegang byte ini.

--- a/docs/website/src-id/index.md
+++ b/docs/website/src-id/index.md
@@ -24,7 +24,7 @@ Agent Anda menjalankan test. Empat ratus baris kembali, yang penting satu.
 
 ```
 $ cargo test
-    Compiling omni v0.7.4
+    Compiling omni v0.7.5
      Running unittests src/lib.rs
 running 412 tests
 test pipeline::scorer::tests::scores_errors_critical ... ok

--- a/docs/website/src/concepts/the-ledger.md
+++ b/docs/website/src/concepts/the-ledger.md
@@ -45,6 +45,25 @@ Because the project claim is not free, it carries a higher bar. A session-origin
 must save 150 bytes over its marker; a project-origin run must save three times that,
 since the agent has no choice about paying a retrieval if it needs the content.
 
+## The two floors that decide nothing folds at all
+
+Both bars above ask whether a run outgrows the marker replacing it. Two floors are
+checked before either of them, and between them they explain most of the cases where
+output comes back untouched and looks like the ledger is off.
+
+**Output under 264 bytes never reaches the ledger.** Below that there is no run long
+enough to be worth a handle, so the whole stage is skipped.
+
+**A fold that covers the entire output needs 1024 bytes.** The bars assume the agent
+still holds the rest of the output beside the marker and can decide whether the handle
+is worth spending. Cover everything and there is nothing beside it, so needing any part
+of the payload costs a retrieval the agent had no say in. Every whole-output fold this
+machine recorded was under 1 KB, and four of the four were retrieved within nine
+seconds, against a 0.85% retrieve rate across all 5,178 distillations in the same
+store. They saved 2,680 bytes, then spent 319 bytes of marker plus four extra tool
+calls handing back the same 2,999. The floor is the top of that measured range rather
+than a knee, because nothing above it was observed either way. n=4, one machine.
+
 ## The premise everything else follows from
 
 > The agent is still holding these bytes.

--- a/docs/website/src/develop/architecture.md
+++ b/docs/website/src/develop/architecture.md
@@ -59,6 +59,7 @@ One SQLite file, `~/.omni/omni.db`.
 | `rewind_store` | compressed content by SHA-256, with a retrieval counter |
 | `session_events` | FTS5 full-text index |
 | `ledger_lines` | which lines a scope has been shown |
+| `ledger_folds` | one row per marker issued: which scope, and which agent's bytes it drew on |
 | `passthrough_events` | telemetry for commands that bypassed the pipeline |
 | `unhandled_tools` | tools OMNI does not support natively yet |
 | `execution_traces` | raw input and distilled output per command |

--- a/docs/website/src/develop/releasing.md
+++ b/docs/website/src/develop/releasing.md
@@ -27,6 +27,15 @@ make bump VERSION=x.y.z
 A correctly cut build prints `omni vx.y.z [AHEAD/RC]` with no `UNRELEASED` line. Verify
 that before pushing the tag.
 
+**The half of that line to trust afterwards is the missing `UNRELEASED`, not the
+label.** `guard::update::get_status` caches the newest known release in
+`~/.omni/update_cache.json` for 14400 seconds, so for four hours after a tag a machine
+that ran `omni doctor` beforehand still holds the previous version and reports `Ahead`
+whatever it is running. Observed on 0.7.5, where the freshly installed release printed
+`[AHEAD/RC]`. `build.rs` computes the unreleased count from the tree with no cache, so
+that half is always current; delete the cache file if you want the label to mean
+something.
+
 Day to day, the entry goes in `changelog.d/<issue>.<section>.md` as the work merges, not
 into `CHANGELOG.md` and not at tag time. One file per entry means two branches never
 write the same path, which is what stopped every parallel branch conflicting on
@@ -35,10 +44,12 @@ unusually detailed on purpose: each states the measured evidence, the wrong numb
 was published, and the mechanism. A one-line entry is a regression in that file's
 quality.
 
-The first cut after this changed may need one manual tidy. Bullets written directly into
-`## [Unreleased]` before the convention existed are carried under the version heading
-with their own `### Added` or `### Fixed`, which can land beside one the fragments just
-wrote. The script says so when it happens.
+The first cut needed one manual tidy and it is done. 0.7.5 folded three fragments beside
+seven bullets written into `## [Unreleased]` before the convention existed, and arrived
+with two `### Changed` and two `### Fixed` under one version heading. Merging those four
+into two was the only hand edit. **Check a cut by word count rather than by eye**: 2,252
+words across the old section plus the fragments, 2,252 in the folded section. A
+reordering that drops a bullet body looks correct in a heading-level diff.
 
 ## CI green does not mean the release will build
 

--- a/docs/website/src/index.md
+++ b/docs/website/src/index.md
@@ -22,7 +22,7 @@ Your agent runs a test suite. Four hundred lines come back, one of them matters.
 
 ```
 $ cargo test
-    Compiling omni v0.7.4
+    Compiling omni v0.7.5
      Running unittests src/lib.rs
 running 412 tests
 test pipeline::scorer::tests::scores_errors_critical ... ok

--- a/plugins/claude-code/skills/omni/SKILL.md
+++ b/plugins/claude-code/skills/omni/SKILL.md
@@ -42,7 +42,7 @@ A healthy install names the binary, the config directory, the database, and one
 line per host:
 
 ```
-  Binary:         omni v0.7.3 [LATEST]
+  Binary:         omni v0.7.5 [LATEST]
   Config dir:     ~/.omni/ [OK]
   Database:       ~/.omni/omni.db (0 distillations, 0 sessions) [OK]
 

--- a/tests/docs_match_the_code.rs
+++ b/tests/docs_match_the_code.rs
@@ -153,7 +153,14 @@ fn every_documented_count_matches_the_code() {
         })
         .count();
 
-    // (regex, what the number has to equal, what it is counting)
+    // (regex, what the number has to equal, what it is counting, stated in both books)
+    //
+    // The last field is coverage, not scanning: every claim is looked for
+    // everywhere, and a `true` also requires each book to state it. One shared
+    // counter would let the English page keep a claim alive while the Indonesian
+    // one quietly stopped stating it, which is #541's reach problem again.
+    // `false` is for a count with no Indonesian counterpart by design, since
+    // `develop/` is deliberately untranslated.
     let claims = [
         // `perkakas` because the Indonesian book states the same counts and the
         // English noun never appears in it, so every count in it was unchecked.
@@ -161,8 +168,9 @@ fn every_documented_count_matches_the_code() {
             r"(\d+)\s+(?:MCP\s+)?(?:tools|perkakas)",
             tools.len(),
             "MCP tools",
+            true,
         ),
-        (r"(\d+)\s+content filters", distillers, "distillers"),
+        (r"(\d+)\s+content filters", distillers, "distillers", false),
         // The ledger page states three floors, in both languages. A constant
         // moving without the prose is #541 one file over: a number in text that
         // nothing reads. Each pattern carries enough of the sentence around the
@@ -172,24 +180,28 @@ fn every_documented_count_matches_the_code() {
             r"(?:save|menghemat) (\d+) (?:bytes over its marker|byte di atas penandanya)",
             omni::guard::limits::MIN_LEDGER_RUN_GAIN,
             "bytes a session-origin run must save",
+            true,
         ),
         (
             r"(?:under|di bawah) (\d+) (?:bytes never reaches|byte tidak pernah)",
             omni::guard::limits::MIN_LEDGER_INPUT,
             "bytes below which the ledger is skipped",
+            true,
         ),
         (
             r"(?:entire output needs|seluruh keluaran butuh) (\d+) (?:bytes|byte)",
             omni::guard::limits::MIN_WHOLE_OUTPUT_FOLD,
             "bytes a whole-output fold needs",
+            true,
         ),
     ];
 
     let mut wrong = Vec::new();
     // A pattern that matches nothing is a check that quietly stopped checking,
     // which is the failure #541 was. Rewording a sentence past its pattern has to
-    // be as loud as getting the number wrong.
-    let mut seen = vec![0usize; claims.len()];
+    // be as loud as getting the number wrong, and per book, or one language keeps
+    // the other's counter warm. Buckets: English book, Indonesian book, the rest.
+    let mut seen = vec![[0usize; 3]; claims.len()];
     for path in doc_files() {
         let text = std::fs::read_to_string(&path).expect("read doc");
         let shown = path
@@ -197,11 +209,19 @@ fn every_documented_count_matches_the_code() {
             .unwrap_or(&path)
             .display()
             .to_string();
-        for (n, (pattern, actual, what)) in claims.iter().enumerate() {
+        // By component, not by substring: the display path uses `\` on Windows.
+        let book = if path.components().any(|c| c.as_os_str() == "src-id") {
+            1
+        } else if path.components().any(|c| c.as_os_str() == "src") {
+            0
+        } else {
+            2
+        };
+        for (n, (pattern, actual, what, _)) in claims.iter().enumerate() {
             let re = regex::Regex::new(pattern).expect("valid regex");
             for (i, line) in text.lines().enumerate() {
                 for c in re.captures_iter(line) {
-                    seen[n] += 1;
+                    seen[n][book] += 1;
                     let claimed: usize = c[1].parse().expect("digits");
                     if claimed != *actual {
                         wrong.push(format!(
@@ -220,16 +240,25 @@ fn every_documented_count_matches_the_code() {
         wrong.join("\n")
     );
 
-    let unmatched: Vec<&str> = claims
-        .iter()
-        .zip(&seen)
-        .filter(|(_, hits)| **hits == 0)
-        .map(|((_, _, what), _)| *what)
-        .collect();
+    let mut uncovered = Vec::new();
+    for ((_, _, what, both_books), hits) in claims.iter().zip(&seen) {
+        if *both_books {
+            if hits[0] == 0 {
+                uncovered.push(format!("  {what}: the English manual no longer states it"));
+            }
+            if hits[1] == 0 {
+                uncovered.push(format!(
+                    "  {what}: the Indonesian manual no longer states it"
+                ));
+            }
+        } else if hits.iter().sum::<usize>() == 0 {
+            uncovered.push(format!("  {what}: no document states it"));
+        }
+    }
     assert!(
-        unmatched.is_empty(),
-        "no document states these any more, so nothing is being checked: {}",
-        unmatched.join(", ")
+        uncovered.is_empty(),
+        "a claim nobody states is a check that stopped checking.\n{}",
+        uncovered.join("\n")
     );
 }
 

--- a/tests/docs_match_the_code.rs
+++ b/tests/docs_match_the_code.rs
@@ -23,18 +23,6 @@ fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 }
 
-/// One `pub const NAME: usize = N;` out of `src/guard/limits.rs`.
-fn limit(name: &str) -> usize {
-    let src =
-        std::fs::read_to_string(repo_root().join("src/guard/limits.rs")).expect("read limits.rs");
-    regex::Regex::new(&format!(r"pub const {name}: usize = (\d+);"))
-        .expect("valid regex")
-        .captures(&src)
-        .unwrap_or_else(|| panic!("{name} is not in guard/limits.rs"))[1]
-        .parse()
-        .expect("digits")
-}
-
 /// Every markdown file the manual, the README and CONTRIBUTING are made of.
 fn doc_files() -> Vec<PathBuf> {
     let root = repo_root();
@@ -177,25 +165,31 @@ fn every_documented_count_matches_the_code() {
         (r"(\d+)\s+content filters", distillers, "distillers"),
         // The ledger page states three floors, in both languages. A constant
         // moving without the prose is #541 one file over: a number in text that
-        // nothing reads. Each pattern is the wording both books already use.
+        // nothing reads. Each pattern carries enough of the sentence around the
+        // number to belong to one floor and nothing else, since `under N bytes`
+        // on its own is ordinary prose that any page may write for other reasons.
         (
-            r"(?:save|menghemat) (\d+) (?:bytes|byte)",
-            limit("MIN_LEDGER_RUN_GAIN"),
+            r"(?:save|menghemat) (\d+) (?:bytes over its marker|byte di atas penandanya)",
+            omni::guard::limits::MIN_LEDGER_RUN_GAIN,
             "bytes a session-origin run must save",
         ),
         (
-            r"(?:under|di bawah) (\d+) (?:bytes|byte)",
-            limit("MIN_LEDGER_INPUT"),
+            r"(?:under|di bawah) (\d+) (?:bytes never reaches|byte tidak pernah)",
+            omni::guard::limits::MIN_LEDGER_INPUT,
             "bytes below which the ledger is skipped",
         ),
         (
-            r"(?:needs|butuh) (\d+) (?:bytes|byte)",
-            limit("MIN_WHOLE_OUTPUT_FOLD"),
+            r"(?:entire output needs|seluruh keluaran butuh) (\d+) (?:bytes|byte)",
+            omni::guard::limits::MIN_WHOLE_OUTPUT_FOLD,
             "bytes a whole-output fold needs",
         ),
     ];
 
     let mut wrong = Vec::new();
+    // A pattern that matches nothing is a check that quietly stopped checking,
+    // which is the failure #541 was. Rewording a sentence past its pattern has to
+    // be as loud as getting the number wrong.
+    let mut seen = vec![0usize; claims.len()];
     for path in doc_files() {
         let text = std::fs::read_to_string(&path).expect("read doc");
         let shown = path
@@ -203,10 +197,11 @@ fn every_documented_count_matches_the_code() {
             .unwrap_or(&path)
             .display()
             .to_string();
-        for (pattern, actual, what) in &claims {
+        for (n, (pattern, actual, what)) in claims.iter().enumerate() {
             let re = regex::Regex::new(pattern).expect("valid regex");
             for (i, line) in text.lines().enumerate() {
                 for c in re.captures_iter(line) {
+                    seen[n] += 1;
                     let claimed: usize = c[1].parse().expect("digits");
                     if claimed != *actual {
                         wrong.push(format!(
@@ -223,6 +218,18 @@ fn every_documented_count_matches_the_code() {
         wrong.is_empty(),
         "the manual states counts the code disagrees with.\n{}",
         wrong.join("\n")
+    );
+
+    let unmatched: Vec<&str> = claims
+        .iter()
+        .zip(&seen)
+        .filter(|(_, hits)| **hits == 0)
+        .map(|((_, _, what), _)| *what)
+        .collect();
+    assert!(
+        unmatched.is_empty(),
+        "no document states these any more, so nothing is being checked: {}",
+        unmatched.join(", ")
     );
 }
 

--- a/tests/docs_match_the_code.rs
+++ b/tests/docs_match_the_code.rs
@@ -23,6 +23,18 @@ fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 }
 
+/// One `pub const NAME: usize = N;` out of `src/guard/limits.rs`.
+fn limit(name: &str) -> usize {
+    let src =
+        std::fs::read_to_string(repo_root().join("src/guard/limits.rs")).expect("read limits.rs");
+    regex::Regex::new(&format!(r"pub const {name}: usize = (\d+);"))
+        .expect("valid regex")
+        .captures(&src)
+        .unwrap_or_else(|| panic!("{name} is not in guard/limits.rs"))[1]
+        .parse()
+        .expect("digits")
+}
+
 /// Every markdown file the manual, the README and CONTRIBUTING are made of.
 fn doc_files() -> Vec<PathBuf> {
     let root = repo_root();
@@ -163,6 +175,24 @@ fn every_documented_count_matches_the_code() {
             "MCP tools",
         ),
         (r"(\d+)\s+content filters", distillers, "distillers"),
+        // The ledger page states three floors, in both languages. A constant
+        // moving without the prose is #541 one file over: a number in text that
+        // nothing reads. Each pattern is the wording both books already use.
+        (
+            r"(?:save|menghemat) (\d+) (?:bytes|byte)",
+            limit("MIN_LEDGER_RUN_GAIN"),
+            "bytes a session-origin run must save",
+        ),
+        (
+            r"(?:under|di bawah) (\d+) (?:bytes|byte)",
+            limit("MIN_LEDGER_INPUT"),
+            "bytes below which the ledger is skipped",
+        ),
+        (
+            r"(?:needs|butuh) (\d+) (?:bytes|byte)",
+            limit("MIN_WHOLE_OUTPUT_FOLD"),
+            "bytes a whole-output fold needs",
+        ),
     ];
 
     let mut wrong = Vec::new();


### PR DESCRIPTION
The ledger page gave the two fold bars and stopped there, so the floor #543 shipped was
invisible: a fold covering the whole output needs 1024 bytes of input or the run stays
verbatim. The 264-byte input floor was undocumented too, and between them the two explain
most of the reports that OMNI did nothing. Both are now on the page in English and
Indonesian, with the measurement that set them.

Two more numbers in prose is how #541 happened, so they are guarded rather than written
down. `every_documented_count_matches_the_code` now reads `MIN_LEDGER_RUN_GAIN`,
`MIN_LEDGER_INPUT` and `MIN_WHOLE_OUTPUT_FOLD` out of `guard/limits.rs` and checks every
statement of them in both books.

```
  docs/website/src/concepts/the-ledger.md:45  says 151 bytes a session-origin run must save, the code has 150
  docs/website/src/concepts/the-ledger.md:54  says 265 bytes below which the ledger is skipped, the code has 264
  docs/website/src/concepts/the-ledger.md:57  says 2048 bytes a whole-output fold needs, the code has 1024
  docs/website/src-id/concepts/the-ledger.md:62  says 4096 bytes a whole-output fold needs, the code has 1024
test result: FAILED. 3 passed; 1 failed
```

Restored, `4 passed`. The Indonesian arm is the half #541 showed the pattern could not
reach. Full suite green with an isolated `OMNI_DB_PATH`, fmt and clippy clean.

The rest: `ledger_folds` was missing from the database table list; the release page told
the reader to verify a tag by `[AHEAD/RC]`, which caches for four hours and so reported
`Ahead` for the fresh 0.7.5 binary, and it forecast a first-cut manual tidy that has
already happened; two samples named `v0.7.4` and `v0.7.3`.

Closes #555

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR documents the ledger’s input and whole-output folding floors in both manuals and adds direct, translation-aware checks that keep those values synchronized with the Rust constants.
- Adds the missing ledger thresholds and supporting measurements to the English and Indonesian manuals.
- Tracks documented claims independently across the two documentation books.
- Updates architecture, release, version, plugin, and changelog documentation.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tests/docs_match_the_code.rs | Imports ledger limits semantically and validates both their values and independent presence in each translated manual. |
| docs/website/src/concepts/the-ledger.md | Documents the 264-byte ledger input floor and 1024-byte whole-output fold floor in English. |
| docs/website/src-id/concepts/the-ledger.md | Adds the corresponding ledger-floor explanation and measurements to the Indonesian manual. |
| docs/website/src/develop/releasing.md | Clarifies reliable post-release verification and updates the completed changelog-cut guidance. |

</details>

<sub>Reviews (4): Last reviewed commit: ["test(docs): count claim coverage per boo..."](https://github.com/fajarhide/omni/commit/de9a2f2abf1f4bddb683092b39c076f0da8dd94e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53353485)</sub>

<!-- /greptile_comment -->