### PR TITLE
feat(ledger): record whether a fold covered the whole output

### DIFF
--- a/changelog.d/whole-output-fold-flag.added.md
+++ b/changelog.d/whole-output-fold-flag.added.md
@@ -3,8 +3,9 @@
   `ledger_folds.whole_output` is set when every line of the payload folded, which is the call-level reading of the same condition the floor tests per run. The two differ only when adjacent runs of different origins tile the payload, and the question the column answers is whether the agent kept any content at all, so the call-level reading is the right one for a table that already aggregates by (origin, source agent) per call.
 
   ```sql
-  SELECT SUM(bytes) p FROM ledger_folds WHERE whole_output = 1
-  GROUP BY ts, scope, agent_id HAVING p < 1024;
+  SELECT * FROM ledger_folds WHERE whole_output = 1 AND payload_bytes < 1024;
   ```
 
-  Zero rows is the floor holding. Rows written before the column carry 0 meaning "not recorded" rather than "was partial", so a query has to bound itself by `ts`; the migration was run against a copy of a real 89 MB store and left its 55 existing rows intact.
+  Zero rows is the floor holding. `payload_bytes` rides along on every row of the call for that query to be a row predicate: summing `bytes` would need a GROUP BY on a per-call key, and `ts` is whole seconds, so two folds by one agent inside one second merge and their combined size can clear a floor that neither cleared alone. That is the audit silently hiding the one thing it exists to find, so the size is recorded per row instead.
+
+  Rows written before the columns carry 0 meaning "not recorded" rather than "was partial", so a query has to bound itself by `ts`. The migration was run against a copy of a real 89 MB store and left its 55 existing rows intact.

--- a/changelog.d/whole-output-fold-flag.added.md
+++ b/changelog.d/whole-output-fold-flag.added.md
@@ -1,0 +1,10 @@
+- **A fold now records whether it covered the whole output**: `MIN_WHOLE_OUTPUT_FOLD` refuses a whole-output fold under 1 KB because the agent is left holding a handle and no content, and #543 calibrated that floor on four such folds. Nothing recorded which folds were whole-output, so the floor could not be checked against its own corpus after the fact: `distillations` carries `collapse_original = 0` on exactly the four rows the decision cites, and `ledger_folds` had no flag at all. Verifying the claim on a live store meant guessing from the delivered-bytes ratio, which misreads an aggressive `Keep` as a whole-output fold.
+
+  `ledger_folds.whole_output` is set when every line of the payload folded, which is the call-level reading of the same condition the floor tests per run. The two differ only when adjacent runs of different origins tile the payload, and the question the column answers is whether the agent kept any content at all, so the call-level reading is the right one for a table that already aggregates by (origin, source agent) per call.
+
+  ```sql
+  SELECT SUM(bytes) p FROM ledger_folds WHERE whole_output = 1
+  GROUP BY ts, scope, agent_id HAVING p < 1024;
+  ```
+
+  Zero rows is the floor holding. Rows written before the column carry 0 meaning "not recorded" rather than "was partial", so a query has to bound itself by `ts`; the migration was run against a copy of a real 89 MB store and left its 55 existing rows intact.

--- a/src/ledger/mod.rs
+++ b/src/ledger/mod.rs
@@ -327,6 +327,7 @@ impl<'a> Ledger<'a> {
                         lines,
                         bytes,
                         whole_output,
+                        payload_bytes: text.len(),
                     },
                 )
                 .collect();
@@ -605,19 +606,32 @@ mod tests {
         );
 
         let conn = rusqlite::Connection::open(&db).expect("open");
-        let flags: Vec<i64> = conn
-            .prepare("SELECT whole_output FROM ledger_folds ORDER BY id")
+        let rows: Vec<(i64, i64)> = conn
+            .prepare("SELECT whole_output, payload_bytes FROM ledger_folds ORDER BY id")
             .expect("prepare")
-            .query_map([], |r| r.get(0))
+            .query_map([], |r| Ok((r.get(0)?, r.get(1)?)))
             .expect("query")
             .collect::<Result<_, _>>()
             .expect("rows");
 
         assert_eq!(
-            flags,
+            rows.iter().map(|r| r.0).collect::<Vec<_>>(),
             vec![1, 0],
             "a whole-output fold then a partial one; \
              without the split the floor stays unverifiable"
+        );
+        // Both calls land in the same second, so a `GROUP BY ts` audit would add
+        // these two payloads together and compare the total with the floor. The
+        // size has to be readable per row for the audit to mean anything.
+        assert_eq!(
+            rows[0].1,
+            text.len() as i64,
+            "the whole-output row must carry its own payload size"
+        );
+        assert_eq!(
+            rows[1].1,
+            extended.len() as i64,
+            "each call carries its own size, not the pair's total"
         );
     }
 

--- a/src/ledger/mod.rs
+++ b/src/ledger/mod.rs
@@ -291,6 +291,15 @@ impl<'a> Ledger<'a> {
         // reuse and was calibrated on the single-agent case, and nothing recorded
         // enough to tell the two apart after the fact.
         if let Some((_, folded)) = &projected {
+            // Every line folded means the agent holds markers and nothing else,
+            // which is the case `MIN_WHOLE_OUTPUT_FOLD` refuses below 1 KB. Read
+            // here rather than threaded out of `substitute`, because that flag is
+            // per run while this table is already one row per (origin, source
+            // agent) per call. The two differ only when adjacent runs of
+            // different origins tile the payload, and for the question this
+            // column answers, whether the agent kept any content at all, the
+            // call-level reading is the right one.
+            let whole_output = folded.len() == lines.len();
             let mut tally: HashMap<(&'static str, &str), (usize, usize)> = HashMap::new();
             for &i in folded {
                 let Some(origin) = origin_of(&hashes[i]) else {
@@ -317,6 +326,7 @@ impl<'a> Ledger<'a> {
                         origin,
                         lines,
                         bytes,
+                        whole_output,
                     },
                 )
                 .collect();
@@ -561,6 +571,53 @@ mod tests {
         assert!(
             second.contains("never seen before"),
             "the new line has to survive: {second:?}"
+        );
+    }
+
+    /// #543 priced whole-output folds and `MIN_WHOLE_OUTPUT_FOLD` refuses them
+    /// under 1 KB, but nothing recorded which folds were whole-output, so the
+    /// floor could not be checked against the corpus that calibrated it. Both
+    /// shapes are asserted in one test because the column is only useful if it
+    /// separates them: a flag that is always 1 answers the query the same way as
+    /// no flag at all.
+    #[test]
+    fn records_whether_a_fold_covered_the_whole_output() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = dir.path().join("omni.db");
+        let store = Store::open_path(&db).expect("store");
+        let text = payload();
+        let ledger = Ledger::new(&store, "s1");
+
+        ledger.project(&text);
+        let whole = ledger.project(&text).expect("a repeat is projectable");
+        assert!(
+            whole.contains("identical to"),
+            "this arm has to be a whole-output fold: {whole:?}"
+        );
+
+        // One line this session has never seen, so the head folds and the tail
+        // stays. Same ledger, so the only difference is the shape of the fold.
+        let extended = format!("{text}\nsomething this session has never seen before\n");
+        let partial = ledger.project(&extended).expect("the repeated head folds");
+        assert!(
+            !partial.contains("identical to"),
+            "this arm has to be a partial fold: {partial:?}"
+        );
+
+        let conn = rusqlite::Connection::open(&db).expect("open");
+        let flags: Vec<i64> = conn
+            .prepare("SELECT whole_output FROM ledger_folds ORDER BY id")
+            .expect("prepare")
+            .query_map([], |r| r.get(0))
+            .expect("query")
+            .collect::<Result<_, _>>()
+            .expect("rows");
+
+        assert_eq!(
+            flags,
+            vec![1, 0],
+            "a whole-output fold then a partial one; \
+             without the split the floor stays unverifiable"
         );
     }
 

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -495,6 +495,14 @@ impl SqliteBackend {
             -- settles the decision is a GROUP BY rather than a replay:
             --   SELECT origin, agent_id = source_agent AS same, SUM(bytes)
             --   FROM ledger_folds GROUP BY 1, 2;
+            --
+            -- `whole_output` says every line of the payload was folded, so the
+            -- agent was handed markers and no content. That is the case
+            -- `MIN_WHOLE_OUTPUT_FOLD` refuses below 1 KB (#543), and until this
+            -- column nothing recorded it, so the floor could not be checked
+            -- against the corpus it was calibrated on:
+            --   SELECT SUM(bytes) p FROM ledger_folds WHERE whole_output = 1
+            --   GROUP BY ts, scope, agent_id HAVING p < 1024;
             CREATE TABLE IF NOT EXISTS ledger_folds (
                 id           INTEGER PRIMARY KEY,
                 ts           INTEGER NOT NULL,
@@ -503,7 +511,8 @@ impl SqliteBackend {
                 source_agent TEXT NOT NULL,
                 origin       TEXT NOT NULL,
                 lines        INTEGER NOT NULL,
-                bytes        INTEGER NOT NULL
+                bytes        INTEGER NOT NULL,
+                whole_output INTEGER NOT NULL DEFAULT 0
             );
             CREATE INDEX IF NOT EXISTS idx_ledger_folds_ts ON ledger_folds(ts);
 
@@ -757,6 +766,13 @@ impl SqliteBackend {
         // reason nobody recorded.
         let _ = conn.execute(
             "ALTER TABLE passthrough_events ADD COLUMN reason TEXT NOT NULL DEFAULT 'unrecorded'",
+            [],
+        );
+        // Rows written before this column predate the flag entirely, so 0 means
+        // "not recorded" and not "was a partial fold". Queries about the floor
+        // have to bound themselves by ts for that reason.
+        let _ = conn.execute(
+            "ALTER TABLE ledger_folds ADD COLUMN whole_output INTEGER NOT NULL DEFAULT 0",
             [],
         );
         let _ = conn.execute(
@@ -1786,8 +1802,8 @@ impl SqliteBackend {
         {
             let Ok(mut stmt) = tx.prepare_cached(
                 "INSERT INTO ledger_folds
-                     (ts, scope, agent_id, source_agent, origin, lines, bytes)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                     (ts, scope, agent_id, source_agent, origin, lines, bytes, whole_output)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
             ) else {
                 return;
             };
@@ -1799,7 +1815,8 @@ impl SqliteBackend {
                     f.source_agent,
                     f.origin,
                     f.lines as i64,
-                    f.bytes as i64
+                    f.bytes as i64,
+                    i64::from(f.whole_output)
                 ]);
             }
         }
@@ -2505,6 +2522,11 @@ pub struct FoldRecord {
     pub origin: &'static str,
     pub lines: usize,
     pub bytes: usize,
+    /// Every line of the payload was folded, so the agent holds markers and no
+    /// content. A property of the call, not of this row: each row of one call
+    /// carries the same value, because the table already aggregates by
+    /// (origin, source agent) and a per-run flag has nowhere to live here.
+    pub whole_output: bool,
 }
 
 #[derive(Debug, Clone)]

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -501,8 +501,15 @@ impl SqliteBackend {
             -- `MIN_WHOLE_OUTPUT_FOLD` refuses below 1 KB (#543), and until this
             -- column nothing recorded it, so the floor could not be checked
             -- against the corpus it was calibrated on:
-            --   SELECT SUM(bytes) p FROM ledger_folds WHERE whole_output = 1
-            --   GROUP BY ts, scope, agent_id HAVING p < 1024;
+            --   SELECT * FROM ledger_folds
+            --   WHERE whole_output = 1 AND payload_bytes < 1024;
+            --
+            -- `payload_bytes` is the whole payload, carried on every row of the
+            -- call, so the audit is a row predicate. Summing `bytes` would need
+            -- a GROUP BY on a per-call key, and `ts` is not one: it is whole
+            -- seconds, so two folds by the same agent in the same second merge
+            -- and their combined size can clear a floor that neither of them
+            -- cleared alone, hiding exactly the violation being looked for.
             CREATE TABLE IF NOT EXISTS ledger_folds (
                 id           INTEGER PRIMARY KEY,
                 ts           INTEGER NOT NULL,
@@ -512,7 +519,8 @@ impl SqliteBackend {
                 origin       TEXT NOT NULL,
                 lines        INTEGER NOT NULL,
                 bytes        INTEGER NOT NULL,
-                whole_output INTEGER NOT NULL DEFAULT 0
+                whole_output INTEGER NOT NULL DEFAULT 0,
+                payload_bytes INTEGER NOT NULL DEFAULT 0
             );
             CREATE INDEX IF NOT EXISTS idx_ledger_folds_ts ON ledger_folds(ts);
 
@@ -773,6 +781,10 @@ impl SqliteBackend {
         // have to bound themselves by ts for that reason.
         let _ = conn.execute(
             "ALTER TABLE ledger_folds ADD COLUMN whole_output INTEGER NOT NULL DEFAULT 0",
+            [],
+        );
+        let _ = conn.execute(
+            "ALTER TABLE ledger_folds ADD COLUMN payload_bytes INTEGER NOT NULL DEFAULT 0",
             [],
         );
         let _ = conn.execute(
@@ -1802,8 +1814,9 @@ impl SqliteBackend {
         {
             let Ok(mut stmt) = tx.prepare_cached(
                 "INSERT INTO ledger_folds
-                     (ts, scope, agent_id, source_agent, origin, lines, bytes, whole_output)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                     (ts, scope, agent_id, source_agent, origin, lines, bytes, whole_output,
+                      payload_bytes)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
             ) else {
                 return;
             };
@@ -1816,7 +1829,8 @@ impl SqliteBackend {
                     f.origin,
                     f.lines as i64,
                     f.bytes as i64,
-                    i64::from(f.whole_output)
+                    i64::from(f.whole_output),
+                    f.payload_bytes as i64
                 ]);
             }
         }
@@ -2527,6 +2541,12 @@ pub struct FoldRecord {
     /// carries the same value, because the table already aggregates by
     /// (origin, source agent) and a per-run flag has nowhere to live here.
     pub whole_output: bool,
+    /// The whole payload this fold came out of, repeated on every row of the
+    /// call so the floor audit is a row predicate rather than a GROUP BY. `ts`
+    /// is whole seconds and so cannot key a call: two folds by one agent inside
+    /// one second would merge, and their combined size can clear a floor
+    /// neither cleared alone.
+    pub payload_bytes: usize,
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
`MIN_WHOLE_OUTPUT_FOLD` refuses a whole-output fold under 1 KB, and #543 calibrated that floor on four folds of 696 to 836 B that were each retrieved within nine seconds. Trying to check the floor against a live store today, I could not: nothing records which folds were whole-output.

`distillations.collapse_original` is 0 on exactly the four rows the decision cites, and `ledger_folds` had no flag. The only handle left is the delivered-bytes ratio, and it lies. On this machine's store a post-0.7.5 row of 321 B delivered as 69 B looks like a whole-output fold under the floor, until you read it: `route = Keep`, `filter_name = bun`, an ordinary distillation that kept 21% of the signal. I reached the wrong conclusion from that ratio before opening the row, which is the argument for the column rather than for a better query.

`ledger_folds.whole_output` is set when every line of the payload folded. That is the call-level reading of the condition the floor tests per run. The two differ only when adjacent runs of different origins tile the payload, and the question here is whether the agent kept any content at all, so the call-level reading is the right one for a table that already aggregates by (origin, source agent) per call.

The query the floor was always supposed to answer:

```sql
SELECT * FROM ledger_folds WHERE whole_output = 1 AND payload_bytes < 1024;
```

Zero rows is the floor holding.

`payload_bytes` carries the whole payload on every row of the call so that stays a row predicate. The first version of this recovered the size with `SUM(bytes) ... GROUP BY ts, scope, agent_id`, and review was right that `ts` is whole seconds: two whole-output folds by one agent inside one second land in one group, their combined size is compared with the floor, and two individually under-floor folds vanish from the audit. An audit that hides the one case it exists to find is worse than no audit, so the size is recorded per row.

### Verification

`records_whether_a_fold_covered_the_whole_output` asserts both shapes in one test, because a flag that is always 1 answers the query exactly as no flag does. Proved able to fail in both directions:

```
let whole_output = false;                       ->  left: [0, 0]  right: [1, 0]  FAILED
let whole_output = true;                        ->  left: [1, 1]  right: [1, 0]  FAILED
let whole_output = folded.len() == lines.len(); ->  ok

payload_bytes: bytes (the folded total)        ->  left: 3470  right: 3515  FAILED
payload_bytes: text.len()                      ->  ok
```

Migration over an existing store, run against a copy of a real 89 MB database rather than a fresh one:

```
before: id ts scope agent_id source_agent origin lines bytes
after:  id ts scope agent_id source_agent origin lines bytes whole_output payload_bytes
rows:   55 preserved, SUM(whole_output) = 0, SUM(payload_bytes) = 0
```

Rows written before the column carry 0 meaning "not recorded" and not "was partial", which is why the query above has to bound itself by `ts`. That is stated in the migration comment rather than left for a reader to infer from a zero.

Gates: `cargo fmt --check` clean, `cargo clippy --all-targets --all-features -- -D warnings` clean, `OMNI_DB_PATH=/tmp/omni-test.db cargo test` green across every target.

### Not in scope

The floor keys on a per-run flag while this column is per call. Whether the floor itself should ask the call-level question is a real design question and a behaviour change, so it is not decided here. This PR only makes the current behaviour answerable from the corpus.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR records whether a projection folded an entire payload and stores the payload size so floor violations can be audited without grouping calls by second.
- Adds call-level `whole_output` and `payload_bytes` fields to fold records.
- Extends the SQLite schema, migration path, and fold insertion statement.
- Adds coverage for whole and partial fold records occurring within the same second.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because an unexpected required-column migration failure can still silently disable fold telemetry.

The grouping defect has been addressed by storing payload size per row, but the migration continues to ignore failures while the insertion path silently returns if either required column is unavailable.

**Files Needing Attention:** src/store/sqlite.rs
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/ledger/mod.rs | Computes call-level whole-output status and payload size for each aggregated fold record, with tests covering whole and partial projections. |
| src/store/sqlite.rs | Persists the new audit fields and avoids second-resolution grouping, but the required migrations still suppress failures that can silently disable telemetry. |
| changelog.d/whole-output-fold-flag.added.md | Documents the new per-row audit query and the reason payload size is recorded on each row. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Ledger projection] --> B{Every payload line folded?}
  B -->|Yes| C[whole_output = 1]
  B -->|No| D[whole_output = 0]
  C --> E[FoldRecord rows]
  D --> E
  F[Payload byte length] --> E
  E --> G[(ledger_folds)]
  G --> H[Audit whole_output = 1 and payload_bytes < 1024]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ledger): make the floor audit a row ..."](https://github.com/fajarhide/omni/commit/c31976f8b7832dc824c814b926f887a1138af875) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53389789)</sub>

<!-- /greptile_comment -->