### PR TITLE
Drop the benchmark image from the six translated READMEs

### DIFF
--- a/changelog.d/drop-performance-card.removed.md
+++ b/changelog.d/drop-performance-card.removed.md
@@ -1,0 +1,7 @@
+- **The benchmark image is gone from the six translated READMEs**: `performance.png` was
+  hotlinked by `id`, `ja`, `ko`, `vi`, `zh` and `ar`, and by nothing else. `README.md`
+  never carried it, so those six readers were the only ones seeing it, and for weeks what
+  they saw was 58.9% across 1,810 executions while the English table beside them said
+  14.9% across 6,656. The card was regenerated from the current corpus first, then
+  dropped, so nothing was removed to hide a number. Every README keeps the table the
+  image duplicated.

--- a/i18n/README-ar.md
+++ b/i18n/README-ar.md
@@ -166,9 +166,6 @@ brew install fajarhide/tap/omni && omni init
   وقد أعلنّاهما ما داما قائمين.
 * **‏21 مللي ثانية لكل أمر**، تنمو مع تاريخك لا مع حجم الحمولة، وتصير 61 مللي ثانية مع
   قاعدة بحجم 205 ميغابايت.
-<div align="center">
-<img src="https://omni.weekndlabs.com/media/performance.png" alt="OMNI" width="600" />
-</div>
 
 <div dir="rtl">
 

--- a/i18n/README-id.md
+++ b/i18n/README-id.md
@@ -148,10 +148,6 @@ hari, jadi sebuah korpus lenyap seminggu setelah diukur.
 * **21 ms per perintah**, tumbuh bersama riwayat Anda dan bukan bersama ukuran
   payload. Pada database 205 MB angkanya 61 ms.
 
-<div align="center">
-<img src="https://omni.weekndlabs.com/media/performance.png" alt="OMNI" width="600" />
-</div>
-
 Angka-angka itu bisa Anda reproduksi sendiri, di mesin Anda:
 
 ```bash

--- a/i18n/README-ja.md
+++ b/i18n/README-ja.md
@@ -145,9 +145,6 @@ OMNI は両方を直し、それ以外では退きます。
   以前は 2 件あり、([#398](https://github.com/fajarhide/omni/issues/398)) で修正しました。あった間はその数字も公開していました。
 * **1コマンドあたり 21 ms**。ペイロードの大きさではなく履歴とともに増え、205 MB の
   データベースでは 61 ms です。
-<div align="center">
-<img src="https://omni.weekndlabs.com/media/performance.png" alt="OMNI" width="600" />
-</div>
 
 これらの数値は自分の環境で再現できます:
 

--- a/i18n/README-ko.md
+++ b/i18n/README-ko.md
@@ -145,9 +145,6 @@ OMNI는 둘 다 고치고, 그 밖에서는 비켜섭니다.
   이전에 2건이 있었고 ([#398](https://github.com/fajarhide/omni/issues/398))에서 고쳤으며, 있는 동안에는 그 숫자도 공개했습니다.
 * **명령당 21 ms**, 페이로드 크기가 아니라 기록과 함께 커지며 205 MB 데이터베이스에서는
   61 ms입니다.
-<div align="center">
-<img src="https://omni.weekndlabs.com/media/performance.png" alt="OMNI" width="600" />
-</div>
 
 이 수치는 직접 재현할 수 있습니다:
 

--- a/i18n/README-vi.md
+++ b/i18n/README-vi.md
@@ -148,9 +148,6 @@ một tập dữ liệu biến mất một tuần sau khi được đo.
   thời gian đó.
 * **21 ms mỗi lệnh**, lớn dần theo lịch sử của bạn chứ không theo kích thước payload. Với
   cơ sở dữ liệu 205 MB con số là 61 ms.
-<div align="center">
-<img src="https://omni.weekndlabs.com/media/performance.png" alt="OMNI" width="600" />
-</div>
 
 Bạn có thể tự tái lập những con số này trên máy mình:
 

--- a/i18n/README-zh.md
+++ b/i18n/README-zh.md
@@ -135,9 +135,6 @@ UTC**，每一次都是抵达模型的输出。时间窗口是这个数字的一
 * **97.3% 的调用一点没省**，我们照样公布，因为这个数字才说明剩下的值多少。**本次测量中没有一次调用让输出变大。**
   此前有 2 次，已由 ([#398](https://github.com/fajarhide/omni/issues/398)) 修复；它们存在时我们也照实公布过。
 * **每条命令 21 ms**，随你的历史增长而不是随载荷大小增长；对着 205 MB 的数据库是 61 ms。
-<div align="center">
-<img src="https://omni.weekndlabs.com/media/performance.png" alt="OMNI" width="600" />
-</div>
 
 这些数字可以在你自己的机器上复现：
 


### PR DESCRIPTION
`performance.png` was hotlinked by `i18n/README-{id,ja,ko,vi,zh,ar}` and by nothing else. `README.md` never carried it, so the only readers who ever saw it were the six who do not read the English one, and for weeks what they saw was **58.9% across 1,810 executions** while the table directly beside it said **14.9% across 6,656**. An image hosted in another repository is the one part of a README nobody re-reads when the numbers move.

The card was regenerated from the current corpus **before** this, not after, so nothing here drops a number to avoid publishing it. What goes is the duplication: each of these files already carries the benchmark table the image restated, in its own language, from the same source.

The `<div align="center">` wrapper goes with the `img` in all six. `git grep performance.png` over `i18n/`, `README.md` and `docs/` now returns nothing.

**Merge this before weekndlabs/omni-pages#43's follow-up**, which deletes the file and its generator. The image is served from that site, so the other order leaves six broken images on GitHub for as long as the two sit apart.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Removes the outdated, externally hosted benchmark image from all six translated READMEs while retaining their localized benchmark tables.
- Deletes each image and its now-empty centering wrapper.
- Adds a changelog fragment explaining why the duplicated benchmark card was removed.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

The changes consistently remove only a duplicated external image and its empty wrappers while preserving the localized benchmark data in every affected README.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| changelog.d/drop-performance-card.removed.md | Documents removal of the stale benchmark card and confirms that the benchmark tables remain. |
| i18n/README-ar.md | Removes the externally hosted benchmark image and its wrapper from the Arabic README. |
| i18n/README-id.md | Removes the externally hosted benchmark image and its wrapper from the Indonesian README. |
| i18n/README-ja.md | Removes the externally hosted benchmark image and its wrapper from the Japanese README. |
| i18n/README-ko.md | Removes the externally hosted benchmark image and its wrapper from the Korean README. |
| i18n/README-vi.md | Removes the externally hosted benchmark image and its wrapper from the Vietnamese README. |
| i18n/README-zh.md | Removes the externally hosted benchmark image and its wrapper from the Chinese README. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: drop the benchmark image from the ..."](https://github.com/fajarhide/omni/commit/71a8185eb3f4c96cfc13f346e1f40e1f5624e3fe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53435268)</sub>

<!-- /greptile_comment -->