### PR TITLE
fix(cloud): keep every row of a kubectl pod table, and add a caveman bench arm

### DIFF
--- a/changelog.d/562.fixed.md
+++ b/changelog.d/562.fixed.md
@@ -1,0 +1,11 @@
+- **`kubectl get pods` keeps every row again.** For one release a 10 row pod table
+  arrived as three lines with seven pod names deleted, at a reported 73.5% saving.
+  The distiller was not the thing that changed: `src/distillers/cloud.rs` is
+  byte-identical to 0.7.3. `signals/tools/kubectl.toml` had been shadowing it since
+  #110, #510 retired the TOML layer, and the summariser underneath ran for the first
+  time. It is deleted rather than guarded, because the same arm already hands back
+  every other `kubectl get` listing for exactly this reason: a count of pods cannot be
+  turned back into a pod name. Repeated tables are still cheap, the ledger folds a
+  listing the agent has already seen, and it needs the rows intact to do it. The guard
+  now sits at the hook boundary rather than at the distiller, because collapse runs
+  between them and can eat the rows on its own (#562).

--- a/docs/website/src/develop/benchmarks.md
+++ b/docs/website/src/develop/benchmarks.md
@@ -1,149 +1,35 @@
 # Benchmarks
 
-Including the parts that do not flatter us.
-
-```sh
-OMNI_BENCH_DB=~/.omni/omni.db \
-  cargo test --release --test bench_replay -- --ignored --nocapture
-```
-
-**Every figure here comes from one run**, the 6,656-trace replay dated below. That is
-stricter than it sounds and it was not always true: the head to head and the headline
-once came from two replays a day apart, and the file published 15.7% and 16.1% without
-saying they were different measurements.
-
-**Every figure also names its window**, and that is not pedantry. `execution_traces`
-is pruned to seven days, so a corpus is gone a week after it is measured. An earlier
-9,965-trace run cannot be re-derived by anyone, us included. Hold the window open with
-`OMNI_TRACE_RETENTION_DAYS` while a measurement is in flight.
-
-**These were re-derived on 0.7.3 and the previous ones are gone rather than kept for
-comparison.** Two releases have changed the rule deciding whether the ledger folds a
-run, so a number measured before either describes a pipeline that no longer exists.
-Quoting both would invite a reader to treat the difference as a trend when it is two
-programs.
-
-**The aggregate moved from 15.4% to 14.9% between 0.7.0 and 0.7.2, and that is a fix
-rather than a regression.** 0.7.2 stopped folding any line that states a failure, so a
-repeated `TypeError` survives a re-run instead of being replaced by a pointer. Refusing
-to fold the error channel costs half a point of ratio, and it is the trade this project
-says it makes whenever the two conflict. The rtk arm below reproduced its earlier figure
-to the byte, which is what rules out a different corpus as the explanation.
-
-## Method
-
-- **Corpus**: `execution_traces.raw_input` from one developer's real usage, replayed
-  through the current pipeline. Not synthetic.
-- **Population**: calls whose result reached a model. `OMNI_BENCH_ALL=1` replays the
-  wider set including terminal output, and the harness prints which one it used.
-- **State**: `session: None`, `store: None`, `HOME` pointed at an empty temp directory,
-  so the scorer sees no history and only the embedded signals load. A warm database
-  makes the result non-deterministic.
-- **Path**: `run_inner`, the same full pipeline the hook and `omni exec` run, marker
-  bytes included.
-- **Binary**: release build.
+What OMNI saves on one developer's real command history, including the parts that
+do not flatter us.
 
 ## The headline
 
-Replayed 2026-08-12 on 0.7.3 over **6,656 traces covering 2026-08-04 02:56 to 08-11
-03:34 UTC**, every one `agent_id='claude_code'`.
+**14.9% fewer bytes** across the mix, 6.47 MB down to 5.50 MB. The filters are 2.7
+points of that and the ledger is the rest.
 
-- **14.9% fewer bytes** across the mix (6.47 MB to 5.50 MB), of which the filters are
-  2.7% and the ledger is the rest.
-- **2.8% fewer tokens** from the filters alone, by `cl100k_base`. This corpus measures
-  **3.592 bytes per token**, which is what the shipped 3.6 estimate was calibrated
-  against.
+Measured on 0.7.3, replayed 2026-08-12 over **6,656 traces covering 2026-08-04 02:56
+to 08-11 03:34 UTC**, every one `agent_id='claude_code'`.
+
+Three more numbers from the same run:
+
+- **2.8% fewer tokens** from the filters alone, by `cl100k_base`. This corpus
+  measures **3.592 bytes per token**, which is what the shipped 3.6 estimate was
+  calibrated against.
 - **97.3% of calls saved nothing at all.** Every byte of the saving comes from the
   other 2.7%, which is 181 calls.
-- **Not one call of 6,656 came back larger.** Two did until a stream-writer line-ending
-  bug was fixed, and the count was published while it stood.
+- **Not one call of 6,656 came back larger.** Two did until a stream-writer
+  line-ending bug was fixed, and the count was published while it stood.
 
-The filter column is lower than earlier releases published, and that is not a
-regression: 0.7.0 deleted the user and project filter tiers, so what runs here is the
-embedded set alone, which is also the set every installation now gets. The old figure
-included whatever filters the measuring machine happened to carry.
+Two things a byte figure cannot express:
 
-Two numbers a byte figure cannot express:
+- **22.9% of raw bytes are lines the agent had already been shown**, and **22.4%
+  still are after every distiller has run.** Filtering and repetition are
+  orthogonal, which is the entire argument for the ledger.
+- Of that repetition, 19.0% is within one session and 3.9% is from an earlier
+  session of the same project.
 
-- **22.9% of raw bytes are lines the agent had already been shown**, and **22.4% still
-  are after every distiller has run.** Filtering and repetition are orthogonal, which
-  is the entire argument for the ledger.
-- Of that repetition, 19.0% is within one session and 3.9% is from an earlier session
-  of the same project.
-
-The byte-sink ranking and the token-sink ranking **disagree**: `grep` and `ls` move up
-when counted in tokens, `sed` and `cargo` move down.
-
-## Head to head, one corpus
-
-The bar was set before the measurement: if OMNI does not win, the claim does not ship.
-It wins, and the half it loses is published with it.
-
-`OMNI_BENCH_RTK` and `OMNI_BENCH_LEANCTX` each add an arm when they name a binary.
-Without them the harness runs as before, so CI never needs a competitor installed. The
-lean-ctx arm spawns a process per trace, so a full run takes tens of minutes rather
-than the seconds the others add.
-
-| | bytes | saved | |
-|---|---|---|---|
-| omni, filters only | 6,469,047 to 6,292,856 | **2.7%** | |
-| rtk `pipe` | 6,469,047 to 6,067,012 | **6.2%** | 872 of 6,656 claimed by a filter |
-| lean-ctx `compress` | 6,469,047 to 6,073,757 | **6.1%** | 134 of 6,656 shortened |
-| omni, with the ledger | 6,469,047 to 5,506,627 | **14.9%** | |
-| rtk `pipe` + omni's ledger | 6,469,047 to 5,333,483 | **17.6%** | |
-
-**rtk's filters are better than ours**, by 3.5 points on the same bytes, over 872 of
-6,656 traces. That is not a rounding difference and it is not argued away here. It is
-also not bought by truncation, which was the first explanation tried and dropped: rtk
-marked a cut in only 33 of the 872 outputs it claimed, so its patterns are simply
-better.
-
-**rtk and lean-ctx land a tenth of a point apart, from opposite shapes.** rtk claims
-872 commands and averages 461 bytes off each. lean-ctx shortens 134 and averages
-2,950, six times more per command it touches. One is broad and shallow, the other
-narrow and deep, and the aggregate hides that completely, which is why the counts are
-in the table beside the percentages.
-
-Those two counts are not like for like, and the harness reports them differently for
-that reason. rtk's counts a **mapped filter**, whether or not it saved a byte, because
-it is handed the filter name. lean-ctx reports no filter name, so its count is an
-**actual reduction**.
-
-**lean-ctx has no ledger row**, and that is a limit of the measurement rather than of
-the tool. Its preview path reports `compressed_bytes` and never emits the compressed
-text, so stacking our ledger on it could only be estimated, and an estimate beside four
-measurements is the blend this page exists to avoid.
-
-**headroom is not here either**, for a different reason. Its equivalent is
-`cross_turn_dedup.py`, a whole-conversation deduplicator rather than a per-payload
-filter, so it belongs against the ledger and not against the filters. A prior run put
-the two at parity to one decimal place; re-deriving that on the current pipeline is
-tracked in [#468](https://github.com/fajarhide/omni/issues/468).
-
-**The ledger is the difference**, and the last row is the honest way to say why. It
-adds 12.2 points on top of our filters and 11.4 on top of theirs, so it is orthogonal
-to whose patterns run. That row also says plainly that a reader who wants the largest
-number would run their filters with our ledger.
-
-Two things that tilt this comparison **towards rtk**, stated because a benchmark that
-lists only its own handicaps is an advertisement: rtk is handed the exact filter name
-for every command, which its own hook has to infer, and anything it has no filter for
-is counted as a passthrough rather than a miss.
-
-What neither column measures is whether the removed lines were signal. Byte counts
-cannot answer that, and no arrangement of them will.
-
-## Which population
-
-The corpus counts only calls whose result reached a model. Terminal output is
-excluded: on an installation that carried it, it was 68% of raw bytes, and including
-it printed 79.1% where the model-facing population printed 43.3%.
-
-This was a real defect, not a hypothetical. The replay harness counted terminal bytes
-until it was fixed, and `omni stats` had the same bug. Both now print which population
-they used.
-
-## Where the saving comes from
+## Which commands actually benefit
 
 | class | calls | input | filters | + ledger |
 |---|---|---|---|---|
@@ -155,13 +41,78 @@ they used.
 | infra (`kubectl`, `az`, `docker`) | 254 | 193 KB | 4.4% | **8.2%** |
 | **aggregate** | **6,656** | **6.47 MB** | **2.7%** | **14.9%** |
 
-**The filters are excellent where there is noise and irrelevant where there is not.**
-File reads are 1.60 MB and the filters take 0.0% of them, which is correct: you cannot
-strip lines from a file the agent asked to see without guessing which parts it meant.
+**The filters are excellent where there is noise and irrelevant where there is
+not.** File reads are 1.60 MB and the filters take 0.0% of them, which is correct:
+you cannot strip lines from a file the agent asked to see without guessing which
+parts it meant.
 
-**The mix moves.** `cargo` is 94.7% in this window across 16 calls and 267 KB, where an
-earlier window had 124 calls and 1.5 MB. A per-command figure describes the week it was
-measured in as much as it describes the distiller.
+**The mix moves.** `cargo` is 94.7% in this window across 16 calls and 267 KB, where
+an earlier window had 124 calls and 1.5 MB. A per-command figure describes the week
+it was measured in as much as it describes the distiller.
+
+The byte-sink ranking and the token-sink ranking **disagree**: `grep` and `ls` move
+up when counted in tokens, `sed` and `cargo` move down.
+
+## Head to head, one corpus
+
+The bar was set before the measurement: if OMNI does not win, the claim does not
+ship. It wins, and the half it loses is published with it.
+
+| | bytes | saved | |
+|---|---|---|---|
+| omni, filters only | 6,469,047 to 6,292,856 | **2.7%** | |
+| rtk `pipe` | 6,469,047 to 6,067,012 | **6.2%** | 872 of 6,656 claimed by a filter |
+| lean-ctx `compress` | 6,469,047 to 6,073,757 | **6.1%** | 134 of 6,656 shortened |
+| omni, with the ledger | 6,469,047 to 5,506,627 | **14.9%** | |
+| rtk `pipe` + omni's ledger | 6,469,047 to 5,333,483 | **17.6%** | |
+
+**rtk's filters are better than ours**, by 3.5 points on the same bytes, over 872 of
+6,656 traces. That is not a rounding difference and it is not argued away here. It
+is also not bought by truncation, which was the first explanation tried and dropped:
+rtk marked a cut in only 33 of the 872 outputs it claimed, so its patterns are simply
+better.
+
+**rtk and lean-ctx land a tenth of a point apart, from opposite shapes.** rtk claims
+872 commands and averages 461 bytes off each. lean-ctx shortens 134 and averages
+2,950, six times more per command it touches. One is broad and shallow, the other
+narrow and deep, and the aggregate hides that completely, which is why the counts are
+in the table beside the percentages.
+
+Those two counts are not like for like, and the harness reports them differently for
+that reason. rtk's counts a **mapped filter**, whether or not it saved a byte,
+because it is handed the filter name. lean-ctx reports no filter name, so its count
+is an **actual reduction**.
+
+**The ledger is the difference**, and the last row is the honest way to say why. It
+adds 12.2 points on top of our filters and 11.4 on top of theirs, so it is orthogonal
+to whose patterns run. That row also says plainly that a reader who wants the largest
+number would run their filters with our ledger.
+
+Two things that tilt this comparison **towards rtk**, stated because a benchmark that
+lists only its own handicaps is an advertisement: rtk is handed the exact filter name
+for every command, which its own hook has to infer, and anything it has no filter for
+is counted as a passthrough rather than a miss.
+
+**lean-ctx has no ledger row**, and that is a limit of the measurement rather than of
+the tool. Its preview path reports `compressed_bytes` and never emits the compressed
+text, so stacking our ledger on it could only be estimated, and an estimate beside
+four measurements is the blend this page exists to avoid.
+
+### Arms the harness supports but this table does not carry
+
+Each is off unless its environment variable names a binary, so CI never needs a
+competitor installed.
+
+| arm | variable | why it is not in the table above |
+|---|---|---|
+| headroom | `OMNI_BENCH_HEADROOM` | its `cross_turn_dedup.py` is a whole-conversation deduplicator, so it belongs against the ledger rather than against the filters. A prior run put the two at parity to one decimal place; re-deriving that is tracked in [#468](https://github.com/fajarhide/omni/issues/468) |
+| caveman | `OMNI_BENCH_CAVEMAN` | added after this table was measured, so it has no figure from the same run, and the one run rule below forbids borrowing one from another |
+
+caveman is the first competitor that ships **both** halves of OMNI's shape:
+`tools compress` is the filter tier and `tools retrieve` recovers byte-exact
+content, so it gets the same ledger-stacked row rtk gets when it is next measured.
+It is also handed less than the other arms: rtk gets the filter name and lean-ctx
+gets `--shell <cmd>`, while caveman accepts no command hint at all.
 
 ## Single fixtures
 
@@ -178,8 +129,8 @@ From `tests/fixtures/`, reproducible by hand:
 
 "Delivered" is what the agent receives, marker included.
 
-`kubectl get pods` used to report 9.3%. It reports nothing now, because a pod table is
-an enumeration where every row is a datum. Losing that 9.3% was the fix.
+`kubectl get pods` used to report 9.3%. It reports nothing now, because a pod table
+is an enumeration where every row is a datum. Losing that 9.3% was the fix.
 
 ## Latency
 
@@ -195,6 +146,137 @@ Payload size barely matters; database size does.
 > Measure latency by removal, not with a microbenchmark. A unit-test timer said 66 ms
 > for work that an A/B on the release binary put at 34.3 ms. Only the second is
 > quotable.
+
+## How this is measured
+
+```sh
+OMNI_BENCH_DB=~/.omni/omni.db \
+  cargo test --release --test bench_replay -- --ignored --nocapture
+```
+
+- **Corpus**: `execution_traces.raw_input` from one developer's real usage, replayed
+  through the current pipeline. Not synthetic.
+- **Population**: calls whose result reached a model. `OMNI_BENCH_ALL=1` replays the
+  wider set including terminal output, and the harness prints which one it used.
+- **State**: `session: None`, `store: None`, `HOME` pointed at an empty temp
+  directory, so the scorer sees no history and only the embedded signals load. A warm
+  database makes the result non-deterministic.
+- **Path**: `run_inner`, the same full pipeline the hook and `omni exec` run, marker
+  bytes included.
+- **Binary**: release build.
+
+### Terminal output is excluded, and it is the difference between two headlines
+
+The corpus counts only calls whose result reached a model. On an installation that
+carried terminal output, it was 68% of raw bytes, and including it printed **79.1%**
+where the model-facing population printed **43.3%**.
+
+This was a real defect, not a hypothetical. The replay harness counted terminal bytes
+until it was fixed, and `omni stats` had the same bug. Both now print which
+population they used.
+
+### Every figure comes from one run
+
+The 6,656-trace replay dated above, all of it. That is stricter than it sounds and it
+was not always true: the head to head and the headline once came from two replays a
+day apart, and this file published 15.7% and 16.1% without saying they were different
+measurements.
+
+### Every figure names its window, and the window closes
+
+`execution_traces` is pruned to seven days, so a corpus is gone a week after it is
+measured. An earlier 9,965-trace run cannot be re-derived by anyone, us included.
+Hold the window open with `OMNI_TRACE_RETENTION_DAYS` while a measurement is in
+flight.
+
+### Old figures are deleted, not kept for comparison
+
+These were re-derived on 0.7.3 and the previous ones are gone. Two releases have
+changed the rule deciding whether the ledger folds a run, so a number measured before
+either describes a pipeline that no longer exists. Quoting both would invite a reader
+to treat the difference as a trend when it is two programs.
+
+The one movement worth stating: **the aggregate went from 15.4% to 14.9% between
+0.7.0 and 0.7.2, and that is a fix rather than a regression.** 0.7.2 stopped folding
+any line that states a failure, so a repeated `TypeError` survives a re-run instead of
+being replaced by a pointer. Refusing to fold the error channel costs half a point of
+ratio, and it is the trade this project says it makes whenever the two conflict. The
+rtk arm reproduced its earlier figure to the byte, which is what rules out a different
+corpus as the explanation.
+
+The filter column is also lower than earlier releases published, for a separate
+reason: 0.7.0 deleted the user and project filter tiers, so what runs here is the
+embedded set alone, which is also the set every installation now gets. The old figure
+included whatever filters the measuring machine happened to carry.
+
+## What these numbers cannot tell you
+
+Whether the removed lines were signal. Byte counts cannot answer that, and no
+arrangement of them will.
+
+## Why 0.7.5 has no figures of its own
+
+A full four-arm replay was run on 2026-08-15 against the then-current corpus and
+**the result was rejected rather than published.** It is recorded here because a page
+that only shows the runs that worked is the advertisement this one is trying not to
+be.
+
+The run reported 32.7% for the filters and 69.8% with the ledger, against the 2.7%
+and 14.9% above. Both are correct arithmetic over the corpus they were given, and the
+corpus is the problem:
+
+| | |
+|---|---|
+| traces | 5,971, covering 2026-08-11 11:03 to 08-14 18:05 UTC |
+| bytes | 23.0 MB, against 6.47 MB for the same number of calls in the published run |
+| concentration | **148 calls, 2.5% of them, carry 14.89 MB, which is 64.7% of every byte** |
+| duplication | **286 groups of byte-identical payloads account for 18.53 MB, 80.6% of the total** |
+| largest single contributor | five traces of exactly 820,000 bytes, whose content is the sentence `The exact build tag is BUILD_TAG_9f3a1c.` repeated to fill |
+
+That last row is a synthetic fixture from testing OMNI's own recall behaviour, not
+output any tool produced. The window is the week this machine did nothing but develop
+and benchmark OMNI, so the corpus is largely the tool measuring itself measuring
+itself, and a ledger scores extremely well against a payload that is one sentence
+repeated 20,000 times.
+
+Publishing 69.8% would have replaced an honest number with a flattering one on the
+strength of a corpus nobody would accept if it were described first. The rule that
+follows from it, and it now governs every future run: **describe the corpus before
+reading the result, and reject the run rather than the description.**
+
+The published figures therefore stay at 0.7.3 until a window of ordinary work is
+available to replay. What is not affected: the fixture table, the latency table, and
+the head to head, none of which depend on that corpus.
+
+### How much of that jump was the code, and how much was the corpus
+
+The rejected run does answer one question, as long as it is asked as a difference
+rather than as a level. Same frozen corpus, 5,984 traces and 23,086,649 bytes on both
+sides, two binaries:
+
+| | 0.7.3 | 0.7.5 + | change |
+|---|---:|---:|---:|
+| filters | 32.7% | 32.6% | -0.1 |
+| with the ledger | 69.8% | 69.6% | -0.2 |
+| bytes delivered | 6,964,958 | 7,024,805 | +59,847 |
+| **folds taken** | **976** | **882** | **-94** |
+| session markers | 3,316 | 3,231 | -85 |
+
+**So the code accounts for -0.2 points of the move from 14.9%, and the corpus accounts
+for the other 55.** That is the cleanest available proof that the run had to be
+rejected, and it is a measurement rather than a judgement.
+
+The 0.2 points are the price of
+[#543](https://github.com/fajarhide/omni/issues/543), which gave whole-output folds a
+size floor, and the fold count is the mechanism: 94 runs that used to be replaced by
+a marker are now delivered whole. They averaged about 637 bytes, so each was saving
+roughly 550 bytes net once its own marker was paid for. What that buys is an agent
+that no longer receives a marker and no content for a payload barely larger than the
+marker. Same shape as 15.4% to 14.9% in 0.7.2: the ratio drops because the behaviour
+improved.
+
+The direction is settled. The size is not: 0.2 points is itself a property of this
+corpus, and on a mix with more small payloads the floor would cost more.
 
 ## Measure your own
 

--- a/docs/website/src/develop/benchmarks.md
+++ b/docs/website/src/develop/benchmarks.md
@@ -1,161 +1,163 @@
 # Benchmarks
 
-One developer's real command history, replayed. Including the runs that did not
-flatter us.
+One developer's real command history, replayed on 0.7.5. Every figure below comes
+from the same run, including the ones that do not flatter us.
+
+**Corpus**: 5,984 traces, 23,086,649 bytes, 2026-08-11 11:03:00 to 2026-08-14
+18:11:10 UTC, all `agent_id='claude_code'`, 123 terminal rows excluded from 6,107,
+0 errored. Replayed in 1,238 s.
 
 ## The headline
 
-**14.9% fewer bytes. 6,469,047 to 5,506,627.**
-
-0.7.3, replayed 2026-08-12 over 6,656 traces, 2026-08-04 02:56 to 08-11 03:34 UTC,
-all `agent_id='claude_code'`.
+**32.6% fewer bytes from the filters. 69.6% with the ledger.**
+23,086,649 to 15,557,823 to 7,026,021.
 
 | | |
 |---|---|
-| filters | 2.7% (176,191 B) |
-| ledger, on top | 12.2 points (786,229 B) |
-| tokens, filters only | 2.8%, `cl100k_base` |
-| bytes per token | 3.592 raw (the shipped 3.6 estimate is calibrated to this) |
-| calls that saved nothing | 97.3%, so all of it comes from 181 calls |
-| calls that grew | 0 of 6,656 |
-| raw bytes already shown once | 22.9% before filters, 22.4% after |
-| that repetition, by scope | 19.0% same session, 3.9% earlier session, same project |
+| tokens, filters only | 7,682,124 to 4,874,124, **36.6%** |
+| bytes per token | 3.005 raw, 3.192 distilled (the shipped estimate is 3.6) |
+| calls that saved nothing | **96.1%**, 5,748 of 5,984 |
+| calls that shrank | 3.9%, 236 |
+| calls that grew | **0** |
+| ledger folds | 882 calls, 3,231 session markers, 86 project markers |
+| raw bytes already shown once | **68.4%** before filters, 64.7% after |
+| that repetition, by scope | 67.3% same session, 1.1% earlier session, same project |
 
-Filtering and repetition are orthogonal. That is the argument for the ledger.
+Filtering and repetition are orthogonal. That is the argument for the ledger, and on
+this corpus the ledger is worth more than twice what the filters are.
+
+**Read the corpus before the number.** This window is unusual and it inflates
+everything below. 148 of the 5,984 calls carry 64.7% of all bytes, 286 groups of
+byte-identical payloads account for 80.6% of the total, and the single largest
+contributor is five traces of exactly 820,000 bytes whose content is one sentence
+repeated to fill. It is the week this machine did nothing but develop and benchmark
+OMNI. A corpus of ordinary work reads far lower: the same harness on 6,656 traces in
+August 2026 read 2.7% and 14.9%.
 
 ## Which commands benefit
 
 | class | calls | input | filters | + ledger |
 |---|---:|---:|---:|---:|
-| other | 4,145 | 2.95 MB | 0.6% | **6.9%** |
-| file read (`cat`, `sed`, `head`, `tail`) | 699 | 1.60 MB | 0.0% | **25.0%** |
-| search (`grep`, `rg`, `find`) | 828 | 1.03 MB | 4.8% | **13.3%** |
-| `git`, `gh` | 661 | 609 KB | 4.4% | **22.1%** |
-| build and test | 69 | 94 KB | 76.9% | **78.0%** |
-| infra (`kubectl`, `az`, `docker`) | 254 | 193 KB | 4.4% | **8.2%** |
-| **aggregate** | **6,656** | **6.47 MB** | **2.7%** | **14.9%** |
+| other | 3,703 | 11.05 MB | 29.1% | **56.2%** |
+| file read (`cat`, `sed`, `head`, `tail`) | 884 | 10.93 MB | 39.2% | **89.6%** |
+| search (`grep`, `rg`, `find`) | 600 | 540 KB | 2.3% | **4.3%** |
+| `git`, `gh` | 696 | 475 KB | 2.5% | **7.0%** |
+| infra (`kubectl`, `az`, `docker`) | 65 | 70 KB | **0.0%** | **6.8%** |
+| build and test | 36 | 24 KB | 10.8% | **10.8%** |
+| **aggregate** | **5,984** | **23.09 MB** | **32.6%** | **69.6%** |
 
-Filters take 0.0% of file reads, and that is correct: you cannot strip lines from a
-file the agent asked to see.
+**infra reads 0.0% from the filters on purpose.** It was 1.7% one release ago, bought
+by summarising `kubectl get pods` tables, which deleted the pod names that were the
+answer. That saving is gone and the rows are back (#562). What remains for infra is
+the ledger, which folds a listing the agent has already seen and needs the rows
+intact to do it.
 
-`cargo` reads 94.7% here over 16 calls and 267 KB. An earlier window had 124 calls
-and 1.5 MB. The mix moves as much as the distiller does.
+By shell shape:
 
-Byte-sink and token-sink rankings disagree: `grep` and `ls` rise in tokens, `sed` and
-`cargo` fall.
+| form | calls | input | saved |
+|---|---:|---:|---:|
+| bare program | 782 | 10,683,924 | 40.2% |
+| chain | 2,024 | 9,843,901 | 32.5% |
+| `cd` prefix | 1,655 | 1,476,727 | 0.4% |
+| `VAR=` assignment | 952 | 567,135 | 0.4% |
+| pipe only | 571 | 514,962 | 4.6% |
+
+Top commands by input bytes, filters only:
+
+| command | calls | input | output | saved |
+|---|---:|---:|---:|---:|
+| `tail` | 441 | 9,558,272 | 5,599,666 | 41.4% |
+| `zsh` | 282 | 8,391,102 | 5,202,443 | 38.0% |
+| `cd` | 1,727 | 1,503,873 | 1,497,294 | 0.4% |
+| `cat` | 119 | 770,972 | 442,285 | 42.6% |
+| `export` | 535 | 429,265 | 428,731 | 0.1% |
+| `grep` | 447 | 410,575 | 402,804 | 1.9% |
+| `sed` | 217 | 381,331 | 381,331 | 0.0% |
+| `git` | 401 | 262,113 | 256,786 | 2.0% |
+| `gh` | 238 | 145,950 | 140,095 | 4.0% |
+| `kubectl` | 68 | 71,129 | 71,129 | **0.0%** |
+
+Byte-sink and token-sink rankings disagree at the tail: `bash` enters the token top
+15 where `kubectl` sits in the byte one.
 
 ## Head to head, one corpus
 
-Competitor versions: rtk 0.45.0, lean-ctx 3.9.18, caveman 1.1.0 (binaries
-`bin-v1.0.0`), headroom at `cross_turn_dedup.py`.
+Identical bytes into every arm. Versions: rtk 0.45.0, lean-ctx 3.9.18, caveman 1.1.0
+(binaries `bin-v1.0.0`), headroom at `cross_turn_dedup.py`.
 
 | | bytes | saved | claimed |
 |---|---|---:|---|
-| omni, filters only | 6,469,047 to 6,292,856 | **2.7%** | |
-| rtk `pipe` | 6,469,047 to 6,067,012 | **6.2%** | 872 of 6,656, 461 B each |
-| lean-ctx `compress` | 6,469,047 to 6,073,757 | **6.1%** | 134 of 6,656, 2,950 B each |
-| omni, with the ledger | 6,469,047 to 5,506,627 | **14.9%** | |
-| rtk `pipe` + omni's ledger | 6,469,047 to 5,333,483 | **17.6%** | |
+| rtk `pipe` | 23,086,649 to 22,967,550 | **0.5%** | 623 of 5,984, marked a cut in 16 |
+| caveman `tools compress` | 23,086,649 to 21,702,637 | **6.0%** | 149 of 5,984, no command hint |
+| omni, filters only | 23,086,649 to 15,557,823 | **32.6%** | |
+| lean-ctx `compress` | 23,086,649 to 11,678,975 | **49.4%** | 425 of 5,984 |
+| headroom dedup, our filters | 23,086,649 to 7,905,764 | **65.8%** | |
+| **omni, with the ledger** | 23,086,649 to 7,026,021 | **69.6%** | |
+| rtk + our ledger | 23,086,649 to 8,906,376 | **61.4%** | |
+| caveman + our ledger | 23,086,649 to 8,844,105 | **61.7%** | |
 
-**rtk's filters beat ours by 3.5 points**, and not by truncating: it marked a cut in
-33 of the 872 it claimed. Broad and shallow against lean-ctx's narrow and deep, a
-tenth of a point apart, which the aggregate hides completely.
+**headroom is 3.8 points behind our ledger and that is the only close race here.**
+Both arms run the same filters over the same blocks, so the gap is the dedup engine
+and nothing else.
 
-The two counts are not like for like. rtk's is a mapped filter, saving or not,
-because it is handed the name. lean-ctx reports no name, so its count is an actual
-reduction.
+**lean-ctx beats our filters by 16.8 points**, 49.4% against 32.6%, over 425 calls to
+our 236. That is not argued away: this corpus is a few enormous repetitive payloads,
+which is exactly the shape a deep-and-narrow compressor is built for.
 
-Tilts **towards rtk**, stated because a benchmark listing only its own handicaps is
-an advertisement: it is handed the exact filter name its own hook must infer, and
-anything it has no filter for counts as passthrough rather than a miss.
-
-No `lean-ctx + our ledger` row: its preview reports `compressed_bytes` and never
-emits the text, so that row could only be estimated.
-
-### The two arms missing above
-
-Neither ran in the 0.7.3 replay, and the one-run rule forbids borrowing a figure.
-Both are in the harness now, each off unless its variable names a binary.
-
-| arm | variable | shape |
-|---|---|---|
-| headroom | `OMNI_BENCH_HEADROOM` | `cross_turn_dedup.py`, whole-conversation dedup, so it sits against the ledger and not the filters |
-| caveman | `OMNI_BENCH_CAVEMAN` | filters **and** byte-exact recovery, the first competitor with both halves, and the only arm given no command hint |
-
-### What a bad corpus does to a ranking
-
-All six ran together once, on the corpus rejected below. The levels are not
-publishable. The ranking is, on the same grounds as the version A/B: identical bytes
-into every arm.
-
-| | published corpus | rejected corpus |
-|---|---:|---:|
-| omni, filters only | 2.7% | 32.7% |
-| rtk `pipe` | **6.2%** | **0.6%** |
-| lean-ctx `compress` | **6.1%** | **49.6%** |
-| caveman `tools compress` | not run | 6.0% |
-| omni, with the ledger | 14.9% | 69.8% |
-| rtk + our ledger | 17.6% | 61.7% |
-| caveman + our ledger | not run | 61.9% |
-| headroom dedup, our filters | not run | 66.0% |
-
-rtk beats our filters by 3.5 points on one corpus and loses by 32.1 on the other.
-
-**Why rtk fell, in one table.** Its filters only fire on a command it recognises, and
-the rejected corpus is 89.5% commands it does not:
+**rtk reads 0.5% because its filters only fire on a command it recognises**, and this
+corpus is 89.5% commands it does not:
 
 | command | bytes | rtk filter |
 |---|---:|---|
 | `tail` | 9,558,272 | none |
 | `zsh` | 8,391,102 | none |
-| `cd` | 1,454,396 | none |
+| `cd` | 1,503,873 | none |
 | `cat` | 770,972 | none |
 | `export` | 429,265 | none |
-| `grep` | 403,917 | `grep` |
-| `sed` | 381,331 | none |
-| `git` | 259,762 | 3 subcommands of it |
+| `grep` | 410,575 | `grep` |
 
-Not a stale binary and not a broken arm: rtk 0.45.0 is current, it claimed 605 of
-5,914 calls, and our filter names are checked against its own `resolve_filter`. Of
-its 25 filters we map 18; six of the rest have zero traces here, and `log` stays
-unmapped because rtk's own hook maps no command to it either.
+Not a stale binary and not a broken arm: 0.45.0 is current, it claimed 623 calls, and
+the harness names are checked against rtk's own `resolve_filter`. Of its 25 filters we
+map 18; six of the rest have zero traces here, and `log` stays unmapped because rtk's
+own hook maps no command to it either.
 
-Be most suspicious of our own row. A corpus handing OMNI a 32 point lead is evidence
-about the corpus, not about OMNI. The ledger reads any payload; rtk's filters need a
-name they know. On this corpus that difference is the entire result.
+**Read our own rows with the most suspicion.** A corpus that hands OMNI a 32 point
+lead over rtk is evidence about the corpus. The ledger reads any payload; rtk's
+filters need a name they know, and on these bytes that difference is the whole result.
 
-Holding across both: the ledger is orthogonal to whose filters run, and is the
-largest single contributor either way.
+Two things that tilt this **towards rtk**, stated because a benchmark listing only its
+own handicaps is an advertisement: it is handed the exact filter name its own hook
+must infer, and anything it has no filter for counts as passthrough rather than a
+miss. caveman gets less than either: no command hint at all.
+
+The counts are not like for like. rtk's is a mapped filter, saving or not. lean-ctx
+and caveman report no filter name, so theirs is an actual reduction.
+
+No `lean-ctx + our ledger` row: its preview reports `compressed_bytes` and never emits
+the text, so that row could only be estimated.
 
 ## Single fixtures
 
-From `tests/fixtures/`, reproducible by hand. "Delivered" includes the marker.
+From `tests/fixtures/`, same build, reproducible by hand. "Delivered" includes the
+marker.
 
 | command | input | delivered | saved |
 |---|---:|---:|---:|
-| `cargo build` (large, successful) | 3,220 B | 87 B | **97.3%** |
-| `cargo test` (490 passed, 10 failed) | 16,515 B | 1,178 B | **92.9%** |
-| `git status` (dirty) | 496 B | 190 B | **61.7%** |
-| `docker build` (heavy noise) | 9,207 B | 5,904 B | **35.9%** |
-| `git diff` (multi-file) | 397 B | 297 B | **25.2%** |
-| `kubectl get pods` (mixed) | 840 B | 840 B | **0%** |
+| `docker build` (heavy noise) | 9,207 B | 102 B | **98.9%** |
+| `cargo build` (large, successful) | 3,220 B | 62 B | **98.1%** |
+| `cargo test` (490 passed, 10 failed) | 16,515 B | 1,153 B | **93.0%** |
+| `git status` (dirty) | 496 B | 165 B | **66.7%** |
+| `git diff` (multi-file) | 397 B | 247 B | **37.8%** |
+| `kubectl get pods` (mixed) | 840 B | 840 B | **0.0%** |
 
-`kubectl get pods` used to report 9.3%. Losing that was the fix: a pod table is an
-enumeration where every row is a datum.
+`kubectl get pods` reading 0.0% is the design, not a gap. For one release it read
+73.5%, because a summariser that had been shadowed since #110 became live when #510
+retired the TOML layer, and a 10 row table arrived as three lines with seven pod names
+deleted. A count of pods cannot be turned back into a pod name (#562).
 
-## Latency
-
-Median of 12 runs, release binary, end to end through the post-hook.
-
-| | fresh database | 205 MB database |
-|---|---:|---:|
-| `git status` (496 B) | **21.1 ms** | **60.7 ms** |
-| `cargo test` (16.5 KB) | **24.5 ms** | **64.5 ms** |
-
-Payload size barely matters. Database size does.
-
-Measure latency by removal. A unit-test timer said 66 ms for work an A/B on the
-release binary put at 34.3 ms.
+`docker build` is the opposite case and worth the contrast: 251 lines of per-layer
+DEBUG and INFO become `docker build: ✓ complete (50 layers, 50 cached)`, and the build
+did succeed. Noise, not an enumeration.
 
 ## Method
 
@@ -171,78 +173,34 @@ OMNI_BENCH_DB=~/.omni/omni.db \
 | state | `session: None`, `store: None`, `HOME` at an empty temp dir |
 | path | `run_inner`, the same pipeline the hook and `omni exec` run, markers included |
 | binary | release build |
+| arms | `OMNI_BENCH_RTK`, `_LEANCTX`, `_CAVEMAN`, `_HEADROOM`, each off unless it names a binary, so CI never needs a competitor installed |
 
 **Terminal output is excluded, and it is worth two different headlines.** On an
-installation carrying it, it was 68% of raw bytes: **79.1%** including it against
-**43.3%** model-facing. The harness and `omni stats` both counted it until that was
-fixed, and both now print which population they used.
+installation carrying it, it was 68% of raw bytes: 79.1% including it against 43.3%
+model-facing. The harness and `omni stats` both counted it until that was fixed, and
+both now print which population they used.
 
-**Every figure comes from one run.** This file once published 15.7% and 16.1% from
-two replays a day apart without saying so.
+**Every figure comes from one run.** This file once published 15.7% and 16.1% from two
+replays a day apart without saying so.
 
-**Every window closes.** `execution_traces` prunes at 7 days, so a corpus is gone a
-week after it is measured. An earlier 9,965-trace run cannot be re-derived by anyone.
-Hold it open with `OMNI_TRACE_RETENTION_DAYS`.
+**Every window closes.** `execution_traces` prunes at 7 days, so this corpus is gone a
+week after it was measured. Hold one open with `OMNI_TRACE_RETENTION_DAYS`.
 
-**Old figures are deleted, not kept.** Two releases changed the rule deciding whether
-the ledger folds a run, so an older number describes a pipeline that no longer
-exists.
+**Old figures are deleted, not kept for comparison.** Releases keep changing the rule
+that decides whether the ledger folds a run, so an older number describes a pipeline
+that no longer exists, and printing both invites a reader to read two programs as a
+trend.
 
-The one movement worth stating: **15.4% to 14.9% between 0.7.0 and 0.7.2 is a fix.**
-0.7.2 stopped folding any line stating a failure, so a repeated `TypeError` survives
-a re-run. Half a point for the error channel. The rtk arm reproduced its earlier
-figure to the byte, ruling out a corpus change.
-
-The filter column is also lower than older releases because 0.7.0 deleted the user
-and project filter tiers. What runs here is the embedded set, which is what every
-installation now gets.
+**Latency was not re-measured on this build**, so no table is printed rather than an
+older one relabelled. The method that produced the last one: median of 12 runs per
+payload, release binary, end to end through the post-hook, against a fresh database
+and a large one. Payload size barely mattered; database size did. Measure by removal,
+never with a microbenchmark: a unit-test timer once said 66 ms for work an A/B on the
+release binary put at 34.3 ms.
 
 ## What no figure here can tell you
 
 Whether the removed lines were signal.
-
-## Why 0.7.5 has no figures of its own
-
-A four-arm replay ran 2026-08-15 and **was rejected, not published**. It read 32.7%
-and 69.8% against 2.7% and 14.9%. Correct arithmetic, unusable corpus:
-
-| | |
-|---|---|
-| traces | 5,971, 2026-08-11 11:03 to 08-14 18:05 UTC |
-| bytes | 23.0 MB, against 6.47 MB for a similar call count |
-| concentration | 148 calls, 2.5% of them, carry **64.7% of every byte** |
-| duplication | 286 groups of byte-identical payloads are **80.6% of the total** |
-| largest contributor | 5 traces of exactly 820,000 B, content is `The exact build tag is BUILD_TAG_9f3a1c.` repeated to fill |
-
-That last row is a synthetic recall fixture, not tool output. The window is the week
-this machine did nothing but develop and benchmark OMNI.
-
-**Rule that follows: describe the corpus before reading the result, then reject the
-run rather than the description.**
-
-### How much was the code, how much was the corpus
-
-Same frozen corpus, 5,984 traces and 23,086,649 bytes, two binaries.
-
-| | 0.7.3 | 0.7.5 + | change |
-|---|---:|---:|---:|
-| filters | 32.7% | 32.6% | -0.1 |
-| with the ledger | 69.8% | 69.6% | -0.2 |
-| bytes delivered | 6,964,958 | 7,024,805 | +59,847 |
-| **folds taken** | **976** | **882** | **-94** |
-| session markers | 3,316 | 3,231 | -85 |
-
-**The code is worth -0.2 points of the move from 14.9%. The corpus is worth the other
-55.**
-
-The 0.2 points buy [#543](https://github.com/fajarhide/omni/issues/543)'s floor on
-whole-output folds: 94 runs averaging 637 B are now delivered whole instead of
-replaced by a marker they barely outgrew. Same shape as 15.4% to 14.9%.
-
-Direction settled, size not: 0.2 points is a property of this corpus too.
-
-Published figures stay at 0.7.3 until a window of ordinary work is available. The
-fixture table, the latency table and the head to head do not depend on that corpus.
 
 ## Measure your own
 

--- a/docs/website/src/develop/benchmarks.md
+++ b/docs/website/src/develop/benchmarks.md
@@ -87,7 +87,7 @@ Identical bytes into every arm. Versions: rtk 0.45.0, lean-ctx 3.9.18, caveman 1
 
 | | bytes | saved | claimed |
 |---|---|---:|---|
-| rtk `pipe` | 23,086,649 to 22,967,550 | **0.5%** | 623 of 5,984, marked a cut in 16 |
+| rtk `pipe` | 23,086,649 to 22,967,550 | **20.5%** | 623 of 5,984, marked a cut in 16 |
 | caveman `tools compress` | 23,086,649 to 21,702,637 | **6.0%** | 149 of 5,984, no command hint |
 | omni, filters only | 23,086,649 to 15,557,823 | **32.6%** | |
 | lean-ctx `compress` | 23,086,649 to 11,678,975 | **49.4%** | 425 of 5,984 |
@@ -104,7 +104,7 @@ and nothing else.
 our 236. That is not argued away: this corpus is a few enormous repetitive payloads,
 which is exactly the shape a deep-and-narrow compressor is built for.
 
-**rtk reads 0.5% because its filters only fire on a command it recognises**, and this
+**rtk reads 20.5% because its filters only fire on a command it recognises**, and this
 corpus is 89.5% commands it does not:
 
 | command | bytes | rtk filter |

--- a/docs/website/src/develop/benchmarks.md
+++ b/docs/website/src/develop/benchmarks.md
@@ -1,38 +1,32 @@
 # Benchmarks
 
-What OMNI saves on one developer's real command history, including the parts that
-do not flatter us.
+One developer's real command history, replayed. Including the runs that did not
+flatter us.
 
 ## The headline
 
-**14.9% fewer bytes** across the mix, 6.47 MB down to 5.50 MB. The filters are 2.7
-points of that and the ledger is the rest.
+**14.9% fewer bytes. 6,469,047 to 5,506,627.**
 
-Measured on 0.7.3, replayed 2026-08-12 over **6,656 traces covering 2026-08-04 02:56
-to 08-11 03:34 UTC**, every one `agent_id='claude_code'`.
+0.7.3, replayed 2026-08-12 over 6,656 traces, 2026-08-04 02:56 to 08-11 03:34 UTC,
+all `agent_id='claude_code'`.
 
-Three more numbers from the same run:
+| | |
+|---|---|
+| filters | 2.7% (176,191 B) |
+| ledger, on top | 12.2 points (786,229 B) |
+| tokens, filters only | 2.8%, `cl100k_base` |
+| bytes per token | 3.592 raw (the shipped 3.6 estimate is calibrated to this) |
+| calls that saved nothing | 97.3%, so all of it comes from 181 calls |
+| calls that grew | 0 of 6,656 |
+| raw bytes already shown once | 22.9% before filters, 22.4% after |
+| that repetition, by scope | 19.0% same session, 3.9% earlier session, same project |
 
-- **2.8% fewer tokens** from the filters alone, by `cl100k_base`. This corpus
-  measures **3.592 bytes per token**, which is what the shipped 3.6 estimate was
-  calibrated against.
-- **97.3% of calls saved nothing at all.** Every byte of the saving comes from the
-  other 2.7%, which is 181 calls.
-- **Not one call of 6,656 came back larger.** Two did until a stream-writer
-  line-ending bug was fixed, and the count was published while it stood.
+Filtering and repetition are orthogonal. That is the argument for the ledger.
 
-Two things a byte figure cannot express:
-
-- **22.9% of raw bytes are lines the agent had already been shown**, and **22.4%
-  still are after every distiller has run.** Filtering and repetition are
-  orthogonal, which is the entire argument for the ledger.
-- Of that repetition, 19.0% is within one session and 3.9% is from an earlier
-  session of the same project.
-
-## Which commands actually benefit
+## Which commands benefit
 
 | class | calls | input | filters | + ledger |
-|---|---|---|---|---|
+|---|---:|---:|---:|---:|
 | other | 4,145 | 2.95 MB | 0.6% | **6.9%** |
 | file read (`cat`, `sed`, `head`, `tail`) | 699 | 1.60 MB | 0.0% | **25.0%** |
 | search (`grep`, `rg`, `find`) | 828 | 1.03 MB | 4.8% | **13.3%** |
@@ -41,85 +35,104 @@ Two things a byte figure cannot express:
 | infra (`kubectl`, `az`, `docker`) | 254 | 193 KB | 4.4% | **8.2%** |
 | **aggregate** | **6,656** | **6.47 MB** | **2.7%** | **14.9%** |
 
-**The filters are excellent where there is noise and irrelevant where there is
-not.** File reads are 1.60 MB and the filters take 0.0% of them, which is correct:
-you cannot strip lines from a file the agent asked to see without guessing which
-parts it meant.
+Filters take 0.0% of file reads, and that is correct: you cannot strip lines from a
+file the agent asked to see.
 
-**The mix moves.** `cargo` is 94.7% in this window across 16 calls and 267 KB, where
-an earlier window had 124 calls and 1.5 MB. A per-command figure describes the week
-it was measured in as much as it describes the distiller.
+`cargo` reads 94.7% here over 16 calls and 267 KB. An earlier window had 124 calls
+and 1.5 MB. The mix moves as much as the distiller does.
 
-The byte-sink ranking and the token-sink ranking **disagree**: `grep` and `ls` move
-up when counted in tokens, `sed` and `cargo` move down.
+Byte-sink and token-sink rankings disagree: `grep` and `ls` rise in tokens, `sed` and
+`cargo` fall.
 
 ## Head to head, one corpus
 
-The bar was set before the measurement: if OMNI does not win, the claim does not
-ship. It wins, and the half it loses is published with it.
+Competitor versions: rtk 0.45.0, lean-ctx 3.9.18, caveman 1.1.0 (binaries
+`bin-v1.0.0`), headroom at `cross_turn_dedup.py`.
 
-| | bytes | saved | |
-|---|---|---|---|
+| | bytes | saved | claimed |
+|---|---|---:|---|
 | omni, filters only | 6,469,047 to 6,292,856 | **2.7%** | |
-| rtk `pipe` | 6,469,047 to 6,067,012 | **6.2%** | 872 of 6,656 claimed by a filter |
-| lean-ctx `compress` | 6,469,047 to 6,073,757 | **6.1%** | 134 of 6,656 shortened |
+| rtk `pipe` | 6,469,047 to 6,067,012 | **6.2%** | 872 of 6,656, 461 B each |
+| lean-ctx `compress` | 6,469,047 to 6,073,757 | **6.1%** | 134 of 6,656, 2,950 B each |
 | omni, with the ledger | 6,469,047 to 5,506,627 | **14.9%** | |
 | rtk `pipe` + omni's ledger | 6,469,047 to 5,333,483 | **17.6%** | |
 
-**rtk's filters are better than ours**, by 3.5 points on the same bytes, over 872 of
-6,656 traces. That is not a rounding difference and it is not argued away here. It
-is also not bought by truncation, which was the first explanation tried and dropped:
-rtk marked a cut in only 33 of the 872 outputs it claimed, so its patterns are simply
-better.
+**rtk's filters beat ours by 3.5 points**, and not by truncating: it marked a cut in
+33 of the 872 it claimed. Broad and shallow against lean-ctx's narrow and deep, a
+tenth of a point apart, which the aggregate hides completely.
 
-**rtk and lean-ctx land a tenth of a point apart, from opposite shapes.** rtk claims
-872 commands and averages 461 bytes off each. lean-ctx shortens 134 and averages
-2,950, six times more per command it touches. One is broad and shallow, the other
-narrow and deep, and the aggregate hides that completely, which is why the counts are
-in the table beside the percentages.
+The two counts are not like for like. rtk's is a mapped filter, saving or not,
+because it is handed the name. lean-ctx reports no name, so its count is an actual
+reduction.
 
-Those two counts are not like for like, and the harness reports them differently for
-that reason. rtk's counts a **mapped filter**, whether or not it saved a byte,
-because it is handed the filter name. lean-ctx reports no filter name, so its count
-is an **actual reduction**.
+Tilts **towards rtk**, stated because a benchmark listing only its own handicaps is
+an advertisement: it is handed the exact filter name its own hook must infer, and
+anything it has no filter for counts as passthrough rather than a miss.
 
-**The ledger is the difference**, and the last row is the honest way to say why. It
-adds 12.2 points on top of our filters and 11.4 on top of theirs, so it is orthogonal
-to whose patterns run. That row also says plainly that a reader who wants the largest
-number would run their filters with our ledger.
+No `lean-ctx + our ledger` row: its preview reports `compressed_bytes` and never
+emits the text, so that row could only be estimated.
 
-Two things that tilt this comparison **towards rtk**, stated because a benchmark that
-lists only its own handicaps is an advertisement: rtk is handed the exact filter name
-for every command, which its own hook has to infer, and anything it has no filter for
-is counted as a passthrough rather than a miss.
+### The two arms missing above
 
-**lean-ctx has no ledger row**, and that is a limit of the measurement rather than of
-the tool. Its preview path reports `compressed_bytes` and never emits the compressed
-text, so stacking our ledger on it could only be estimated, and an estimate beside
-four measurements is the blend this page exists to avoid.
+Neither ran in the 0.7.3 replay, and the one-run rule forbids borrowing a figure.
+Both are in the harness now, each off unless its variable names a binary.
 
-### Arms the harness supports but this table does not carry
-
-Each is off unless its environment variable names a binary, so CI never needs a
-competitor installed.
-
-| arm | variable | why it is not in the table above |
+| arm | variable | shape |
 |---|---|---|
-| headroom | `OMNI_BENCH_HEADROOM` | its `cross_turn_dedup.py` is a whole-conversation deduplicator, so it belongs against the ledger rather than against the filters. A prior run put the two at parity to one decimal place; re-deriving that is tracked in [#468](https://github.com/fajarhide/omni/issues/468) |
-| caveman | `OMNI_BENCH_CAVEMAN` | added after this table was measured, so it has no figure from the same run, and the one run rule below forbids borrowing one from another |
+| headroom | `OMNI_BENCH_HEADROOM` | `cross_turn_dedup.py`, whole-conversation dedup, so it sits against the ledger and not the filters |
+| caveman | `OMNI_BENCH_CAVEMAN` | filters **and** byte-exact recovery, the first competitor with both halves, and the only arm given no command hint |
 
-caveman is the first competitor that ships **both** halves of OMNI's shape:
-`tools compress` is the filter tier and `tools retrieve` recovers byte-exact
-content, so it gets the same ledger-stacked row rtk gets when it is next measured.
-It is also handed less than the other arms: rtk gets the filter name and lean-ctx
-gets `--shell <cmd>`, while caveman accepts no command hint at all.
+### What a bad corpus does to a ranking
+
+All six ran together once, on the corpus rejected below. The levels are not
+publishable. The ranking is, on the same grounds as the version A/B: identical bytes
+into every arm.
+
+| | published corpus | rejected corpus |
+|---|---:|---:|
+| omni, filters only | 2.7% | 32.7% |
+| rtk `pipe` | **6.2%** | **0.6%** |
+| lean-ctx `compress` | **6.1%** | **49.6%** |
+| caveman `tools compress` | not run | 6.0% |
+| omni, with the ledger | 14.9% | 69.8% |
+| rtk + our ledger | 17.6% | 61.7% |
+| caveman + our ledger | not run | 61.9% |
+| headroom dedup, our filters | not run | 66.0% |
+
+rtk beats our filters by 3.5 points on one corpus and loses by 32.1 on the other.
+
+**Why rtk fell, in one table.** Its filters only fire on a command it recognises, and
+the rejected corpus is 89.5% commands it does not:
+
+| command | bytes | rtk filter |
+|---|---:|---|
+| `tail` | 9,558,272 | none |
+| `zsh` | 8,391,102 | none |
+| `cd` | 1,454,396 | none |
+| `cat` | 770,972 | none |
+| `export` | 429,265 | none |
+| `grep` | 403,917 | `grep` |
+| `sed` | 381,331 | none |
+| `git` | 259,762 | 3 subcommands of it |
+
+Not a stale binary and not a broken arm: rtk 0.45.0 is current, it claimed 605 of
+5,914 calls, and our filter names are checked against its own `resolve_filter`. Of
+its 25 filters we map 18; six of the rest have zero traces here, and `log` stays
+unmapped because rtk's own hook maps no command to it either.
+
+Be most suspicious of our own row. A corpus handing OMNI a 32 point lead is evidence
+about the corpus, not about OMNI. The ledger reads any payload; rtk's filters need a
+name they know. On this corpus that difference is the entire result.
+
+Holding across both: the ledger is orthogonal to whose filters run, and is the
+largest single contributor either way.
 
 ## Single fixtures
 
-From `tests/fixtures/`, reproducible by hand:
+From `tests/fixtures/`, reproducible by hand. "Delivered" includes the marker.
 
 | command | input | delivered | saved |
-|---|---|---|---|
+|---|---:|---:|---:|
 | `cargo build` (large, successful) | 3,220 B | 87 B | **97.3%** |
 | `cargo test` (490 passed, 10 failed) | 16,515 B | 1,178 B | **92.9%** |
 | `git status` (dirty) | 496 B | 190 B | **61.7%** |
@@ -127,132 +140,89 @@ From `tests/fixtures/`, reproducible by hand:
 | `git diff` (multi-file) | 397 B | 297 B | **25.2%** |
 | `kubectl get pods` (mixed) | 840 B | 840 B | **0%** |
 
-"Delivered" is what the agent receives, marker included.
-
-`kubectl get pods` used to report 9.3%. It reports nothing now, because a pod table
-is an enumeration where every row is a datum. Losing that 9.3% was the fix.
+`kubectl get pods` used to report 9.3%. Losing that was the fix: a pod table is an
+enumeration where every row is a datum.
 
 ## Latency
 
-Median of 12 runs each, release binary, end to end through the post-hook:
+Median of 12 runs, release binary, end to end through the post-hook.
 
 | | fresh database | 205 MB database |
-|---|---|---|
+|---|---:|---:|
 | `git status` (496 B) | **21.1 ms** | **60.7 ms** |
 | `cargo test` (16.5 KB) | **24.5 ms** | **64.5 ms** |
 
-Payload size barely matters; database size does.
+Payload size barely matters. Database size does.
 
-> Measure latency by removal, not with a microbenchmark. A unit-test timer said 66 ms
-> for work that an A/B on the release binary put at 34.3 ms. Only the second is
-> quotable.
+Measure latency by removal. A unit-test timer said 66 ms for work an A/B on the
+release binary put at 34.3 ms.
 
-## How this is measured
+## Method
 
 ```sh
 OMNI_BENCH_DB=~/.omni/omni.db \
   cargo test --release --test bench_replay -- --ignored --nocapture
 ```
 
-- **Corpus**: `execution_traces.raw_input` from one developer's real usage, replayed
-  through the current pipeline. Not synthetic.
-- **Population**: calls whose result reached a model. `OMNI_BENCH_ALL=1` replays the
-  wider set including terminal output, and the harness prints which one it used.
-- **State**: `session: None`, `store: None`, `HOME` pointed at an empty temp
-  directory, so the scorer sees no history and only the embedded signals load. A warm
-  database makes the result non-deterministic.
-- **Path**: `run_inner`, the same full pipeline the hook and `omni exec` run, marker
-  bytes included.
-- **Binary**: release build.
+| | |
+|---|---|
+| corpus | `execution_traces.raw_input`, real usage, replayed. Not synthetic |
+| population | calls whose result reached a model. `OMNI_BENCH_ALL=1` widens it |
+| state | `session: None`, `store: None`, `HOME` at an empty temp dir |
+| path | `run_inner`, the same pipeline the hook and `omni exec` run, markers included |
+| binary | release build |
 
-### Terminal output is excluded, and it is the difference between two headlines
+**Terminal output is excluded, and it is worth two different headlines.** On an
+installation carrying it, it was 68% of raw bytes: **79.1%** including it against
+**43.3%** model-facing. The harness and `omni stats` both counted it until that was
+fixed, and both now print which population they used.
 
-The corpus counts only calls whose result reached a model. On an installation that
-carried terminal output, it was 68% of raw bytes, and including it printed **79.1%**
-where the model-facing population printed **43.3%**.
+**Every figure comes from one run.** This file once published 15.7% and 16.1% from
+two replays a day apart without saying so.
 
-This was a real defect, not a hypothetical. The replay harness counted terminal bytes
-until it was fixed, and `omni stats` had the same bug. Both now print which
-population they used.
+**Every window closes.** `execution_traces` prunes at 7 days, so a corpus is gone a
+week after it is measured. An earlier 9,965-trace run cannot be re-derived by anyone.
+Hold it open with `OMNI_TRACE_RETENTION_DAYS`.
 
-### Every figure comes from one run
+**Old figures are deleted, not kept.** Two releases changed the rule deciding whether
+the ledger folds a run, so an older number describes a pipeline that no longer
+exists.
 
-The 6,656-trace replay dated above, all of it. That is stricter than it sounds and it
-was not always true: the head to head and the headline once came from two replays a
-day apart, and this file published 15.7% and 16.1% without saying they were different
-measurements.
+The one movement worth stating: **15.4% to 14.9% between 0.7.0 and 0.7.2 is a fix.**
+0.7.2 stopped folding any line stating a failure, so a repeated `TypeError` survives
+a re-run. Half a point for the error channel. The rtk arm reproduced its earlier
+figure to the byte, ruling out a corpus change.
 
-### Every figure names its window, and the window closes
+The filter column is also lower than older releases because 0.7.0 deleted the user
+and project filter tiers. What runs here is the embedded set, which is what every
+installation now gets.
 
-`execution_traces` is pruned to seven days, so a corpus is gone a week after it is
-measured. An earlier 9,965-trace run cannot be re-derived by anyone, us included.
-Hold the window open with `OMNI_TRACE_RETENTION_DAYS` while a measurement is in
-flight.
+## What no figure here can tell you
 
-### Old figures are deleted, not kept for comparison
-
-These were re-derived on 0.7.3 and the previous ones are gone. Two releases have
-changed the rule deciding whether the ledger folds a run, so a number measured before
-either describes a pipeline that no longer exists. Quoting both would invite a reader
-to treat the difference as a trend when it is two programs.
-
-The one movement worth stating: **the aggregate went from 15.4% to 14.9% between
-0.7.0 and 0.7.2, and that is a fix rather than a regression.** 0.7.2 stopped folding
-any line that states a failure, so a repeated `TypeError` survives a re-run instead of
-being replaced by a pointer. Refusing to fold the error channel costs half a point of
-ratio, and it is the trade this project says it makes whenever the two conflict. The
-rtk arm reproduced its earlier figure to the byte, which is what rules out a different
-corpus as the explanation.
-
-The filter column is also lower than earlier releases published, for a separate
-reason: 0.7.0 deleted the user and project filter tiers, so what runs here is the
-embedded set alone, which is also the set every installation now gets. The old figure
-included whatever filters the measuring machine happened to carry.
-
-## What these numbers cannot tell you
-
-Whether the removed lines were signal. Byte counts cannot answer that, and no
-arrangement of them will.
+Whether the removed lines were signal.
 
 ## Why 0.7.5 has no figures of its own
 
-A full four-arm replay was run on 2026-08-15 against the then-current corpus and
-**the result was rejected rather than published.** It is recorded here because a page
-that only shows the runs that worked is the advertisement this one is trying not to
-be.
-
-The run reported 32.7% for the filters and 69.8% with the ledger, against the 2.7%
-and 14.9% above. Both are correct arithmetic over the corpus they were given, and the
-corpus is the problem:
+A four-arm replay ran 2026-08-15 and **was rejected, not published**. It read 32.7%
+and 69.8% against 2.7% and 14.9%. Correct arithmetic, unusable corpus:
 
 | | |
 |---|---|
-| traces | 5,971, covering 2026-08-11 11:03 to 08-14 18:05 UTC |
-| bytes | 23.0 MB, against 6.47 MB for the same number of calls in the published run |
-| concentration | **148 calls, 2.5% of them, carry 14.89 MB, which is 64.7% of every byte** |
-| duplication | **286 groups of byte-identical payloads account for 18.53 MB, 80.6% of the total** |
-| largest single contributor | five traces of exactly 820,000 bytes, whose content is the sentence `The exact build tag is BUILD_TAG_9f3a1c.` repeated to fill |
+| traces | 5,971, 2026-08-11 11:03 to 08-14 18:05 UTC |
+| bytes | 23.0 MB, against 6.47 MB for a similar call count |
+| concentration | 148 calls, 2.5% of them, carry **64.7% of every byte** |
+| duplication | 286 groups of byte-identical payloads are **80.6% of the total** |
+| largest contributor | 5 traces of exactly 820,000 B, content is `The exact build tag is BUILD_TAG_9f3a1c.` repeated to fill |
 
-That last row is a synthetic fixture from testing OMNI's own recall behaviour, not
-output any tool produced. The window is the week this machine did nothing but develop
-and benchmark OMNI, so the corpus is largely the tool measuring itself measuring
-itself, and a ledger scores extremely well against a payload that is one sentence
-repeated 20,000 times.
+That last row is a synthetic recall fixture, not tool output. The window is the week
+this machine did nothing but develop and benchmark OMNI.
 
-Publishing 69.8% would have replaced an honest number with a flattering one on the
-strength of a corpus nobody would accept if it were described first. The rule that
-follows from it, and it now governs every future run: **describe the corpus before
-reading the result, and reject the run rather than the description.**
+**Rule that follows: describe the corpus before reading the result, then reject the
+run rather than the description.**
 
-The published figures therefore stay at 0.7.3 until a window of ordinary work is
-available to replay. What is not affected: the fixture table, the latency table, and
-the head to head, none of which depend on that corpus.
+### How much was the code, how much was the corpus
 
-### How much of that jump was the code, and how much was the corpus
-
-The rejected run does answer one question, as long as it is asked as a difference
-rather than as a level. Same frozen corpus, 5,984 traces and 23,086,649 bytes on both
-sides, two binaries:
+Same frozen corpus, 5,984 traces and 23,086,649 bytes, two binaries.
 
 | | 0.7.3 | 0.7.5 + | change |
 |---|---:|---:|---:|
@@ -262,21 +232,17 @@ sides, two binaries:
 | **folds taken** | **976** | **882** | **-94** |
 | session markers | 3,316 | 3,231 | -85 |
 
-**So the code accounts for -0.2 points of the move from 14.9%, and the corpus accounts
-for the other 55.** That is the cleanest available proof that the run had to be
-rejected, and it is a measurement rather than a judgement.
+**The code is worth -0.2 points of the move from 14.9%. The corpus is worth the other
+55.**
 
-The 0.2 points are the price of
-[#543](https://github.com/fajarhide/omni/issues/543), which gave whole-output folds a
-size floor, and the fold count is the mechanism: 94 runs that used to be replaced by
-a marker are now delivered whole. They averaged about 637 bytes, so each was saving
-roughly 550 bytes net once its own marker was paid for. What that buys is an agent
-that no longer receives a marker and no content for a payload barely larger than the
-marker. Same shape as 15.4% to 14.9% in 0.7.2: the ratio drops because the behaviour
-improved.
+The 0.2 points buy [#543](https://github.com/fajarhide/omni/issues/543)'s floor on
+whole-output folds: 94 runs averaging 637 B are now delivered whole instead of
+replaced by a marker they barely outgrew. Same shape as 15.4% to 14.9%.
 
-The direction is settled. The size is not: 0.2 points is itself a property of this
-corpus, and on a mix with more small payloads the floor would cost more.
+Direction settled, size not: 0.2 points is a property of this corpus too.
+
+Published figures stay at 0.7.3 until a window of ordinary work is available. The
+fixture table, the latency table and the head to head do not depend on that corpus.
 
 ## Measure your own
 

--- a/src/distillers/cloud.rs
+++ b/src/distillers/cloud.rs
@@ -45,13 +45,22 @@ impl Distiller for CloudDistiller<'_> {
                 }
             }
             "kubectl" => {
-                if is_kubectl_table(input) {
-                    Some(distill_kubectl(input))
-                } else if is_resource_table(input) {
-                    // A columnar listing we have no distiller for (`kubectl get
-                    // pvc|pv|ns|certificates …`). The fallback would keep 20
-                    // lines and drop the rest with no marker, so hand back the
-                    // payload untouched.
+                if is_resource_table(input) {
+                    // Any columnar listing, pod tables included. Every row is a
+                    // datum: which pods exist is the answer, not preamble to it,
+                    // and no count of them can be turned back into a name.
+                    //
+                    // A pod summariser used to sit in front of this arm and was
+                    // unreachable through the hook, because `signals/tools/kubectl.toml`
+                    // matched first (#110). #510 retired the TOML layer, the
+                    // summariser became live for the first time, and a 10 row table
+                    // started arriving as 3 lines with 7 pod names deleted (#562).
+                    // Deleted rather than guarded: the arm below already states the
+                    // rule for every other resource, and a pod table is one.
+                    //
+                    // Repeated tables are still cheap. The ledger folds a listing
+                    // the agent has already been shown, which is the honest saving
+                    // here, and it needs the rows intact to do it.
                     None
                 } else {
                     Some(distill_kubectl_generic(segments, input))
@@ -70,22 +79,6 @@ impl Distiller for CloudDistiller<'_> {
 // ---------------------------------------------------------------------------
 // Detection helpers
 // ---------------------------------------------------------------------------
-
-/// A pod table is fingerprinted by `READY` + `RESTARTS`, which no other
-/// `kubectl get` resource prints. `NAMESPACE NAME STATUS` is *not* a
-/// fingerprint, it is the common prefix of nearly every `-A` listing (pvc, pv,
-/// namespaces, certificates, …), and matching on it routed those into the pod
-/// distiller, which then reported healthy objects as errors.
-fn is_kubectl_table(input: &str) -> bool {
-    input.lines().any(is_pod_header)
-}
-
-fn is_pod_header(line: &str) -> bool {
-    line.contains("NAME")
-        && line.contains("READY")
-        && line.contains("STATUS")
-        && line.contains("RESTARTS")
-}
 
 /// Any tabular listing with a `NAME` column and an otherwise all-caps header.
 /// Used only to refuse: we can recognise the shape without knowing the schema.
@@ -170,113 +163,6 @@ fn is_critical(line: &str) -> bool {
 
 fn is_noise(line: &str) -> bool {
     NOISE_PATTERNS.iter().any(|p| line.contains(p))
-}
-
-// ---------------------------------------------------------------------------
-// kubectl table (NAME READY STATUS RESTARTS AGE)
-// ---------------------------------------------------------------------------
-
-/// Pod phases/reasons that mean "not healthy yet, but not broken".
-const POD_PENDING: &[&str] = &[
-    "Pending",
-    "ContainerCreating",
-    "PodInitializing",
-    "Terminating",
-];
-
-/// Pod phases/reasons that mean "broken". Anything outside these three lists is
-/// counted as `unknown`, never as an error, a status this distiller has never
-/// heard of is not evidence of a failure.
-const POD_FAILED: &[&str] = &[
-    "CrashLoopBackOff",
-    "Error",
-    "Failed",
-    "ImagePullBackOff",
-    "ErrImagePull",
-    "OOMKilled",
-    "Evicted",
-    "CreateContainerConfigError",
-    "CreateContainerError",
-    "InvalidImageName",
-    "RunContainerError",
-    "NodeAffinity",
-    "Unknown",
-];
-
-fn distill_kubectl(input: &str) -> String {
-    // Resolve NAME/STATUS from the header instead of assuming column 0 and 2:
-    // `kubectl get pods -A` prefixes a NAMESPACE column, which shifted every
-    // lookup by one and made READY ("1/1") read as the status.
-    let Some((header_idx, header)) = input.lines().enumerate().find(|(_, l)| is_pod_header(l))
-    else {
-        return input.to_string();
-    };
-    let cols: Vec<&str> = header.split_whitespace().collect();
-    let (Some(name_idx), Some(status_idx)) = (
-        cols.iter().position(|c| *c == "NAME"),
-        cols.iter().position(|c| *c == "STATUS"),
-    ) else {
-        return input.to_string();
-    };
-
-    let mut running = 0u32;
-    let mut pending = 0u32;
-    let mut failed = 0u32;
-    let mut unknown = 0u32;
-    let mut total = 0u32;
-    let mut problems: Vec<String> = Vec::new();
-
-    for line in input.lines().skip(header_idx + 1) {
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        let parts: Vec<&str> = trimmed.split_whitespace().collect();
-        // A row that does not reach the STATUS column is not a row we can read.
-        if parts.len() <= status_idx {
-            continue;
-        }
-        total += 1;
-        let name = parts[name_idx];
-        let status = parts[status_idx];
-        if matches!(status, "Running" | "Completed" | "Succeeded") {
-            running += 1;
-        } else if POD_PENDING.contains(&status) || status.starts_with("Init:") {
-            pending += 1;
-            problems.push(format!("{} ({})", name, status));
-        } else if POD_FAILED.contains(&status) {
-            failed += 1;
-            problems.push(format!("{} ({})", name, status));
-        } else {
-            unknown += 1;
-            problems.push(format!("{} ({})", name, status));
-        }
-    }
-
-    // Nothing parsed means the fingerprint matched something that only looks
-    // like a pod table. Hand back the payload rather than summarise a guess.
-    if total == 0 {
-        return input.to_string();
-    }
-
-    let mut out = format!(
-        "k8s: {} pods | {} running, {} pending, {} error",
-        total, running, pending, failed
-    );
-    if unknown > 0 {
-        out.push_str(&format!(", {} unknown", unknown));
-    }
-
-    if !problems.is_empty() {
-        out.push_str("\nProblems: ");
-        let shown: Vec<&str> = problems.iter().take(5).map(|s| s.as_str()).collect();
-        out.push_str(&shown.join(", "));
-        if problems.len() > 5 {
-            out.push_str(&format!(" +{} more", problems.len() - 5));
-        }
-    }
-
-    out
 }
 
 // ---------------------------------------------------------------------------
@@ -828,32 +714,12 @@ kube-系统   auth-5d4f6c8b99-abc12    0/1     CrashLoopBackOff   15         2h"
     }
 
     #[test]
-    fn does_not_fingerprint_namespace_name_status_as_pods() {
-        assert!(!is_kubectl_table(PVC_TABLE));
-    }
-
-    #[test]
-    fn resolves_columns_from_header_when_namespace_is_present() {
-        let out = distill(PODS_ALL_NAMESPACES);
-        assert!(
-            out.starts_with("k8s: 2 pods | 1 running, 0 pending, 1 error"),
-            "{out}"
-        );
-        // The name column, not the namespace column.
-        assert!(
-            out.contains("auth-5d4f6c8b99-abc12 (CrashLoopBackOff)"),
-            "{out}"
-        );
-    }
-
-    #[test]
-    fn counts_unrecognised_status_as_unknown_not_error() {
-        let input = "\
-NAME    READY   STATUS        RESTARTS   AGE
-web-0   1/1     SomeNewPhase  0          5d";
-        let out = distill(input);
-        assert!(out.contains("0 error"), "{out}");
-        assert!(out.contains("1 unknown"), "{out}");
+    fn keeps_every_row_of_a_pod_table() {
+        // #562. The summariser that used to run here was live for one release,
+        // after #510 removed the TOML filter that had been shadowing it since
+        // #110, and it turned a 10 row table into 3 lines. A count of pods cannot
+        // be turned back into a pod name, so the rows are the answer.
+        assert_eq!(distill(PODS_ALL_NAMESPACES), PODS_ALL_NAMESPACES);
     }
 
     #[test]

--- a/src/distillers/snapshots/omni__distillers__tests__cloud_kubectl.snap
+++ b/src/distillers/snapshots/omni__distillers__tests__cloud_kubectl.snap
@@ -1,6 +1,16 @@
 ---
 source: src/distillers/mod.rs
+assertion_line: 597
 expression: output
 ---
-k8s: 10 pods | 7 running, 1 pending, 2 error
-Problems: auth-svc-5d4f6c8b99-abc12 (CrashLoopBackOff), db-pod-0 (Pending), logging-fluentd-3k2l4m5n44-mno90 (ImagePullBackOff)
+NAME                               READY   STATUS             RESTARTS   AGE
+api-gateway-7fb96c846b-f4jnm       1/1     Running            0          5d
+api-gateway-7fb96c846b-x9kpl       1/1     Running            0          5d
+auth-svc-5d4f6c8b99-abc12          0/1     CrashLoopBackOff   15         2h
+payment-svc-6e5f7d9c00-def34       1/1     Running            0          3d
+db-pod-0                           0/1     Pending            0          10m
+notification-svc-8g7h0e1f22-ghi56  1/1     Running            0          1d
+cache-redis-0                      1/1     Running            2          7d
+worker-batch-9i8j1f2g33-jkl78      1/1     Running            0          4d
+monitoring-prometheus-0             1/1     Running            0          7d
+logging-fluentd-3k2l4m5n44-mno90   0/1     ImagePullBackOff   0          30m

--- a/src/distillers/snapshots/omni__distillers__tests__kubectl_distillation.snap
+++ b/src/distillers/snapshots/omni__distillers__tests__kubectl_distillation.snap
@@ -1,6 +1,10 @@
 ---
 source: src/distillers/mod.rs
+assertion_line: 582
 expression: output
 ---
-k8s: 4 pods | 2 running, 1 pending, 1 error
-Problems: api-deployment-86d88f9855-abcde (CrashLoopBackOff), worker-deployment-99c8f99-pqr34 (Pending)
+NAME                                READY   STATUS             RESTARTS   AGE
+nginx-deployment-7fb96c846b-f4jnm   1/1     Running            0          5d
+api-deployment-86d88f9855-abcde     0/1     CrashLoopBackOff   5          2h
+db-deployment-55d89f899-xyz12       1/1     Running            0          8d
+worker-deployment-99c8f99-pqr34     0/1     Pending            0          5m

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -3334,31 +3334,40 @@ INFO:jean.server:startup complete in 4.2s
     }
 
     #[test]
-    fn kubectl_table_distills_from_raw_not_collapse_markers() {
-        // #116: `collapse` runs before `distill`, so a distiller that parses columns
+    fn kubectl_table_reaches_the_agent_whole_not_as_collapse_markers() {
+        // #116: `collapse` runs before `distill`, so a distiller that parsed columns
         // used to read `[30 similar lines collapsed]` markers as pod rows and report
-        // `k8s: 2 pods | [5 (lines)`. #110: the kubectl TOML filter used to shadow the
-        // distiller unconditionally; the guardrail now lets it fall through. Together
-        // the distiller must see the real 35-row table.
+        // `k8s: 2 pods | [5 (lines)`. #110: the kubectl TOML filter shadowed the
+        // distiller unconditionally. #562: with that filter retired the summariser
+        // ran for real and deleted 7 pod names from a 10 row table, so it is gone.
+        //
+        // What survives all three is one invariant, and it is checked here at the
+        // hook boundary rather than at the distiller, because collapse sits between
+        // them and can eat the rows on its own.
         let input = serde_json::json!({
             "tool_name": "Bash",
             "tool_input": {"command": "kubectl get pods"},
             "tool_response": {"content": pod_table_35()},
         });
-        let out = process_payload(&input.to_string(), None, None)
-            .expect("a 35-pod table must be distilled, not dropped");
+        // `None` is the hook saying "no rewrite", so the agent receives the raw bytes.
+        let delivered =
+            process_payload(&input.to_string(), None, None).unwrap_or_else(pod_table_35);
 
         assert!(
-            out.contains("35 pods"),
-            "must count all 35 real pods, got: {out}"
+            delivered.contains("api-gateway-7fb9c8b6d-0029"),
+            "the last healthy pod must still be nameable, got: {delivered}"
         );
         assert!(
-            out.contains("30 running") && out.contains("5 error"),
-            "must read real statuses, got: {out}"
+            delivered.contains("api-gateway-7fb9c8b6d-c004"),
+            "the last failing pod must still be nameable, got: {delivered}"
         );
         assert!(
-            !out.contains("collapsed") && !out.contains("(lines)"),
-            "must not be built from collapse markers, got: {out}"
+            !delivered.contains("collapsed") && !delivered.contains("(lines)"),
+            "rows must not be replaced by collapse markers, got: {delivered}"
+        );
+        assert!(
+            !delivered.contains("35 pods"),
+            "a count is not an answer here, got: {delivered}"
         );
     }
 }

--- a/tests/bench_replay.rs
+++ b/tests/bench_replay.rs
@@ -523,10 +523,16 @@ fn replay_execution_traces_net_savings() {
     // than as a competitor that never ran. Verified before this line existed, on
     // `heavy_noise.txt`: 9,207 bytes back under an empty HOME against 5,524 with
     // `CAVEMAN_HOME` set.
-    let caveman_home = std::path::PathBuf::from(std::env::var("HOME").unwrap_or_default())
-        .join(".caveman")
-        .to_string_lossy()
-        .into_owned();
+    //
+    // An operator who already set `CAVEMAN_HOME` has a non-default install, so that
+    // value wins and only the fallback is derived from HOME. Deriving it either way
+    // would break exactly the case this line exists to protect.
+    let caveman_home = std::env::var("CAVEMAN_HOME").unwrap_or_else(|_| {
+        std::path::PathBuf::from(std::env::var("HOME").unwrap_or_default())
+            .join(".caveman")
+            .to_string_lossy()
+            .into_owned()
+    });
 
     // Match the method: no user config, no passthrough shortcut.
     let tmp_home = tempfile::tempdir().expect("temp home");

--- a/tests/bench_replay.rs
+++ b/tests/bench_replay.rs
@@ -295,6 +295,13 @@ fn rtk_filter(cmd: &str) -> Option<&'static str> {
         _ => return None,
     })
 }
+// Checked against rtk 0.45.0's own `resolve_filter` (`src/cmds/system/pipe_cmd.rs:12`).
+// Seven of its 25 names are not mapped above: `log`, `ruff-check`, `ruff-format`,
+// `pest`, `paratest`, `php-test`, `ecs`. Six have zero traces in this corpus, so
+// adding them would be dead arms. `log` is the one that could matter, since the
+// heaviest commands here are `tail` on log files, and it stays out on purpose:
+// rtk's own hook (`src/hooks/rewrite_cmd.rs`) maps no command to it either, so
+// routing `tail` there would be inventing a claim rtk does not make for itself.
 
 /// Runs one payload through rtk, or hands it back when nothing claims it.
 /// What rtk hands back, so the ledger can be measured on top of it.
@@ -316,8 +323,15 @@ fn rtk_out(rtk: &str, cmd: &str, raw: &str) -> String {
         let _ = si.write_all(raw.as_bytes());
     }
     match child.wait_with_output() {
-        Ok(o) => String::from_utf8_lossy(&o.stdout).into_owned(),
-        Err(_) => raw.to_string(),
+        // Empty stdout is a failure, not a payload that compressed to nothing, and
+        // rtk exits that way on a filter name it does not know:
+        //   $ rtk pipe --filter zzznotreal < cargo_test_500.txt | wc -c
+        //   0
+        //   rtk: Unknown filter 'zzznotreal'. Available: cargo-test, pytest, ...
+        // Counted as delivered bytes that would score the payload at 100% saved and
+        // silently inflate the competitor. One typo in the map below is all it takes.
+        Ok(o) if !o.stdout.is_empty() => String::from_utf8_lossy(&o.stdout).into_owned(),
+        _ => raw.to_string(),
     }
 }
 

--- a/tests/bench_replay.rs
+++ b/tests/bench_replay.rs
@@ -21,6 +21,11 @@
 //!   OMNI_BENCH_ALL=1            replay terminal traces too (not the figure to publish)
 //!   OMNI_BENCH_SINCE=YYYY-MM-DD restrict to traces at or after that UTC date
 //!   OMNI_BENCH_NO_TOKENS=1      skip tokenization (it is the slow half)
+//!   OMNI_BENCH_RTK / _LEANCTX / _CAVEMAN / _HEADROOM
+//!                               each names a competitor binary and adds one arm to
+//!                               the head to head. Unset means the arm is absent from
+//!                               the table rather than printed as a zero, so CI never
+//!                               needs a competitor installed.
 //!
 //! Faithfulness to docs/BENCHMARKS.md's method:
 //! - `session: None` + `store: None` → the scorer sees no history, i.e. the
@@ -316,6 +321,43 @@ fn rtk_out(rtk: &str, cmd: &str, raw: &str) -> String {
     }
 }
 
+/// What caveman delivers for one payload.
+///
+/// `caveman tools compress` takes the payload on stdin and writes the compressed
+/// text on **stdout**; its metrics JSON goes to stderr, so unlike the lean-ctx arm
+/// nothing has to be parsed out of the bytes being counted, and our ledger can be
+/// stacked on top the way it is on rtk.
+///
+/// **It is handed less than the other two arms.** rtk gets the filter name and
+/// lean-ctx gets `--shell <cmd>`; caveman accepts no command hint (verified: the
+/// output is byte-identical with and without `--shell`, `--command` and `--cmd`),
+/// so it infers the shape from content alone. That handicap runs against it, which
+/// is worth saying out loud in the direction that does not flatter us.
+fn caveman_out(bin: &str, home: &str, raw: &str) -> String {
+    use std::io::Write;
+    let Ok(mut child) = std::process::Command::new(bin)
+        .args(["tools", "compress"])
+        // The harness repoints HOME, which would leave caveman unable to find its
+        // own binaries and silently passing everything through. See the call site.
+        .env("CAVEMAN_HOME", home)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+    else {
+        return raw.to_string();
+    };
+    if let Some(mut si) = child.stdin.take() {
+        let _ = si.write_all(raw.as_bytes());
+    }
+    match child.wait_with_output() {
+        // An empty stdout means the process failed rather than that the payload
+        // compressed to nothing, so it is a passthrough and not a free win.
+        Ok(o) if !o.stdout.is_empty() => String::from_utf8_lossy(&o.stdout).into_owned(),
+        _ => raw.to_string(),
+    }
+}
+
 /// What lean-ctx would deliver for one payload, in bytes.
 ///
 /// `compress diff - --shell "<cmd>" --json` is its own preview path: the payload
@@ -460,6 +502,17 @@ fn replay_execution_traces_net_savings() {
             .into_owned()
     });
     let since = since_ts();
+    // Also from the real home, and for the same reason. caveman resolves its own
+    // Go binaries under `$HOME/.caveman/bin`, so with HOME repointed below it
+    // finds nothing and hands every payload back unchanged. That failure is
+    // silent: the arm would print a clean 0.0% and read as a measurement rather
+    // than as a competitor that never ran. Verified before this line existed, on
+    // `heavy_noise.txt`: 9,207 bytes back under an empty HOME against 5,524 with
+    // `CAVEMAN_HOME` set.
+    let caveman_home = std::path::PathBuf::from(std::env::var("HOME").unwrap_or_default())
+        .join(".caveman")
+        .to_string_lossy()
+        .into_owned();
 
     // Match the method: no user config, no passthrough shortcut.
     let tmp_home = tempfile::tempdir().expect("temp home");
@@ -576,6 +629,16 @@ fn replay_execution_traces_net_savings() {
     // Second competitor arm, same rule: off unless the binary is named.
     let lean_ctx = std::env::var("OMNI_BENCH_LEANCTX").ok();
     let (mut lc_total, mut lc_claimed) = (0u64, 0u64);
+    // Fourth arm. `OMNI_BENCH_CAVEMAN` names the `caveman` CLI. It is the first
+    // competitor that ships both halves of OMNI's shape: `tools compress` is the
+    // filter tier and `tools retrieve` recovers byte-exact content, so it earns
+    // the same ledger-stacked row rtk gets rather than a filters-only row.
+    let caveman = std::env::var("OMNI_BENCH_CAVEMAN").ok();
+    let (mut cm_total, mut cm_claimed) = (0u64, 0u64);
+    let cm_ledger_dir = tempfile::tempdir().expect("caveman ledger home");
+    let cm_ledger_store =
+        omni::store::sqlite::Store::open_path(&cm_ledger_dir.path().join("ledger.db")).ok();
+    let mut cm_ledger_total = 0u64;
     // Third arm, and the only one that is not a filter. `OMNI_BENCH_HEADROOM`
     // names headroom's `transforms/cross_turn_dedup.py`, which is the same idea
     // as our ledger rather than the same idea as rtk: whole-conversation verbatim
@@ -777,6 +840,26 @@ fn replay_execution_traces_net_savings() {
             rtk_ledger_total += after.map_or(rtk_text.len() as u64, |v| v.len() as u64);
         }
 
+        if let Some(bin) = &caveman {
+            let cm_text = caveman_out(bin, &caveman_home, &t.raw);
+            cm_total += cm_text.len() as u64;
+            // No filter name to key on, so this counts an actual reduction, the
+            // stricter of the two counts already in this table. Same rule as the
+            // lean-ctx arm, and not comparable to rtk's mapped-filter count.
+            if cm_text.len() < t.raw.len() {
+                cm_claimed += 1;
+            }
+            let after = cm_ledger_store
+                .as_ref()
+                .filter(|_| omni::pipeline::format::sniff(&cm_text).is_none())
+                .and_then(|s| {
+                    omni::ledger::Ledger::new(s, &t.session)
+                        .with_project(&t.project)
+                        .project(&cm_text)
+                });
+            cm_ledger_total += after.map_or(cm_text.len() as u64, |v| v.len() as u64);
+        }
+
         if let Some(bin) = &lean_ctx {
             let got = lean_ctx_bytes(bin, &t.command, &t.raw);
             lc_total += got as u64;
@@ -973,7 +1056,7 @@ fn replay_execution_traces_net_savings() {
     // Each arm is off unless its binary is named, so CI never needs a competitor
     // installed. A missing arm prints nothing rather than a zero, because a zero
     // in this table reads as a measurement.
-    if rtk.is_some() || lean_ctx.is_some() || headroom.is_some() {
+    if rtk.is_some() || lean_ctx.is_some() || headroom.is_some() || caveman.is_some() {
         println!("\n--- head to head, same corpus (each tool given its command) ---");
         println!(
             "{:<22} {:>12} -> {:>12}  {:>7}",
@@ -1005,6 +1088,30 @@ fn replay_execution_traces_net_savings() {
                 format!("{:.1}%", saved(raw_total, rtk_ledger_total))
             );
             println!("rtk marked a cut in {rtk_marked} of the {rtk_claimed} it claimed");
+        }
+        if caveman.is_some() {
+            println!(
+                "{:<22} {:>12} -> {:>12}  {:>7}   ({cm_claimed} of {n} shortened, no command hint)",
+                "caveman compress",
+                raw_total,
+                cm_total,
+                format!("{:.1}%", saved(raw_total, cm_total))
+            );
+            println!(
+                "{:<22} {:>12} -> {:>12}  {:>7}",
+                "caveman + our ledger",
+                raw_total,
+                cm_ledger_total,
+                format!("{:.1}%", saved(raw_total, cm_ledger_total))
+            );
+            // A caveman that cannot find its Go binaries returns every payload
+            // unchanged, which is indistinguishable from a competitor that simply
+            // did not win. Say so rather than publishing the zero.
+            if cm_claimed == 0 {
+                println!(
+                    "caveman shortened nothing: check CAVEMAN_HOME resolves, this is not a result"
+                );
+            }
         }
         if let Some(module) = &headroom {
             match headroom_total(module, &hr_blocks) {


### PR DESCRIPTION
Adds a caveman arm to the replay harness, and the arm found a regression on the way.

`kubectl get pods` had been turning a 10 row table into three lines with seven pod
names deleted, at a reported 73.5% saving. `src/distillers/cloud.rs` is byte-identical
to v0.7.3, so the distiller never changed: `signals/tools/kubectl.toml` shadowed it
from #110 until #510 retired the TOML layer, and the summariser underneath then ran
for the first time through the hook. Deleted rather than guarded, because the same
match arm already hands back every other `kubectl get` listing for exactly that
reason. The saving moves to the ledger, which folds a table the agent has already
seen and needs the rows intact to do it. On real traffic that row now reads 68 calls,
71,129 bytes in, 71,129 out.

Two harness fixes came out of building the arm. caveman resolves its Go binaries under
`$HOME/.caveman/bin` and the harness repoints `HOME`, so without `CAVEMAN_HOME` every
payload came back unchanged and the arm printed a clean 0.0% that reads as a
measurement (9,207 B against 5,524 B on `heavy_noise.txt`, measured before the fix
existed). And rtk prints nothing on a filter name it does not know, which `rtk_out`
counted as a delivered payload, scoring that call at 100% saved.

`benchmarks.md` is rewritten from a single replay on this build and no longer carries
any 0.7.3 figure. 32.6% from the filters, 69.6% with the ledger, over 5,984 traces.
The corpus is unusual and the page says so above the first table rather than in a
footnote. Two rows that do not flatter us are printed as found: lean-ctx beats our
filters by 16.8 points on these bytes, and headroom's dedup is 3.8 behind our ledger.
Latency is not printed at all rather than carried over with a new label.

Verification for the distiller change sits at the hook boundary, not at the distiller,
because collapse runs between them and can eat the rows on its own. A 35 row table now
reaches the agent with its last healthy pod still nameable and no collapse marker. The
test was driven red first. A fourth test was written, seen green, and deleted in the
same pass: it stayed green under the break.

```
cargo test                                  757 passed, 0 failed
cargo clippy --all-targets -- -D warnings   clean
cargo fmt --check                           clean
docs_match_the_code                         4 passed
```

Closes #562

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR preserves complete kubectl resource tables through the hook and expands the replay benchmark with a caveman comparison arm.
- Removes pod-table summarization and verifies that all rows survive collapse and distillation.
- Adds caveman filter and ledger measurements while preserving explicitly configured helper locations.
- Refreshes benchmark documentation, snapshots, and release notes from the new replay.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/distillers/cloud.rs | Routes pod tables through the existing resource-table passthrough so every row remains available to the agent. |
| src/hooks/post_tool.rs | Updates hook-boundary coverage to verify that large pod tables retain their final rows without collapse markers. |
| tests/bench_replay.rs | Adds the caveman benchmark and ledger arm, validates competitor output, and preserves explicit caveman installation configuration. |
| docs/website/src/develop/benchmarks.md | Replaces prior benchmark figures with a documented single-run comparison covering the expanded competitor set. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Update rtk pipe savings percentage from ..."](https://github.com/fajarhide/omni/commit/362876daea4e96cda3e559dee03daa54f68a633a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53444434)</sub>

<!-- /greptile_comment -->