### PR TITLE
fix(hooks): stop booking a saving when the reply is never sent

### DIFF
--- a/changelog.d/566.fixed.md
+++ b/changelog.d/566.fixed.md
@@ -1,0 +1,21 @@
+- **`omni stats` booked savings on calls where the hook sent nothing, and the
+  all-time figure was 4.5x too high.** `process_payload` returns `None` when the
+  route is a passthrough and nothing was redacted, so the host keeps the bytes it
+  already had, but every byte and token column on the recorded row was computed
+  from the distiller's output before that decision was made. A distiller that cut
+  more than the guardrail's tenth and less than the soft threshold therefore
+  booked a saving the model never received. Found by reconciling `distillations`
+  against the host's own transcripts under `~/.claude/projects`, where the
+  `tool_result` bytes are post-hook and are what the model was actually given: over
+  the 45 sessions holding a transcript, 67 of the 389 rows that booked a saving
+  were this shape, 33,751 bytes of 205,873, and one was verified end to end before
+  anything changed (raw 7,744 B, booked 6,356 B, transcript entry 7,744 B with no
+  marker). `applied_only()` could not separate them, because it gates on
+  `delivered_bytes` and `delivered_bytes` was copied from the same string: it
+  equalled `output_bytes` on all 6,145 `claude_code` rows. Existing rows are
+  corrected once by migration rather than by a `CASE` in each of the six queries
+  that sum those columns, and `execution_traces` still holds what the distiller
+  produced. On the reporting installation these rows carried 93.0% of every byte
+  ever booked as saved: all time went from **37.1% to 8.3%** over an unchanged
+  6,386 commands, which matches the 4% to 15% per command measured independently
+  from `execution_traces`. (#566)

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -2365,23 +2365,26 @@ INFO:jean.server:startup complete in 4.2s
     /// if the hook sent nothing, the row says nothing was saved.
     #[test]
     fn a_dropped_reply_books_no_saving() {
-        // Sized to land between the two gates. Under a tenth cut the guardrail at
-        // `post_tool.rs:815` already restores the raw bytes, and at or above the
-        // soft threshold the reply is really sent, so neither side can catch this.
-        let mut content = String::new();
-        for i in 0..40 {
-            content.push_str(&format!("src/module_{i}.rs: ok\n"));
-        }
-        for i in 0..6 {
-            content.push_str(&format!(
-                "[=================>      ] {i}0% building module_{i}\n"
-            ));
-        }
+        // Taken from a real recorded trace rather than invented, because the
+        // window is narrow and every synthetic fixture tried first missed it: a
+        // cut under a tenth is restored by the guardrail at `post_tool.rs:815`,
+        // and at or above the soft threshold the reply is really sent. This one
+        // measured 424 B in, 346 B out, a ratio of 0.184, sitting between them.
+        // The grep distiller hoists the repeated filename into a header, so the
+        // cut is lossless and genuinely worth having, which is what makes booking
+        // it and then discarding it the wrong pair of decisions.
+        let content = "\
+src/distillers/system_ops.rs:614:    if !is_sensitive_key(key) || value.trim().is_empty() {
+src/distillers/system_ops.rs:688:fn is_sensitive_key(key: &str) -> bool {
+src/distillers/system_ops.rs:728:        // match, so fixing only `is_sensitive_key` would have left `env` output
+src/distillers/system_ops.rs:822:                !is_sensitive_key(key),
+src/distillers/system_ops.rs:849:                is_sensitive_key(key),
+";
 
         let payload = json!({
             "tool_name": "Bash",
-            "tool_input": {"command": "make build"},
-            "tool_response": bash_response(&content),
+            "tool_input": {"command": "grep -rn \"is_sensitive_key\" src/ --include=\"*.rs\" | head -20"},
+            "tool_response": bash_response(content),
         })
         .to_string();
 

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -878,17 +878,25 @@ pub fn process_payload(
         }
     }
 
-    // The reply is dropped at the end of this function whenever the route is a
-    // passthrough and nothing was redacted, so the host keeps the bytes it
-    // already had. Every column below is computed from `final_out`, so leaving a
-    // shrunken string here books a saving nobody received. Reconciled against the
-    // host's own transcripts, that was 67 rows and 16.4% of the bytes booked as
-    // saved on this machine, and `applied_only()` cannot separate them afterwards
-    // because `delivered_bytes` is copied from the same string (#566). This is the
-    // restore the guardrail above already performs, for the same reason.
-    if route == Route::Passthrough && !redacted_here {
-        final_out = content.to_string();
-    }
+    // What the model is actually handed, which is not what the distiller
+    // produced. The reply is dropped at the end of this function whenever the
+    // route is a passthrough and nothing was redacted, so the host keeps the
+    // bytes it already had. Every accounting column used to be computed from
+    // `final_out` regardless, which booked a saving nobody received: reconciled
+    // against the host's own transcripts that was 67 rows and 16.4% of the bytes
+    // booked as saved on this machine, and `applied_only()` cannot separate them
+    // afterwards because `delivered_bytes` is copied from the same string (#566).
+    //
+    // A separate binding rather than overwriting `final_out`, so `record_trace`
+    // below still stores what the distiller produced. Overwriting made
+    // `execution_traces` report raw and distilled as identical strings, which
+    // silently removes the one corpus that can measure distiller behaviour
+    // without going through these books. Caught in review on the first version.
+    let delivered: &str = if route == Route::Passthrough && !redacted_here {
+        &content
+    } else {
+        &final_out
+    };
 
     let latency_ms = start.elapsed().as_millis() as u32;
 
@@ -898,16 +906,16 @@ pub fn process_payload(
     // against GPT's vocabulary rather than Claude's (#283).
     use crate::util::token_estimate::{ContentHint, estimate_tokens};
     let raw_tokens = estimate_tokens(content.len(), ContentHint::Mixed);
-    let filtered_tokens = estimate_tokens(final_out.len(), ContentHint::Mixed);
+    let filtered_tokens = estimate_tokens(delivered.len(), ContentHint::Mixed);
 
     let result = DistillResult {
-        output: final_out.clone(),
+        output: delivered.to_string(),
         route: route.clone(),
         filter_name: filter_name.clone(),
         score: 0.0,
         context_score: 0.0,
         input_bytes: content.len(),
-        output_bytes: final_out.len(),
+        output_bytes: delivered.len(),
         latency_ms: latency_ms as u64,
         rewind_hash: if rewind_hash.is_empty() {
             None
@@ -924,7 +932,7 @@ pub fn process_payload(
         // output above the host's own cap, where the raw output is persisted and
         // the hook's reply dropped, now returns before reaching here, so this
         // is what the model receives (#212).
-        delivered_bytes: final_out.len(),
+        delivered_bytes: delivered.len(),
     };
 
     if let Some(ref s) = store {
@@ -2411,6 +2419,20 @@ src/distillers/system_ops.rs:849:                is_sensitive_key(key),
             assert_eq!(
                 delivered, 0,
                 "the hook sent nothing and the row still reports {delivered} bytes delivered"
+            );
+            // The books say nothing was saved, and the trace still has to say
+            // what the distiller produced. The first version of this fix
+            // overwrote `final_out` before `record_trace` and made the two
+            // columns identical, which silently removes the only corpus that
+            // measures distiller behaviour without going through these books.
+            assert_eq!(
+                count(
+                    &db,
+                    "SELECT COUNT(*) FROM execution_traces \
+                     WHERE LENGTH(distilled_output) < LENGTH(raw_input)",
+                ),
+                1,
+                "the trace lost what the distiller produced"
             );
         } else {
             // The fixture stopped exercising the window. Say so rather than

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -878,6 +878,18 @@ pub fn process_payload(
         }
     }
 
+    // The reply is dropped at the end of this function whenever the route is a
+    // passthrough and nothing was redacted, so the host keeps the bytes it
+    // already had. Every column below is computed from `final_out`, so leaving a
+    // shrunken string here books a saving nobody received. Reconciled against the
+    // host's own transcripts, that was 67 rows and 16.4% of the bytes booked as
+    // saved on this machine, and `applied_only()` cannot separate them afterwards
+    // because `delivered_bytes` is copied from the same string (#566). This is the
+    // restore the guardrail above already performs, for the same reason.
+    if route == Route::Passthrough && !redacted_here {
+        final_out = content.to_string();
+    }
+
     let latency_ms = start.elapsed().as_millis() as u32;
 
     let kept = check_segments.len() - noise_count;
@@ -2337,6 +2349,74 @@ INFO:jean.server:startup complete in 4.2s
             .expect("open recorded db")
             .query_row(sql, [], |r| r.get(0))
             .expect("count")
+    }
+
+    /// #566. `process_payload` returns `None` whenever the route is a passthrough
+    /// and nothing was redacted, so the host keeps the bytes it already had. Every
+    /// column of the row is computed from `final_out`, which meant a distiller that
+    /// cut more than the guardrail's tenth and less than the soft threshold booked
+    /// a saving the model never received. Reconciled against the host's own
+    /// transcripts, that was 67 rows and 16.4% of every byte booked as saved on
+    /// this machine, and `applied_only()` cannot separate them afterwards because
+    /// `delivered_bytes` is copied from the same string.
+    ///
+    /// The assertion is stated over the return value rather than over a route name,
+    /// because the return value is what decides whether the model saw anything:
+    /// if the hook sent nothing, the row says nothing was saved.
+    #[test]
+    fn a_dropped_reply_books_no_saving() {
+        // Sized to land between the two gates. Under a tenth cut the guardrail at
+        // `post_tool.rs:815` already restores the raw bytes, and at or above the
+        // soft threshold the reply is really sent, so neither side can catch this.
+        let mut content = String::new();
+        for i in 0..40 {
+            content.push_str(&format!("src/module_{i}.rs: ok\n"));
+        }
+        for i in 0..6 {
+            content.push_str(&format!(
+                "[=================>      ] {i}0% building module_{i}\n"
+            ));
+        }
+
+        let payload = json!({
+            "tool_name": "Bash",
+            "tool_input": {"command": "make build"},
+            "tool_response": bash_response(&content),
+        })
+        .to_string();
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = dir.path().join("omni.db");
+        let store = Arc::new(Store::open_path(&db).expect("store"));
+
+        let reply = process_payload(&payload, Some(store), None);
+
+        let booked = count(
+            &db,
+            "SELECT COALESCE(SUM(input_bytes - output_bytes), 0) FROM distillations",
+        );
+        let delivered = count(
+            &db,
+            "SELECT COALESCE(SUM(input_bytes - delivered_bytes), 0) FROM distillations",
+        );
+
+        if reply.is_none() {
+            assert_eq!(
+                booked, 0,
+                "the hook sent nothing and the row still books {booked} bytes saved"
+            );
+            assert_eq!(
+                delivered, 0,
+                "the hook sent nothing and the row still reports {delivered} bytes delivered"
+            );
+        } else {
+            // The fixture stopped exercising the window. Say so rather than
+            // passing: a green run here would mean the guard is untested.
+            panic!(
+                "fixture no longer reaches the dropped-reply path, so this test \
+                 proves nothing; retune it against the 0.10 and soft thresholds"
+            );
+        }
     }
 
     /// #271. `README.md:81` promises "everything cut is archived". The gate meant

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -890,6 +890,50 @@ impl SqliteBackend {
             tx.commit()?;
         }
 
+        // #566. The hook sends no reply on the `Passthrough` route, so the host
+        // keeps the bytes it already had, but every byte and token column on the
+        // row was computed from the distiller's output. The row therefore booked a
+        // saving nobody received. Reconciled against the host's own transcripts
+        // that was 16.4% of the bytes booked as saved over the sessions a
+        // transcript exists for; across the whole table these rows are 93.0% of
+        // them, and they are the difference between the 37.1% `omni stats`
+        // published and the 8.3% that is true.
+        //
+        // Corrected in the column rather than in the queries. Six call sites sum
+        // these columns, and a `CASE` in each is one rule in six copies waiting to
+        // drift, which this repo has already paid for once. Nothing is lost:
+        // `execution_traces` still carries `raw_input` and `distilled_output` for
+        // these rows, so what the distiller produced is still readable.
+        //
+        // A redaction is the one passthrough that does send a reply, and no column
+        // records that it happened, so those rows are zeroed here too. That
+        // undercounts a rare case by the few bytes `[REDACTED]` saves, which is the
+        // safe direction to be wrong in.
+        let migration_passthrough = "2026_08_passthrough_rows_book_no_saving";
+        let passthrough_applied: Option<i64> = conn
+            .query_row(
+                "SELECT 1 FROM schema_migrations WHERE id = ?1 LIMIT 1",
+                params![migration_passthrough],
+                |row| row.get(0),
+            )
+            .optional()?;
+        if passthrough_applied.is_none() {
+            let tx = conn.unchecked_transaction()?;
+            tx.execute(
+                "UPDATE distillations \
+                 SET output_bytes = input_bytes, \
+                     delivered_bytes = input_bytes, \
+                     filtered_tokens = raw_tokens \
+                 WHERE route = 'Passthrough' AND output_bytes < input_bytes",
+                [],
+            )?;
+            tx.execute(
+                "INSERT INTO schema_migrations (id, applied_at) VALUES (?1, ?2)",
+                params![migration_passthrough, chrono::Utc::now().timestamp()],
+            )?;
+            tx.commit()?;
+        }
+
         // `context_turns` was written on every hooked command, carried an index,
         // and had no `SELECT` anywhere in the tree: 5,532 rows paying write
         // latency and disk for a reader that never existed (#270). The in-memory
@@ -3315,6 +3359,68 @@ mod tests {
             store.distillation_count(),
             sessions,
             "the two numbers must not be interchangeable"
+        );
+    }
+
+    /// #566. A `Passthrough` row books a saving the model never received: the
+    /// hook sends no reply on that route, so the host keeps its own bytes, while
+    /// every byte and token column was computed from the distiller's output.
+    /// Across the reporting installation these rows carried 93.0% of every byte
+    /// booked as saved, and correcting them moves `omni stats` all-time from a
+    /// published 37.1% to 8.3%.
+    ///
+    /// A `Keep` row in the same table is the control: it really was delivered, so
+    /// the migration must not touch it. Without that half the test would pass
+    /// against an `UPDATE` with no `WHERE` clause.
+    #[test]
+    fn passthrough_rows_stop_booking_a_saving() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = dir.path().join("omni.db");
+        drop(Store::open_path(&db).expect("first open builds the schema"));
+
+        {
+            let conn = rusqlite::Connection::open(&db).expect("open seed db");
+            conn.execute(
+                "DELETE FROM schema_migrations WHERE id = '2026_08_passthrough_rows_book_no_saving'",
+                [],
+            )
+            .expect("re-arm migration");
+            for (route, out, delivered, filtered) in
+                [("Passthrough", 346, 346, 90), ("Keep", 200, 200, 50)]
+            {
+                conn.execute(
+                    "INSERT INTO distillations
+                       (session_id, ts, filter_name, input_bytes, output_bytes, route,
+                        latency_ms, command, delivered_bytes, raw_tokens, filtered_tokens)
+                     VALUES ('s1', 1700000000, 'grep', 424, ?1, ?2, 1, 'grep -rn x', ?3, 110, ?4)",
+                    params![out, route, delivered, filtered],
+                )
+                .expect("seed row");
+            }
+        }
+
+        drop(Store::open_path(&db).expect("second open runs the migration"));
+
+        let conn = rusqlite::Connection::open(&db).expect("open assert db");
+        let read = |route: &str| -> (i64, i64, i64) {
+            conn.query_row(
+                "SELECT output_bytes, delivered_bytes, filtered_tokens
+                 FROM distillations WHERE route = ?1",
+                params![route],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .expect("row")
+        };
+
+        assert_eq!(
+            read("Passthrough"),
+            (424, 424, 110),
+            "a passthrough row still books bytes the hook never sent"
+        );
+        assert_eq!(
+            read("Keep"),
+            (200, 200, 50),
+            "the migration rewrote a row that really was delivered"
         );
     }
 


### PR DESCRIPTION
`process_payload` returns `None` when the route is a passthrough and nothing was redacted, so the host keeps the bytes it already had. Every byte and token column on the recorded row was computed from the distiller's output before that decision. A distiller that cut more than the guardrail's tenth and less than the soft threshold therefore booked a saving the model never received, and the comment at `post_tool.rs:1030` already claimed the row was "recorded above, at its honest 0%" while it was not.

Three commits: restore the raw bytes on the path that drops its reply, correct the rows already written, and the changelog entry.

The read side needed the migration because the hook fix only reaches rows written from now on. It is one correction in the column rather than a `CASE` in each of the six queries that sum it, which would be one rule in six copies. `execution_traces` still carries `raw_input` and `distilled_output`, so what the distiller produced is still readable.

Review caught that the first version made that last sentence false going forward: it overwrote `final_out` before `record_trace`, so every future passthrough would have stored raw and distilled as one string, removing the corpus that corroborates the figure in the same change that leans on it. Now a separate binding, with a test that goes red when the overwrite is reinstated.

Found by reconciling `distillations` against the host's own transcripts, where the `tool_result` bytes are post-hook and are therefore what the model was given. One row was verified end to end before anything changed: `cat scripts/build-docs.sh`, raw 7,744 B, booked 6,356 B, transcript entry 7,744 B with no marker.

Verified on a copy of the reporting installation's database, same binary either side:

```
before   All Time:  6,386 commands │ 8.3M → 5.2M tokens │ 37.1% saved
after    All Time:  6,386 commands │ 8.3M → 7.6M tokens │  8.3% saved
```

The command count is unchanged, so nothing was hidden, only the fiction removed. 8.3% agrees with the 4% to 15% per command measured independently from `execution_traces`, which never went through the books.

Both tests were driven red before they were trusted. The hook test uses a real recorded trace, because four invented fixtures measured a ratio of 0.000 and passed with the guard removed. The migration test seeds a `Keep` row beside the `Passthrough` one and was broken in both directions, once by neutering the `UPDATE` and once by widening its `WHERE`.

`make ci` green.

Closes #566

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR corrects savings attributed to passthrough calls where the hook sends no replacement reply.
- Separates model-delivered content used for accounting from distiller output retained in execution traces.
- Migrates historical passthrough rows so they no longer report undelivered savings.
- Adds regression coverage for both the hook behavior and migration scope.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/hooks/post_tool.rs | Uses raw host-retained content for passthrough accounting while preserving the distiller output in execution traces; the prior trace-loss finding is fixed. |
| src/store/sqlite.rs | Adds an idempotent, route-scoped migration that resets historical passthrough byte and token savings while leaving delivered rows unchanged. |
| changelog.d/566.fixed.md | Documents the incorrect savings accounting, historical correction, and resulting statistics adjustment. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(hooks): keep the distiller&#39;s output ..."](https://github.com/fajarhide/omni/commit/b94a87575a3b36ae9279bf048471701b1585183f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53575978)</sub>

<!-- /greptile_comment -->