### PR TITLE
fix(security): a bare pass is a counter, and passwd was never redacted

### DIFF
--- a/changelog.d/559.fixed.md
+++ b/changelog.d/559.fixed.md
@@ -1,0 +1,15 @@
+- **A bare `pass=` was redacted as a credential, so a test loop's result was
+  destroyed.** `echo "pass=$P/10"` after ten runs came back as
+  `pass=[REDACTED]`, and nothing in the output said the token had been a count
+  rather than a secret, which leaves re-running the loop or reporting a number
+  nobody saw. Bare `pass` now gives the value a say, the same treatment `KEY` has
+  had since #486. Only the single-segment form: `DB_PASS` is named after what it
+  opens and keeps its strength unconditionally. A tally joins the value shapes
+  that carry no credential material, since `3/3` is what a test loop prints and
+  the slash is not an identifier character. `password=`, `PGPASSWORD=` and
+  `db_pass=` are unchanged, and each has a row in the test. (#559)
+- **`passwd=` had never been redacted at all.** Found while fixing the above
+  rather than reported: the pattern set matches on whole segments, so `PASSWD` is
+  neither equal to `PASS` nor a word ending in it, and `PASSWORD` is a different
+  word again. `passwd=hunter2` was delivered in full by every release that has
+  shipped this matcher. Added to the set. (#559)

--- a/changelog.d/559.fixed.md
+++ b/changelog.d/559.fixed.md
@@ -2,12 +2,15 @@
   destroyed.** `echo "pass=$P/10"` after ten runs came back as
   `pass=[REDACTED]`, and nothing in the output said the token had been a count
   rather than a secret, which leaves re-running the loop or reporting a number
-  nobody saw. Bare `pass` now gives the value a say, the same treatment `KEY` has
-  had since #486. Only the single-segment form: `DB_PASS` is named after what it
-  opens and keeps its strength unconditionally. A tally joins the value shapes
-  that carry no credential material, since `3/3` is what a test loop prints and
-  the slash is not an identifier character. `password=`, `PGPASSWORD=` and
-  `db_pass=` are unchanged, and each has a row in the test. (#559)
+  nobody saw. A bare `pass` now delivers a count, `3` or `3/10` and nothing
+  else. The `KEY` value rule from #486 is deliberately not reused: it accepts any
+  short lowercase word, which is right for `key` and wrong for `pass`, where
+  `hunter2` is what a password looks like. So `pass=hello` and `pass=hunter2`
+  stay redacted, which is narrower than the report asked for and follows the rule
+  this file already states, that hiding a value which did not need hiding is
+  recoverable and printing a secret is not. `DB_PASS` is named after what it
+  opens and keeps its strength unconditionally; `password=`, `PGPASSWORD=` and
+  `db_pass=` are unchanged. Each of those has a row in the test. (#559)
 - **`passwd=` had never been redacted at all.** Found while fixing the above
   rather than reported: the pattern set matches on whole segments, so `PASSWD` is
   neither equal to `PASS` nor a word ending in it, and `PASSWORD` is a different

--- a/src/distillers/system_ops.rs
+++ b/src/distillers/system_ops.rs
@@ -566,14 +566,6 @@ fn only_the_key_pattern_matched(key: &str) -> bool {
         if *p == "KEY" {
             return false;
         }
-        // #559. A bare `pass` is a test counter far more often than a
-        // credential, and a real one is written `password`, `passwd` or with a
-        // qualifier in front. Only the single-segment form gives the value a
-        // say: `DB_PASS` keeps its strength, because a suffixed `pass` is
-        // named after what it opens.
-        if *p == "PASS" && segments.len() == 1 {
-            return false;
-        }
         match p.strip_suffix('_') {
             Some(prefix) => *first == prefix,
             None if p.contains('_') => {
@@ -613,22 +605,31 @@ fn looks_like_plain_identifier(value: &str) -> bool {
         .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || matches!(c, '.' | '_' | '-'))
 }
 
-/// A tally is a score, not a secret.
+/// A count is a score, not a secret: `3` or `3/10` and nothing else.
 ///
-/// `pass=3/3` is the shape the identifier rule cannot reach, because the slash
-/// is not an identifier character, and it is exactly what a test loop prints
-/// (#559). Both sides have to be digits: `pass=admin/hunter2` is not a tally.
-fn looks_like_tally(value: &str) -> bool {
+/// Deliberately narrower than `looks_like_plain_identifier`. That rule accepts
+/// any short lowercase word, which is right for `key` and wrong for `pass`,
+/// where `hunter2` is exactly what a password looks like. Review caught the
+/// first version reusing it (#559), and the direction of doubt this file already
+/// states settles it: hiding a value that did not need hiding is recoverable,
+/// printing a secret is not. So `pass=hello` stays redacted.
+fn looks_like_count(value: &str) -> bool {
     let v = value.trim().trim_matches(['"', '\'']).trim();
+    let digits = |s: &str| !s.is_empty() && s.chars().all(|c| c.is_ascii_digit());
     match v.split_once('/') {
-        Some((done, total)) => {
-            !done.is_empty()
-                && !total.is_empty()
-                && done.chars().all(|c| c.is_ascii_digit())
-                && total.chars().all(|c| c.is_ascii_digit())
-        }
-        None => false,
+        Some((done, total)) => digits(done) && digits(total),
+        None => digits(v),
     }
+}
+
+/// `pass` on its own, which is a counter far more often than a credential.
+///
+/// A real one is written `password`, `passwd`, or with a qualifier in front, and
+/// a suffixed `pass` is named after what it opens, so `DB_PASS` keeps its
+/// strength unconditionally.
+fn is_bare_pass(key: &str) -> bool {
+    let k = key.trim().trim_start_matches("export ").trim();
+    k.eq_ignore_ascii_case("pass")
 }
 
 /// A brace expression is code, not a value.
@@ -683,10 +684,14 @@ fn redact_assignment(key: &str, value: &str) -> Option<String> {
     // Letting it speak for every pattern would wave through `sk-ant-abc123`,
     // which is lowercase, short and a credential.
     if only_the_key_pattern_matched(key)
-        && (looks_like_plain_identifier(value)
-            || looks_like_code_expression(value)
-            || looks_like_tally(value))
+        && (looks_like_plain_identifier(value) || looks_like_code_expression(value))
     {
+        return None;
+    }
+    // #559. `echo "pass=$P/10"` after a test loop came back as `[REDACTED]`, so
+    // ten runs' result was gone with nothing saying the token had been a count.
+    // Only a count is waved through, and only for the bare key.
+    if is_bare_pass(key) && looks_like_count(value) {
         return None;
     }
     // The surrounding syntax survives, so a redacted assignment still parses.
@@ -1161,7 +1166,6 @@ mod tests {
         for (key, value) in [
             ("pass", "3/3"),
             ("pass", "10"),
-            ("pass", "hello"),
             ("fail", "3/3"),
             ("passed", "3/3"),
             ("PASS", "$((PASS + 1))"),
@@ -1178,6 +1182,11 @@ mod tests {
             ("passwd", "hunter2"),
             ("db_pass", "hunter2"),
             ("PGPASSWORD", "hunter2"),
+            // Review's case, and the reason the `KEY` value rule is not reused
+            // here: it accepts any short lowercase word, and this one is a
+            // password. The issue asked for it to be delivered; the direction of
+            // doubt in this file outranks that, and the deviation is on the PR.
+            ("pass", "hunter2"),
         ] {
             assert!(
                 redact_assignment(key, value).is_some(),

--- a/src/distillers/system_ops.rs
+++ b/src/distillers/system_ops.rs
@@ -45,6 +45,11 @@ const SENSITIVE_PATTERNS: &[&str] = &[
     "TOKEN",
     "KEY",
     "PASSWORD",
+    // Segment matching means `PASSWD` was never reached by either of its
+    // neighbours: it is not equal to `PASS` and does not end with it, and
+    // `PASSWORD` is a different word. `passwd=hunter2` was delivered in full
+    // until #559 went looking (added there, not reported there).
+    "PASSWD",
     "PASS",
     "AUTH",
     // `CRED` was a stem, and a stem only works under substring matching. Segment
@@ -561,6 +566,14 @@ fn only_the_key_pattern_matched(key: &str) -> bool {
         if *p == "KEY" {
             return false;
         }
+        // #559. A bare `pass` is a test counter far more often than a
+        // credential, and a real one is written `password`, `passwd` or with a
+        // qualifier in front. Only the single-segment form gives the value a
+        // say: `DB_PASS` keeps its strength, because a suffixed `pass` is
+        // named after what it opens.
+        if *p == "PASS" && segments.len() == 1 {
+            return false;
+        }
         match p.strip_suffix('_') {
             Some(prefix) => *first == prefix,
             None if p.contains('_') => {
@@ -598,6 +611,24 @@ fn looks_like_plain_identifier(value: &str) -> bool {
     }
     v.chars()
         .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || matches!(c, '.' | '_' | '-'))
+}
+
+/// A tally is a score, not a secret.
+///
+/// `pass=3/3` is the shape the identifier rule cannot reach, because the slash
+/// is not an identifier character, and it is exactly what a test loop prints
+/// (#559). Both sides have to be digits: `pass=admin/hunter2` is not a tally.
+fn looks_like_tally(value: &str) -> bool {
+    let v = value.trim().trim_matches(['"', '\'']).trim();
+    match v.split_once('/') {
+        Some((done, total)) => {
+            !done.is_empty()
+                && !total.is_empty()
+                && done.chars().all(|c| c.is_ascii_digit())
+                && total.chars().all(|c| c.is_ascii_digit())
+        }
+        None => false,
+    }
 }
 
 /// A brace expression is code, not a value.
@@ -652,7 +683,9 @@ fn redact_assignment(key: &str, value: &str) -> Option<String> {
     // Letting it speak for every pattern would wave through `sk-ant-abc123`,
     // which is lowercase, short and a credential.
     if only_the_key_pattern_matched(key)
-        && (looks_like_plain_identifier(value) || looks_like_code_expression(value))
+        && (looks_like_plain_identifier(value)
+            || looks_like_code_expression(value)
+            || looks_like_tally(value))
     {
         return None;
     }
@@ -1112,6 +1145,45 @@ mod tests {
         let env = "GOOGLE_CREDENTIALS={\"type\":\"service_account\",\"private_key\":\"abc\"}\n";
         let out = redact_sensitive_assignments(env).expect("a JSON credential is still a secret");
         assert!(!out.contains("service_account"), "secret delivered:\n{out}");
+    }
+
+    /// #559. `echo "pass=$P/10"` after a ten-run test loop came back as
+    /// `pass=[REDACTED]`, so the result was gone and nothing in the output said
+    /// the token had been a count rather than a secret.
+    ///
+    /// The second half of the table is the point. A rule that only proves the
+    /// counters survive is indistinguishable from deleting the pattern, and
+    /// `passwd` is in there because it turned out never to have been redacted
+    /// at all: segment matching means it is neither equal to `PASS` nor a word
+    /// ending in it, and `PASSWORD` is a different word.
+    #[test]
+    fn a_bare_pass_is_a_counter_and_a_qualified_one_is_still_a_secret() {
+        for (key, value) in [
+            ("pass", "3/3"),
+            ("pass", "10"),
+            ("pass", "hello"),
+            ("fail", "3/3"),
+            ("passed", "3/3"),
+            ("PASS", "$((PASS + 1))"),
+        ] {
+            assert_eq!(
+                redact_assignment(key, value),
+                None,
+                "{key}={value} carries no credential and was destroyed"
+            );
+        }
+
+        for (key, value) in [
+            ("password", "hunter2"),
+            ("passwd", "hunter2"),
+            ("db_pass", "hunter2"),
+            ("PGPASSWORD", "hunter2"),
+        ] {
+            assert!(
+                redact_assignment(key, value).is_some(),
+                "{key}={value} is a credential and was delivered in full"
+            );
+        }
     }
 
     /// #532, found in `tests/smoke_test.sh`: a counter in this repository's own


### PR DESCRIPTION
`echo "pass=$P/10"` after a ten-run test loop came back as `pass=[REDACTED]`. The result of ten runs was gone, and nothing in the output said the token had been a count rather than a secret, which leaves re-running the loop or reporting a number nobody saw.

Bare `pass` now gives the value a say, which is the treatment `KEY` has had since #486 and for the same reason. Only the single-segment form: `DB_PASS` is named after what it opens and keeps its strength unconditionally. A tally joins the value shapes that carry no credential material, because `3/3` is what a test loop prints and the slash is not an identifier character, so the existing rule could not reach it.

The issue offered two options. This is the second one, narrowed. Dropping the pattern outright would also have dropped `*_PASS`, since the matcher works on whole segments and `DB_PASS` matches through `PASS` itself.

**A second hole turned up while implementing it, and it was not in the report: `passwd=` has never been redacted.** Segment matching means `PASSWD` is not equal to `PASS`, does not end with it, and `PASSWORD` is a different word again, so `passwd=hunter2` has been delivered in full by every release that shipped this matcher. Added to the pattern set.

The test is a table, and its second half is the part that matters: `password=`, `passwd=`, `db_pass=` and `PGPASSWORD=` each have a row that must stay redacted. Without them the test would pass against simply deleting the pattern. Driven red three times, once per moving part: removing the bare-`pass` exemption, removing the tally rule, and removing `PASSWD`.

`make ci` green.

Closes #559

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR narrows the bare-`pass` redaction exemption to numeric count-shaped values and adds previously missing `passwd` coverage.
- Adds `PASSWD` to the sensitive-pattern set.
- Allows bare `pass` values shaped as integers or integer ratios to pass through.
- Adds regression tests and a changelog entry for both behaviors.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

This PR is not safe to merge because the attempted fix still exposes numeric credentials assigned to a bare PASS key.

The reply from the unnamed author shown as `Reply from :` says the exemption was narrowed to counts, but `looks_like_count` classifies numeric passwords and PINs by the same shape and the callers consequently emit them unchanged.

**Files Needing Attention:** src/distillers/system_ops.rs
</details>

<details open><summary><h3>Security Review</h3></summary>

The bare-`pass` exemption cannot distinguish counters from numeric credentials, so values such as `pass=1234` or `pass=1234/5678` are emitted verbatim. **How this was verified:** The new numeric predicate reaches the early `None` return, and callers preserve the original assignment without a later redaction guard.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/distillers/system_ops.rs | Adds PASSWD redaction and a narrowed bare-PASS exemption, but the exemption still exposes numeric passwords and PINs. |
| changelog.d/559.fixed.md | Documents the intended counter exemption and newly covered PASSWD pattern. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20fajarhide%2Fomni%20PR%20%23570%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=fajarhide%2Fomni&pr=570&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fdistillers%2Fsystem_ops.rs%3A619-622%0A**Numeric%20credentials%20bypass%20redaction**%0A%0AWhen%20command%20output%20contains%20a%20bare%20%60pass%60%20or%20%60PASS%60%20assignment%20with%20a%20numeric%20credential%20such%20as%20%60pass%3D1234%60%20or%20%60pass%3D1234%2F5678%60%2C%20%60looks_like_count%60%20classifies%20it%20as%20a%20counter%20and%20the%20early%20%60None%60%20return%20causes%20callers%20to%20emit%20the%20credential%20verbatim.%20**How%20this%20was%20verified%3A**%20The%20numeric%20predicate%20reaches%20the%20bare-PASS%20bypass%2C%20and%20callers%20preserve%20the%20original%20assignment%20without%20a%20later%20redaction%20guard.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni&pr=570&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fajarhide%2Fomni%22%20on%20the%20existing%20branch%20%22fix%2F559-bare-pass-is-a-counter%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F559-bare-pass-is-a-counter%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fdistillers%2Fsystem_ops.rs%3A619-622%0A**Numeric%20credentials%20bypass%20redaction**%0A%0AWhen%20command%20output%20contains%20a%20bare%20%60pass%60%20or%20%60PASS%60%20assignment%20with%20a%20numeric%20credential%20such%20as%20%60pass%3D1234%60%20or%20%60pass%3D1234%2F5678%60%2C%20%60looks_like_count%60%20classifies%20it%20as%20a%20counter%20and%20the%20early%20%60None%60%20return%20causes%20callers%20to%20emit%20the%20credential%20verbatim.%20**How%20this%20was%20verified%3A**%20The%20numeric%20predicate%20reaches%20the%20bare-PASS%20bypass%2C%20and%20callers%20preserve%20the%20original%20assignment%20without%20a%20later%20redaction%20guard.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni&pr=570&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Asrc%2Fdistillers%2Fsystem_ops.rs%3A619-622%0A**Numeric%20credentials%20bypass%20redaction**%0A%0AWhen%20command%20output%20contains%20a%20bare%20%60pass%60%20or%20%60PASS%60%20assignment%20with%20a%20numeric%20credential%20such%20as%20%60pass%3D1234%60%20or%20%60pass%3D1234%2F5678%60%2C%20%60looks_like_count%60%20classifies%20it%20as%20a%20counter%20and%20the%20early%20%60None%60%20return%20causes%20callers%20to%20emit%20the%20credential%20verbatim.%20**How%20this%20was%20verified%3A**%20The%20numeric%20predicate%20reaches%20the%20bare-PASS%20bypass%2C%20and%20callers%20preserve%20the%20original%20assignment%20without%20a%20later%20redaction%20guard.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=570&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fajarhide%2Fomni%22%20on%20the%20existing%20branch%20%22fix%2F559-bare-pass-is-a-counter%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F559-bare-pass-is-a-counter%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fdistillers%2Fsystem_ops.rs%3A619-622%0A**Numeric%20credentials%20bypass%20redaction**%0A%0AWhen%20command%20output%20contains%20a%20bare%20%60pass%60%20or%20%60PASS%60%20assignment%20with%20a%20numeric%20credential%20such%20as%20%60pass%3D1234%60%20or%20%60pass%3D1234%2F5678%60%2C%20%60looks_like_count%60%20classifies%20it%20as%20a%20counter%20and%20the%20early%20%60None%60%20return%20causes%20callers%20to%20emit%20the%20credential%20verbatim.%20**How%20this%20was%20verified%3A**%20The%20numeric%20predicate%20reaches%20the%20bare-PASS%20bypass%2C%20and%20callers%20preserve%20the%20original%20assignment%20without%20a%20later%20redaction%20guard.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/distillers/system_ops.rs:619-622
**Numeric credentials bypass redaction**

When command output contains a bare `pass` or `PASS` assignment with a numeric credential such as `pass=1234` or `pass=1234/5678`, `looks_like_count` classifies it as a counter and the early `None` return causes callers to emit the credential verbatim. **How this was verified:** The numeric predicate reaches the bare-PASS bypass, and callers preserve the original assignment without a later redaction guard.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["docs(changelog): narrow the #559 entry t..."](https://github.com/fajarhide/omni/commit/621b81cf4cd29c8cabcc5dc9c60fb14f67054ca5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53578372)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->