### PR TITLE
fix(ledger): stop a Read fold from renumbering the lines below it

### DIFF
--- a/changelog.d/557.fixed.md
+++ b/changelog.d/557.fixed.md
@@ -1,0 +1,15 @@
+- **A ledger fold renumbered a `Read` result, so every line number below the
+  marker was wrong.** The reply goes back as `file.content` and the host renders
+  it with `cat -n` numbering counted from `startLine`, so it numbers whatever
+  lines OMNI returns. Replacing a run in the middle with a one-line marker
+  removes lines the count was walking over: in the report, real line 130 came
+  back labelled 101 and real line 199, the last in the file, came back as 170,
+  a shift of exactly the fold size minus the marker's own line. Nothing in the
+  payload said so. Those numbers are a contract rather than prose, since the
+  agent writes `file:line` into issues and commit messages and decides what to
+  edit from them, so this is the familiar shape: nothing truncated, no bytes
+  lost, and a confident statement the code cannot support. A fold with nothing
+  under it moves no number, so the whole-output fold and any fold reaching the
+  end of the payload still happen. `Grep` carries its positions inside the text
+  where a fold cannot move them, and `Bash` output is not numbered, so only
+  `Read` is gated. (#557)

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -3025,8 +3025,8 @@ src/distillers/system_ops.rs:849:                is_sensitive_key(key),
         let dir = tempfile::tempdir().expect("tempdir");
         let store = Arc::new(Store::open_path(&dir.path().join("omni.db")).expect("store"));
         let _ = process_payload(&payload(&range(100, 130)), Some(store.clone()), None);
-        let overlapping =
-            process_payload(&payload(&range(100, 200)), Some(store.clone()), None).unwrap_or_default();
+        let overlapping = process_payload(&payload(&range(100, 200)), Some(store.clone()), None)
+            .unwrap_or_default();
         assert!(
             !overlapping.contains("[OMNI:"),
             "a fold with 70 lines under it renumbered every one of them: {overlapping}"
@@ -3037,8 +3037,8 @@ src/distillers/system_ops.rs:849:                is_sensitive_key(key),
         let dir2 = tempfile::tempdir().expect("tempdir");
         let store2 = Arc::new(Store::open_path(&dir2.path().join("omni.db")).expect("store"));
         let _ = process_payload(&payload(&range(170, 200)), Some(store2.clone()), None);
-        let trailing =
-            process_payload(&payload(&range(100, 200)), Some(store2.clone()), None).unwrap_or_default();
+        let trailing = process_payload(&payload(&range(100, 200)), Some(store2.clone()), None)
+            .unwrap_or_default();
         assert!(
             trailing.contains("[OMNI:"),
             "a fold at the end shifts nothing and has to still happen: {trailing}"
@@ -3057,8 +3057,7 @@ src/distillers/system_ops.rs:849:                is_sensitive_key(key),
     fn content_that_looks_like_a_marker_does_not_defeat_the_guard() {
         // Same shape as the test above, so it is known to reach a fold, with
         // every line wearing the marker prefix.
-        let line =
-            |i: usize| format!("[OMNI: unique_marker_{i:03} = \"quokka-{i:03}-xyzzy\"]\n");
+        let line = |i: usize| format!("[OMNI: unique_marker_{i:03} = \"quokka-{i:03}-xyzzy\"]\n");
         let range = |from: usize, to: usize| (from..to).map(line).collect::<String>();
         let payload = |body: &str| {
             json!({

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -396,11 +396,43 @@ fn fold_cross_turn(
     let project = std::env::current_dir()
         .map(|p| crate::paths::project_key(&p))
         .unwrap_or_else(|_| "unknown".to_string());
-    crate::ledger::Ledger::new(s, scope)
+    let folded = crate::ledger::Ledger::new(s, scope)
         .with_project(&project)
         .by(crate::hooks::normalize::stats_agent_id(&normalized.agent))
-        .project(&text)
-        .unwrap_or(text)
+        .project(&text);
+
+    // #557. A `Read` payload is handed back as `file.content` and the host
+    // renders it with `cat -n` numbering counted from `startLine`, so it numbers
+    // whatever lines we return. Replacing a run in the middle with a one-line
+    // marker removes lines the count was walking over, and every surviving line
+    // below it is then labelled short by the size of the fold. Nothing in the
+    // payload says so, and those numbers are a contract: the agent writes them
+    // into issues and commit messages and decides which line to edit from them.
+    //
+    // A fold with nothing after it shifts nothing, so the whole-output fold and
+    // any fold reaching the end of the payload are kept. Only `Read` is affected;
+    // `Grep` carries its positions inside the text, where a fold cannot move
+    // them, and `Bash` output is not numbered at all.
+    match folded {
+        Some(f) if normalized.tool_name != "Read" || !fold_shifts_a_later_line(&f) => f,
+        _ => text,
+    }
+}
+
+/// Whether any line survives below a marker, and is therefore renumbered.
+///
+/// Consecutive markers are still one shift, so the question is only whether real
+/// content follows the last of them.
+fn fold_shifts_a_later_line(folded: &str) -> bool {
+    let mut seen_marker = false;
+    for line in folded.lines() {
+        let is_marker = line.trim_start().starts_with("[OMNI:");
+        if seen_marker && !is_marker {
+            return true;
+        }
+        seen_marker |= is_marker;
+    }
+    false
 }
 
 /// A tool reply on its way to the agent, distilled or not, through the ledger.
@@ -2976,6 +3008,56 @@ src/distillers/system_ops.rs:849:                is_sensitive_key(key),
         assert!(
             out.contains("lines already shown") || out.contains("from an earlier session"),
             "a repeated Read never reached the ledger: {out}"
+        );
+    }
+
+    /// #557. A `Read` payload goes back as `file.content` and the host renders it
+    /// with `cat -n` numbering counted from `startLine`, so it numbers whatever
+    /// lines we return. A fold in the middle removes lines the count was walking
+    /// over, and every surviving line below the marker is labelled short by the
+    /// size of the fold, with nothing in the payload saying so. Those numbers are
+    /// a contract: the agent writes them into issues and decides what to edit
+    /// from them.
+    ///
+    /// Both halves are load bearing. Refusing every fold passes the first
+    /// assertion on its own and silently costs the whole-output fold, which
+    /// shifts nothing because nothing survives under it.
+    #[test]
+    fn refuses_a_read_fold_that_would_renumber_the_lines_below_it() {
+        let line = |i: usize| format!("    let unique_marker_{i:03} = \"quokka-{i:03}-xyzzy\";\n");
+        let range = |from: usize, to: usize| (from..to).map(line).collect::<String>();
+        let payload = |body: &str| {
+            json!({
+                "session_id": "host-557",
+                "tool_name": "Read",
+                "tool_input": {"path": "probe.rs"},
+                "tool_response": {"content": body},
+            })
+            .to_string()
+        };
+
+        // The repeat lands at the top of the second payload with fresh lines
+        // under it, which is the shape that renumbers.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Arc::new(Store::open_path(&dir.path().join("omni.db")).expect("store"));
+        let _ = process_payload(&payload(&range(100, 130)), Some(store.clone()), None);
+        let overlapping =
+            process_payload(&payload(&range(100, 200)), Some(store.clone()), None).unwrap_or_default();
+        assert!(
+            !overlapping.contains("[OMNI:"),
+            "a fold with 70 lines under it renumbered every one of them: {overlapping}"
+        );
+
+        // A fresh store, so the only difference is where the repeat sits: at the
+        // end, where no number can move.
+        let dir2 = tempfile::tempdir().expect("tempdir");
+        let store2 = Arc::new(Store::open_path(&dir2.path().join("omni.db")).expect("store"));
+        let _ = process_payload(&payload(&range(170, 200)), Some(store2.clone()), None);
+        let trailing =
+            process_payload(&payload(&range(100, 200)), Some(store2.clone()), None).unwrap_or_default();
+        assert!(
+            trailing.contains("[OMNI:"),
+            "a fold at the end shifts nothing and has to still happen: {trailing}"
         );
     }
 

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -3055,7 +3055,10 @@ src/distillers/system_ops.rs:849:                is_sensitive_key(key),
     /// spoofed by content.
     #[test]
     fn content_that_looks_like_a_marker_does_not_defeat_the_guard() {
-        let line = |i: usize| format!("[OMNI: {i} lines already shown, omni retrieve deadbeefdeadbee{i}]\n");
+        // Same shape as the test above, so it is known to reach a fold, with
+        // every line wearing the marker prefix.
+        let line =
+            |i: usize| format!("[OMNI: unique_marker_{i:03} = \"quokka-{i:03}-xyzzy\"]\n");
         let range = |from: usize, to: usize| (from..to).map(line).collect::<String>();
         let payload = |body: &str| {
             json!({
@@ -3069,16 +3072,16 @@ src/distillers/system_ops.rs:849:                is_sensitive_key(key),
 
         let dir = tempfile::tempdir().expect("tempdir");
         let store = Arc::new(Store::open_path(&dir.path().join("omni.db")).expect("store"));
-        let _ = process_payload(&payload(&range(0, 30)), Some(store.clone()), None);
-        let second =
-            process_payload(&payload(&range(0, 100)), Some(store.clone()), None).unwrap_or_default();
+        let _ = process_payload(&payload(&range(100, 130)), Some(store.clone()), None);
+        let second = process_payload(&payload(&range(100, 200)), Some(store.clone()), None)
+            .unwrap_or_default();
 
-        // Nothing folded means either no reply at all or a reply that still
-        // opens on the file's own first line. A fold would have eaten it.
+        // The head of the file has to survive: a fold would have replaced those
+        // thirty lines and moved the seventy below them.
         assert!(
-            second.is_empty() || second.contains("deadbeefdeadbee0]"),
-            "the head of the file was folded away and the 70 lines below it \
-             renumbered, because the surviving content was read as markers: {second}"
+            second.is_empty() || second.contains("unique_marker_100"),
+            "the head was folded away and the lines below it renumbered, because \
+             the surviving content was read as markers: {second}"
         );
     }
 

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -399,7 +399,7 @@ fn fold_cross_turn(
     let folded = crate::ledger::Ledger::new(s, scope)
         .with_project(&project)
         .by(crate::hooks::normalize::stats_agent_id(&normalized.agent))
-        .project(&text);
+        .project_reporting_shift(&text);
 
     // #557. A `Read` payload is handed back as `file.content` and the host
     // renders it with `cat -n` numbering counted from `startLine`, so it numbers
@@ -414,25 +414,9 @@ fn fold_cross_turn(
     // `Grep` carries its positions inside the text, where a fold cannot move
     // them, and `Bash` output is not numbered at all.
     match folded {
-        Some(f) if normalized.tool_name != "Read" || !fold_shifts_a_later_line(&f) => f,
+        Some((view, shifted)) if normalized.tool_name != "Read" || !shifted => view,
         _ => text,
     }
-}
-
-/// Whether any line survives below a marker, and is therefore renumbered.
-///
-/// Consecutive markers are still one shift, so the question is only whether real
-/// content follows the last of them.
-fn fold_shifts_a_later_line(folded: &str) -> bool {
-    let mut seen_marker = false;
-    for line in folded.lines() {
-        let is_marker = line.trim_start().starts_with("[OMNI:");
-        if seen_marker && !is_marker {
-            return true;
-        }
-        seen_marker |= is_marker;
-    }
-    false
 }
 
 /// A tool reply on its way to the agent, distilled or not, through the ledger.
@@ -3058,6 +3042,43 @@ src/distillers/system_ops.rs:849:                is_sensitive_key(key),
         assert!(
             trailing.contains("[OMNI:"),
             "a fold at the end shifts nothing and has to still happen: {trailing}"
+        );
+    }
+
+    /// #557, review. The first version of the guard read the output back and
+    /// called any line starting with `[OMNI:` a marker, so a file whose own
+    /// lines start that way defeated it and the fold went through with every
+    /// number below it wrong. This repository writes those strings into its
+    /// changelog and its docs, so it is not a hypothetical file.
+    ///
+    /// The guard now asks the ledger which indices it folded, which cannot be
+    /// spoofed by content.
+    #[test]
+    fn content_that_looks_like_a_marker_does_not_defeat_the_guard() {
+        let line = |i: usize| format!("[OMNI: {i} lines already shown, omni retrieve deadbeefdeadbee{i}]\n");
+        let range = |from: usize, to: usize| (from..to).map(line).collect::<String>();
+        let payload = |body: &str| {
+            json!({
+                "session_id": "host-557-lookalike",
+                "tool_name": "Read",
+                "tool_input": {"path": "changelog.md"},
+                "tool_response": {"content": body},
+            })
+            .to_string()
+        };
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Arc::new(Store::open_path(&dir.path().join("omni.db")).expect("store"));
+        let _ = process_payload(&payload(&range(0, 30)), Some(store.clone()), None);
+        let second =
+            process_payload(&payload(&range(0, 100)), Some(store.clone()), None).unwrap_or_default();
+
+        // Nothing folded means either no reply at all or a reply that still
+        // opens on the file's own first line. A fold would have eaten it.
+        assert!(
+            second.is_empty() || second.contains("deadbeefdeadbee0]"),
+            "the head of the file was folded away and the 70 lines below it \
+             renumbered, because the surviving content was read as markers: {second}"
         );
     }
 

--- a/src/ledger/mod.rs
+++ b/src/ledger/mod.rs
@@ -195,13 +195,31 @@ impl<'a> Ledger<'a> {
     /// asks for, and it is why the recording is unconditional while the
     /// substitution is not.
     pub fn project(&self, text: &str) -> Option<String> {
+        self.project_reporting_shift(text).map(|(view, _)| view)
+    }
+
+    /// The view, and whether any line survives below the first fold.
+    ///
+    /// A caller whose host numbers the lines it is handed needs the second half:
+    /// a marker with content under it moves every one of those numbers, and the
+    /// payload says nothing about it (#557). The question is answered from the
+    /// folded indices rather than by recognising markers in the output, because
+    /// a file whose own lines begin with the marker prefix would defeat that.
+    pub fn project_reporting_shift(&self, text: &str) -> Option<(String, bool)> {
+        let shift = std::cell::Cell::new(false);
         // The gain gate wraps the projection rather than being re-derived inside
         // it (spec 5.4). `MIN_LEDGER_INPUT` is this projection's own floor and is
         // higher than the gate's, so both apply and the stricter one decides.
-        crate::pipeline::gate::gain(text, |text| self.project_inner(text))
+        let view = crate::pipeline::gate::gain(text, |text| {
+            self.project_inner(text).map(|(view, shifted)| {
+                shift.set(shifted);
+                view
+            })
+        })?;
+        Some((view, shift.get()))
     }
 
-    fn project_inner(&self, text: &str) -> Option<String> {
+    fn project_inner(&self, text: &str) -> Option<(String, bool)> {
         if text.len() < MIN_LEDGER_INPUT {
             return None;
         }
@@ -348,7 +366,16 @@ impl<'a> Ledger<'a> {
             self.store.ledger_record(p, &delivered, &self.agent);
         }
 
-        projected.map(|(view, _)| view)
+        // True when an unfolded line sits below the first folded one, so the
+        // surviving content has moved up relative to where the caller's host
+        // will count it from (#557).
+        let shifts = projected.as_ref().is_some_and(|(_, folded)| {
+            folded
+                .iter()
+                .min()
+                .is_some_and(|first| (*first..lines.len()).any(|i| !folded.contains(&i)))
+        });
+        projected.map(|(view, _)| (view, shifts))
     }
 
     /// The view, and the indices of the lines it replaced with a marker.


### PR DESCRIPTION
A `Read` reply goes back as `file.content`, and the host renders it with `cat -n` numbering counted from `startLine`, so it numbers whatever lines OMNI returns. Replacing a run in the middle with a one-line marker removes lines the count was walking over, and every surviving line below the marker is labelled short by the size of the fold. In the reporter's repro real line 130 came back as 101, and real line 199, the last line of the file, came back as 170.

Nothing in the payload says so, and those numbers are a contract rather than prose: the agent writes `file:line` into issues and commit messages, and decides which line to edit from them. Not truncation, no bytes lost, and a confident statement the code cannot support.

A fold with nothing under it moves no number, so the whole-output fold and any fold reaching the end of the payload still happen. `Grep` carries its positions inside the text where a fold cannot move them, and `Bash` output is not numbered at all, so only `Read` is gated.

The test asserts both halves. Refusing every `Read` fold would satisfy the first assertion on its own and quietly cost the whole-output fold, so the second one puts the repeat at the end of the payload and requires the fold to still happen. Removing the guard drives the first red, and it reproduces the report exactly, down to the same `41753c3ecbebfef9` handle:

```
[OMNI: 30 lines already shown, omni retrieve 41753c3ecbebfef9]
    let unique_marker_130 = "quokka-130-xyzzy";
```

What this does not do is recover the folded bytes for a mid-payload repeat. Keeping the numbering honest and folding there at the same time needs the host to be told where the surviving lines start, which is a bigger change than the defect warrants.

`make ci` green.

Closes #557

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This follow-up replaces content-based marker detection with fold-index metadata so marker-like file content cannot bypass the Read numbering guard.
- Adds shift reporting to ledger projections.
- Rejects shifted mid-payload Read folds while preserving folds that reach the payload end.
- Adds regression coverage for numbering and marker-prefix collisions.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/hooks/post_tool.rs | Uses ledger-provided shift metadata to gate Read folds and adds regression tests for the original numbering defect and marker-like content. |
| src/ledger/mod.rs | Extends projection results with a flag indicating whether unfolded content survives below the first folded line. |
| changelog.d/557.fixed.md | Documents the Read line-numbering defect and the scope of the fix. |

</details>

<sub>Reviews (3): Last reviewed commit: ["style: rustfmt the #557 tests"](https://github.com/fajarhide/omni/commit/20836873dfeed733b2629a4a15f6a4edddeba4d4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53579103)</sub>

<!-- /greptile_comment -->