### PR TITLE
feat(ledger): fold a repeated head again, and move the host's start line with it

### DIFF
--- a/changelog.d/leading-fold-keeps-numbering.added.md
+++ b/changelog.d/leading-fold-keeps-numbering.added.md
@@ -1,21 +1,25 @@
 - **A `Read` that repeats the head of a file folds again, and the host's line
   numbers stay true.** #557 stopped a fold renumbering the lines under it by
-  refusing the fold, which is correct and costs the most common shape there is:
-  re-reading a file at a later offset repeats its head, so the run the ledger can
-  fold is exactly the run that has content below it. The host renders
-  `file.content` with `cat -n` numbering counted from `startLine`, so when the
-  repeated run is at the head one number fixes all of it: move `startLine` by the
-  size of the run minus the marker's own line and every survivor lands back where
-  the file has it. Verified on live host transcripts before being relied on
-  rather than assumed, which is the #158 lesson: a `Read` requested at offset 215
-  comes back with `215` on its first line. The rule is about what survives rather
-  than where the folds are: contiguous survivors all sit the same distance from
-  where they started, so one number puts every one of them back, which covers a
-  fold at the head and one reaching the end of the same payload. Survivors split
-  into two blocks still refuse, because one starting number cannot describe two
-  offsets, and
-  the shape is read from the ledger's own folded indices so content that looks
-  like a marker cannot change the answer. Measured on four overlapping windows of
-  a markdown file under the host's output cap: **0.0% saved before, 4.7% after**,
-  one fold where there had been none. Source files are unaffected, since the
-  `readfile` distiller acts on those first (46.6% either way).
+  refusing the fold. That is correct, and it costs the most common shape there
+  is: re-reading a file at a later offset repeats its head, so the run the ledger
+  can fold is exactly the run with content below it. The host renders
+  `file.content` with `cat -n` numbering counted from `startLine`, so moving
+  `startLine` by the number of marker lines now standing above the survivors puts
+  every one of them back where the file has it. Verified on live host transcripts
+  before being relied on rather than assumed, which is the #158 lesson: a `Read`
+  requested at offset 215 comes back with `215` on its first line.
+
+  The rule is exact rather than clever. The survivors have to be one block
+  running to the end of the payload, which makes the lines above them a
+  subtraction and means nothing has to be searched for. Everything else refuses,
+  including shapes that are correctable in principle, because the alternatives
+  are searching the view for the survivors' text, which can match inside a
+  marker, or a marker count nothing reports. A refused fold costs bytes; a wrong
+  number costs an edit in the wrong place. The shape comes from the ledger's own
+  folded indices, so a file whose lines begin with `[OMNI:` cannot change the
+  answer.
+
+  Measured on four overlapping windows of a markdown file under the host's output
+  cap: **0.0% saved before, 4.7% after**, one fold where there had been none.
+  Source files are unaffected, since the `readfile` distiller acts on those first
+  (46.6% either way).

--- a/changelog.d/leading-fold-keeps-numbering.added.md
+++ b/changelog.d/leading-fold-keeps-numbering.added.md
@@ -1,0 +1,17 @@
+- **A `Read` that repeats the head of a file folds again, and the host's line
+  numbers stay true.** #557 stopped a fold renumbering the lines under it by
+  refusing the fold, which is correct and costs the most common shape there is:
+  re-reading a file at a later offset repeats its head, so the run the ledger can
+  fold is exactly the run that has content below it. The host renders
+  `file.content` with `cat -n` numbering counted from `startLine`, so when the
+  repeated run is at the head one number fixes all of it: move `startLine` by the
+  size of the run minus the marker's own line and every survivor lands back where
+  the file has it. Verified on live host transcripts before being relied on
+  rather than assumed, which is the #158 lesson: a `Read` requested at offset 215
+  comes back with `215` on its first line. A run with content above **and** below
+  it still refuses, because one starting number cannot describe two offsets, and
+  the shape is read from the ledger's own folded indices so content that looks
+  like a marker cannot change the answer. Measured on four overlapping windows of
+  a markdown file under the host's output cap: **0.0% saved before, 4.7% after**,
+  one fold where there had been none. Source files are unaffected, since the
+  `readfile` distiller acts on those first (46.6% either way).

--- a/changelog.d/leading-fold-keeps-numbering.added.md
+++ b/changelog.d/leading-fold-keeps-numbering.added.md
@@ -8,8 +8,12 @@
   size of the run minus the marker's own line and every survivor lands back where
   the file has it. Verified on live host transcripts before being relied on
   rather than assumed, which is the #158 lesson: a `Read` requested at offset 215
-  comes back with `215` on its first line. A run with content above **and** below
-  it still refuses, because one starting number cannot describe two offsets, and
+  comes back with `215` on its first line. The rule is about what survives rather
+  than where the folds are: contiguous survivors all sit the same distance from
+  where they started, so one number puts every one of them back, which covers a
+  fold at the head and one reaching the end of the same payload. Survivors split
+  into two blocks still refuse, because one starting number cannot describe two
+  offsets, and
   the shape is read from the ledger's own folded indices so content that looks
   like a marker cannot change the answer. Measured on four overlapping windows of
   a markdown file under the host's output cap: **0.0% saved before, 4.7% after**,

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -3095,12 +3095,14 @@ src/distillers/system_ops.rs:849:                is_sensitive_key(key),
         );
     }
 
-    /// #572, review. Two folds in one payload, at the head and at the end, leave
-    /// the survivors as one block in the middle, all at the same distance from
-    /// where they started. One starting number still puts every one of them
-    /// back, and an earlier version of the rule threw the projection away.
+    /// #572, review, twice. Folds at the head and at the end leave the survivors
+    /// as one block, and one starting number could in principle put all of them
+    /// back. It is refused anyway, because knowing how many marker lines stand
+    /// above them means either searching the view for their text, which review
+    /// showed can match inside a marker, or a marker count nothing reports. A
+    /// refused fold costs bytes; a wrong number costs an edit in the wrong place.
     #[test]
-    fn folds_at_both_ends_still_correct_with_one_start_line() {
+    fn refuses_folds_at_both_ends_rather_than_guess_the_offset() {
         let line = |i: usize| format!("    let unique_marker_{i:03} = \"quokka-{i:03}-xyzzy\";\n");
         let range = |from: usize, to: usize| (from..to).map(line).collect::<String>();
         let payload = |from: usize, to: usize| {
@@ -3124,21 +3126,12 @@ src/distillers/system_ops.rs:849:                is_sensitive_key(key),
         // Two earlier reads, one at each end of the window that follows.
         let _ = process_payload(&payload(100, 130), Some(store.clone()), None);
         let _ = process_payload(&payload(170, 200), Some(store.clone()), None);
-        let out = process_payload(&payload(100, 200), Some(store.clone()), None)
-            .expect("both ends repeat, so this folds");
-
-        let v: serde_json::Value = serde_json::from_str(&out).expect("hook json");
-        let file = &v["hookSpecificOutput"]["updatedToolOutput"]["file"];
+        let out =
+            process_payload(&payload(100, 200), Some(store.clone()), None).unwrap_or_default();
         assert!(
-            file["content"]
-                .as_str()
-                .expect("content")
-                .contains("[OMNI:"),
-            "neither repeated end was folded: {out}"
-        );
-        assert_eq!(
-            file["startLine"], 129,
-            "the middle block keeps numbers it is no longer at: {out}"
+            !out.contains("[OMNI:"),
+            "a fold with content standing below it went through, so the number of \
+             lines above the survivors was guessed: {out}"
         );
     }
 

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -452,7 +452,7 @@ fn fold_cross_turn(
         // minus the marker's own line puts every surviving number back where the
         // file has it. Verified against live transcripts before relying on it: a
         // `Read` requested at offset 215 renders its first line as `215`.
-        Some((view, FoldShift::Leading { lines })) => (view, lines.saturating_sub(1)),
+        Some((view, FoldShift::Leading { bump })) => (view, bump),
         // Content above and below: one starting number cannot describe both.
         _ => (text, 0),
     }
@@ -3139,6 +3139,58 @@ src/distillers/system_ops.rs:849:                is_sensitive_key(key),
         assert_eq!(
             file["startLine"], 129,
             "the middle block keeps numbers it is no longer at: {out}"
+        );
+    }
+
+    /// #572, review. Adjacent runs of different origin emit one marker each, so a
+    /// repeated head can stand as two lines rather than one. The bump is the
+    /// number of lines above the survivors, not the number of lines folded minus
+    /// one, and the earlier arithmetic put every survivor a line too high.
+    ///
+    /// Built by giving the project scope one half of the head and this session
+    /// the other, which is what makes the two runs differ in origin.
+    #[test]
+    fn a_head_folded_into_two_markers_bumps_by_two() {
+        let line = |i: usize| format!("    let unique_marker_{i:03} = \"quokka-{i:03}-xyzzy\";\n");
+        let range = |from: usize, to: usize| (from..to).map(line).collect::<String>();
+        let payload = |sid: &str, from: usize, to: usize| {
+            json!({
+                "session_id": sid,
+                "tool_name": "Read",
+                "tool_input": {"path": "probe.rs"},
+                "tool_response": {"file": {
+                    "filePath": "probe.rs",
+                    "content": range(from, to),
+                    "startLine": from,
+                    "numLines": to - from,
+                    "totalLines": 400,
+                }},
+            })
+            .to_string()
+        };
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Arc::new(Store::open_path(&dir.path().join("omni.db")).expect("store"));
+        // An earlier session saw the first half of the head, this one saw the
+        // second, so the two runs are adjacent and differently attributed.
+        let _ = process_payload(&payload("earlier", 100, 115), Some(store.clone()), None);
+        let _ = process_payload(&payload("current", 115, 130), Some(store.clone()), None);
+        let out = process_payload(&payload("current", 100, 200), Some(store.clone()), None)
+            .expect("the whole head repeats, so this folds");
+
+        let v: serde_json::Value = serde_json::from_str(&out).expect("hook json");
+        let file = &v["hookSpecificOutput"]["updatedToolOutput"]["file"];
+        let content = file["content"].as_str().expect("content");
+        let markers = content.matches("[OMNI:").count();
+        assert!(markers >= 1, "the repeated head was not folded: {out}");
+
+        // Thirty lines stood above the survivors and `markers` lines stand there
+        // now, so the host has to start counting that much later.
+        let expected = 100 + 30 - markers as u64;
+        assert_eq!(
+            file["startLine"], expected,
+            "{markers} marker line(s) above the survivors, so startLine should be \
+             {expected}: {out}"
         );
     }
 

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -3095,6 +3095,53 @@ src/distillers/system_ops.rs:849:                is_sensitive_key(key),
         );
     }
 
+    /// #572, review. Two folds in one payload, at the head and at the end, leave
+    /// the survivors as one block in the middle, all at the same distance from
+    /// where they started. One starting number still puts every one of them
+    /// back, and an earlier version of the rule threw the projection away.
+    #[test]
+    fn folds_at_both_ends_still_correct_with_one_start_line() {
+        let line = |i: usize| format!("    let unique_marker_{i:03} = \"quokka-{i:03}-xyzzy\";\n");
+        let range = |from: usize, to: usize| (from..to).map(line).collect::<String>();
+        let payload = |from: usize, to: usize| {
+            json!({
+                "session_id": "host-572-ends",
+                "tool_name": "Read",
+                "tool_input": {"path": "probe.rs"},
+                "tool_response": {"file": {
+                    "filePath": "probe.rs",
+                    "content": range(from, to),
+                    "startLine": from,
+                    "numLines": to - from,
+                    "totalLines": 400,
+                }},
+            })
+            .to_string()
+        };
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Arc::new(Store::open_path(&dir.path().join("omni.db")).expect("store"));
+        // Two earlier reads, one at each end of the window that follows.
+        let _ = process_payload(&payload(100, 130), Some(store.clone()), None);
+        let _ = process_payload(&payload(170, 200), Some(store.clone()), None);
+        let out = process_payload(&payload(100, 200), Some(store.clone()), None)
+            .expect("both ends repeat, so this folds");
+
+        let v: serde_json::Value = serde_json::from_str(&out).expect("hook json");
+        let file = &v["hookSpecificOutput"]["updatedToolOutput"]["file"];
+        assert!(
+            file["content"]
+                .as_str()
+                .expect("content")
+                .contains("[OMNI:"),
+            "neither repeated end was folded: {out}"
+        );
+        assert_eq!(
+            file["startLine"], 129,
+            "the middle block keeps numbers it is no longer at: {out}"
+        );
+    }
+
     /// The other half. A run with content above **and** below it cannot be
     /// corrected by a starting number, because one number cannot describe two
     /// offsets, so the fold is refused and the payload goes back whole.

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -77,6 +77,24 @@ enum ToolOutput {
 /// instead of asserting one. The rule is "reply in the shape you were spoken
 /// to in", and it needs no table of per-tool schemas to stay correct.
 fn shape_for_host(raw_response: Option<&serde_json::Value>, distilled: String) -> ToolOutput {
+    shape_for_host_from(raw_response, distilled, 0)
+}
+
+/// As `shape_for_host`, plus how far to move the number the host starts counting
+/// from.
+///
+/// Only a leading fold uses it. The host renders `file.content` with `cat -n`
+/// numbering counted from `startLine`, verified on live transcripts rather than
+/// assumed: a `Read` requested at offset 215 comes back with `215` on its first
+/// line. So a run of `n` lines replaced by one marker leaves everything below
+/// short by `n - 1`, and adding that to `startLine` puts all of it back at once.
+/// The marker itself then carries the number of the last line it replaced, which
+/// is the honest label for a run (#557).
+fn shape_for_host_from(
+    raw_response: Option<&serde_json::Value>,
+    distilled: String,
+    start_line_bump: usize,
+) -> ToolOutput {
     // The `Read` result carries its text at `file.content`, beside numbers that
     // describe it. Captured from a live Claude Code transcript rather than
     // assumed:
@@ -98,6 +116,16 @@ fn shape_for_host(raw_response: Option<&serde_json::Value>, distilled: String) -
         let mut echoed = obj.clone();
         let line_count = distilled.lines().count();
         if let Some(file) = echoed.get_mut("file").and_then(|f| f.as_object_mut()) {
+            if start_line_bump > 0 {
+                let start = file
+                    .get("startLine")
+                    .and_then(serde_json::Value::as_u64)
+                    .unwrap_or(1);
+                file.insert(
+                    "startLine".into(),
+                    serde_json::Value::from(start + start_line_bump as u64),
+                );
+            }
             file.insert("content".into(), serde_json::Value::String(distilled));
             file.insert("numLines".into(), serde_json::Value::from(line_count));
         }
@@ -380,16 +408,18 @@ fn trim_enormous(content: &str) -> std::borrow::Cow<'_, str> {
 /// Same two gates and the same order as the Bash path: structured payloads are
 /// never projected, no host session id means no ledger, and it runs **after**
 /// archiving so a folded run is already recoverable when its marker is written.
+/// The folded text, and how far the caller must move its host's starting line
+/// number so the survivors keep the positions the file gives them (#557).
 fn fold_cross_turn(
     store: Option<&Arc<Store>>,
     normalized: &crate::hooks::normalize::NormalizedInput,
     text: String,
-) -> String {
+) -> (String, usize) {
     let (Some(s), Some(scope)) = (store, normalized.host_session_id.as_deref()) else {
-        return text;
+        return (text, 0);
     };
     if crate::pipeline::format::sniff(&text).is_some() {
-        return text;
+        return (text, 0);
     }
     // The repository, not the directory this ran in: a worktree or a second
     // checkout is the same project and must share its history (#525).
@@ -413,9 +443,18 @@ fn fold_cross_turn(
     // any fold reaching the end of the payload are kept. Only `Read` is affected;
     // `Grep` carries its positions inside the text, where a fold cannot move
     // them, and `Bash` output is not numbered at all.
+    use crate::ledger::FoldShift;
     match folded {
-        Some((view, shifted)) if normalized.tool_name != "Read" || !shifted => view,
-        _ => text,
+        // Not a `Read`: nothing downstream renumbers, so any fold is fine.
+        Some((view, _)) if normalized.tool_name != "Read" => (view, 0),
+        Some((view, FoldShift::None)) => (view, 0),
+        // The host counts from `startLine`, so moving it by the size of the run
+        // minus the marker's own line puts every surviving number back where the
+        // file has it. Verified against live transcripts before relying on it: a
+        // `Read` requested at offset 215 renders its first line as `215`.
+        Some((view, FoldShift::Leading { lines })) => (view, lines.saturating_sub(1)),
+        // Content above and below: one starting number cannot describe both.
+        _ => (text, 0),
     }
 }
 
@@ -441,11 +480,15 @@ fn reply_through_ledger(
     let carried = shortened.is_some();
     let text = shortened.unwrap_or_else(|| content.to_string());
 
-    let folded = fold_cross_turn(store, normalized, text);
+    let (folded, start_line_bump) = fold_cross_turn(store, normalized, text);
     if !carried && folded == content {
         return None;
     }
-    Some(wrap_hook_output(normalized.raw_response.as_ref(), folded))
+    Some(wrap_hook_output(
+        normalized.raw_response.as_ref(),
+        folded,
+        start_line_bump,
+    ))
 }
 
 fn distil_tool_reply(
@@ -532,7 +575,7 @@ fn distil_tool_reply(
             if summary.len() < content.len() * 8 / 10 {
                 return Some(
                     archive_tool_reply(store, content, summary)
-                        .map(|d| wrap_hook_output(normalized.raw_response.as_ref(), d)),
+                        .map(|d| wrap_hook_output(normalized.raw_response.as_ref(), d, 0)),
                 );
             }
             return Some(None);
@@ -551,7 +594,7 @@ fn distil_tool_reply(
                 );
                 return Some(
                     archive_tool_reply(store, content, summary)
-                        .map(|d| wrap_hook_output(normalized.raw_response.as_ref(), d)),
+                        .map(|d| wrap_hook_output(normalized.raw_response.as_ref(), d, 0)),
                 );
             }
             return Some(None);
@@ -1237,11 +1280,15 @@ fn carries_our_marker(content: &str) -> bool {
     })
 }
 
-fn wrap_hook_output(raw_response: Option<&serde_json::Value>, distilled: String) -> String {
+fn wrap_hook_output(
+    raw_response: Option<&serde_json::Value>,
+    distilled: String,
+    start_line_bump: usize,
+) -> String {
     serde_json::to_string(&HookOutput {
         hook_specific_output: HookSpecificOutput {
             hook_event_name: "PostToolUse",
-            updated_tool_output: shape_for_host(raw_response, distilled),
+            updated_tool_output: shape_for_host_from(raw_response, distilled, start_line_bump),
             additional_context: None,
         },
     })
@@ -1613,7 +1660,7 @@ mod tests {
     /// the first day of the Rust rewrite until it was found by hand.
     #[test]
     fn serialises_the_key_the_host_actually_reads() {
-        let json = wrap_hook_output(None, "distilled".to_string());
+        let json = wrap_hook_output(None, "distilled".to_string(), 0);
 
         assert!(json.contains(r#""updatedToolOutput""#), "{json}");
         assert!(
@@ -2995,92 +3042,127 @@ src/distillers/system_ops.rs:849:                is_sensitive_key(key),
         );
     }
 
-    /// #557. A `Read` payload goes back as `file.content` and the host renders it
-    /// with `cat -n` numbering counted from `startLine`, so it numbers whatever
-    /// lines we return. A fold in the middle removes lines the count was walking
-    /// over, and every surviving line below the marker is labelled short by the
-    /// size of the fold, with nothing in the payload saying so. Those numbers are
-    /// a contract: the agent writes them into issues and decides what to edit
-    /// from them.
+    /// A `Read` payload goes back as `file.content` and the host renders it with
+    /// `cat -n` numbering counted from `startLine`, so it numbers whatever lines
+    /// it is handed. Replacing a run with a one-line marker removes lines the
+    /// count was walking over (#557).
     ///
-    /// Both halves are load bearing. Refusing every fold passes the first
-    /// assertion on its own and silently costs the whole-output fold, which
-    /// shifts nothing because nothing survives under it.
+    /// When the run is at the head, one number fixes all of it: move `startLine`
+    /// by the size of the run minus the marker's own line and every survivor is
+    /// back where the file has it. Verified against live transcripts before being
+    /// relied on, rather than assumed: a `Read` requested at offset 215 comes back
+    /// with `215` on its first line.
     #[test]
-    fn refuses_a_read_fold_that_would_renumber_the_lines_below_it() {
+    fn a_leading_fold_moves_the_start_line_so_the_numbers_stay_true() {
         let line = |i: usize| format!("    let unique_marker_{i:03} = \"quokka-{i:03}-xyzzy\";\n");
         let range = |from: usize, to: usize| (from..to).map(line).collect::<String>();
-        let payload = |body: &str| {
+        let payload = |from: usize, to: usize| {
             json!({
-                "session_id": "host-557",
+                "session_id": "host-557-lead",
                 "tool_name": "Read",
                 "tool_input": {"path": "probe.rs"},
-                "tool_response": {"content": body},
+                "tool_response": {"file": {
+                    "filePath": "probe.rs",
+                    "content": range(from, to),
+                    "startLine": from,
+                    "numLines": to - from,
+                    "totalLines": 400,
+                }},
             })
             .to_string()
         };
 
-        // The repeat lands at the top of the second payload with fresh lines
-        // under it, which is the shape that renumbers.
         let dir = tempfile::tempdir().expect("tempdir");
         let store = Arc::new(Store::open_path(&dir.path().join("omni.db")).expect("store"));
-        let _ = process_payload(&payload(&range(100, 130)), Some(store.clone()), None);
-        let overlapping = process_payload(&payload(&range(100, 200)), Some(store.clone()), None)
-            .unwrap_or_default();
-        assert!(
-            !overlapping.contains("[OMNI:"),
-            "a fold with 70 lines under it renumbered every one of them: {overlapping}"
-        );
+        let _ = process_payload(&payload(100, 130), Some(store.clone()), None);
+        let out = process_payload(&payload(100, 200), Some(store.clone()), None)
+            .expect("the head repeats, so this folds");
 
-        // A fresh store, so the only difference is where the repeat sits: at the
-        // end, where no number can move.
-        let dir2 = tempfile::tempdir().expect("tempdir");
-        let store2 = Arc::new(Store::open_path(&dir2.path().join("omni.db")).expect("store"));
-        let _ = process_payload(&payload(&range(170, 200)), Some(store2.clone()), None);
-        let trailing = process_payload(&payload(&range(100, 200)), Some(store2.clone()), None)
-            .unwrap_or_default();
+        let v: serde_json::Value = serde_json::from_str(&out).expect("hook json");
+        let file = &v["hookSpecificOutput"]["updatedToolOutput"]["file"];
         assert!(
-            trailing.contains("[OMNI:"),
-            "a fold at the end shifts nothing and has to still happen: {trailing}"
+            file["content"]
+                .as_str()
+                .expect("content")
+                .contains("[OMNI:"),
+            "the repeated head was not folded: {out}"
+        );
+        // Thirty lines became one marker, so the survivors moved up by 29 and the
+        // host has to start counting 29 later for them to land where they live.
+        assert_eq!(
+            file["startLine"], 129,
+            "the survivors keep the numbers of a file they are no longer at: {out}"
         );
     }
 
-    /// #557, review. The first version of the guard read the output back and
-    /// called any line starting with `[OMNI:` a marker, so a file whose own
-    /// lines start that way defeated it and the fold went through with every
-    /// number below it wrong. This repository writes those strings into its
-    /// changelog and its docs, so it is not a hypothetical file.
-    ///
-    /// The guard now asks the ledger which indices it folded, which cannot be
-    /// spoofed by content.
+    /// The other half. A run with content above **and** below it cannot be
+    /// corrected by a starting number, because one number cannot describe two
+    /// offsets, so the fold is refused and the payload goes back whole.
+    #[test]
+    fn refuses_an_interior_fold_that_would_renumber_the_lines_below_it() {
+        let line = |i: usize| format!("    let unique_marker_{i:03} = \"quokka-{i:03}-xyzzy\";\n");
+        let range = |from: usize, to: usize| (from..to).map(line).collect::<String>();
+        let payload = |from: usize, to: usize| {
+            json!({
+                "session_id": "host-557-mid",
+                "tool_name": "Read",
+                "tool_input": {"path": "probe.rs"},
+                "tool_response": {"file": {
+                    "filePath": "probe.rs",
+                    "content": range(from, to),
+                    "startLine": from,
+                    "numLines": to - from,
+                    "totalLines": 400,
+                }},
+            })
+            .to_string()
+        };
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Arc::new(Store::open_path(&dir.path().join("omni.db")).expect("store"));
+        let _ = process_payload(&payload(130, 165), Some(store.clone()), None);
+        let out =
+            process_payload(&payload(100, 200), Some(store.clone()), None).unwrap_or_default();
+        assert!(
+            !out.contains("[OMNI:"),
+            "a fold with content on both sides renumbered the lines under it: {out}"
+        );
+    }
+
+    /// #557, review. An earlier guard read the output back and called any line
+    /// starting with `[OMNI:` a marker, so a file whose own lines start that way
+    /// defeated it. This repository writes those strings into its changelog and
+    /// its docs, so it is not a hypothetical file. The shape is asked of the
+    /// ledger's folded indices now, which content cannot spoof.
     #[test]
     fn content_that_looks_like_a_marker_does_not_defeat_the_guard() {
-        // Same shape as the test above, so it is known to reach a fold, with
-        // every line wearing the marker prefix.
         let line = |i: usize| format!("[OMNI: unique_marker_{i:03} = \"quokka-{i:03}-xyzzy\"]\n");
         let range = |from: usize, to: usize| (from..to).map(line).collect::<String>();
-        let payload = |body: &str| {
+        let payload = |from: usize, to: usize| {
             json!({
                 "session_id": "host-557-lookalike",
                 "tool_name": "Read",
                 "tool_input": {"path": "changelog.md"},
-                "tool_response": {"content": body},
+                "tool_response": {"file": {
+                    "filePath": "changelog.md",
+                    "content": range(from, to),
+                    "startLine": from,
+                    "numLines": to - from,
+                    "totalLines": 400,
+                }},
             })
             .to_string()
         };
 
         let dir = tempfile::tempdir().expect("tempdir");
         let store = Arc::new(Store::open_path(&dir.path().join("omni.db")).expect("store"));
-        let _ = process_payload(&payload(&range(100, 130)), Some(store.clone()), None);
-        let second = process_payload(&payload(&range(100, 200)), Some(store.clone()), None)
-            .unwrap_or_default();
-
-        // The head of the file has to survive: a fold would have replaced those
-        // thirty lines and moved the seventy below them.
+        let _ = process_payload(&payload(130, 165), Some(store.clone()), None);
+        let out =
+            process_payload(&payload(100, 200), Some(store.clone()), None).unwrap_or_default();
         assert!(
-            second.is_empty() || second.contains("unique_marker_100"),
-            "the head was folded away and the lines below it renumbered, because \
-             the surviving content was read as markers: {second}"
+            !out.contains("omni retrieve"),
+            "an interior fold went through because the surviving content was read \
+             as markers: {out}"
         );
     }
 

--- a/src/ledger/mod.rs
+++ b/src/ledger/mod.rs
@@ -130,6 +130,44 @@ impl Origin {
 /// silently folding runs that do not pay.
 const HANDLE_LEN: usize = 16;
 
+/// What a fold did to the numbers of the lines still under it.
+///
+/// Only a caller that controls where its host starts counting can act on this,
+/// which today is the `Read` path: the host renders `file.content` with `cat -n`
+/// numbering counted from `startLine`, so it numbers whatever it is handed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FoldShift {
+    /// Nothing survives below the fold, so no number moves. A whole-output fold
+    /// and any fold reaching the end of the payload are this.
+    None,
+    /// The fold starts at the first line and covers `lines` of them, replacing
+    /// them with one marker. Everything below is short by `lines - 1`, and a
+    /// caller that can move its starting number corrects all of it at once.
+    Leading { lines: usize },
+    /// Content above the fold and content below it. Nothing can correct that,
+    /// because one starting number cannot describe two different offsets.
+    Interior,
+}
+
+impl FoldShift {
+    fn of(folded: &HashSet<usize>, total: usize) -> Self {
+        let Some(&first) = folded.iter().min() else {
+            return Self::None;
+        };
+        if !(first..total).any(|i| !folded.contains(&i)) {
+            return Self::None;
+        }
+        // Contiguous from the top: the run is exactly 0..len, so one marker sits
+        // where `len` lines were and the rest of the payload follows it intact.
+        if first == 0 && (0..folded.len()).all(|i| folded.contains(&i)) {
+            return Self::Leading {
+                lines: folded.len(),
+            };
+        }
+        Self::Interior
+    }
+}
+
 /// Addresses the ledger for one session, and optionally for its project.
 ///
 /// Cross-session repetition measures 3.7% of post-filter bytes against 19.1%
@@ -198,15 +236,15 @@ impl<'a> Ledger<'a> {
         self.project_reporting_shift(text).map(|(view, _)| view)
     }
 
-    /// The view, and whether any line survives below the first fold.
+    /// The view, and what the fold did to the numbering of the lines under it.
     ///
     /// A caller whose host numbers the lines it is handed needs the second half:
     /// a marker with content under it moves every one of those numbers, and the
     /// payload says nothing about it (#557). The question is answered from the
     /// folded indices rather than by recognising markers in the output, because
     /// a file whose own lines begin with the marker prefix would defeat that.
-    pub fn project_reporting_shift(&self, text: &str) -> Option<(String, bool)> {
-        let shift = std::cell::Cell::new(false);
+    pub fn project_reporting_shift(&self, text: &str) -> Option<(String, FoldShift)> {
+        let shift = std::cell::Cell::new(FoldShift::None);
         // The gain gate wraps the projection rather than being re-derived inside
         // it (spec 5.4). `MIN_LEDGER_INPUT` is this projection's own floor and is
         // higher than the gate's, so both apply and the stricter one decides.
@@ -219,7 +257,7 @@ impl<'a> Ledger<'a> {
         Some((view, shift.get()))
     }
 
-    fn project_inner(&self, text: &str) -> Option<(String, bool)> {
+    fn project_inner(&self, text: &str) -> Option<(String, FoldShift)> {
         if text.len() < MIN_LEDGER_INPUT {
             return None;
         }
@@ -366,15 +404,12 @@ impl<'a> Ledger<'a> {
             self.store.ledger_record(p, &delivered, &self.agent);
         }
 
-        // True when an unfolded line sits below the first folded one, so the
-        // surviving content has moved up relative to where the caller's host
-        // will count it from (#557).
-        let shifts = projected.as_ref().is_some_and(|(_, folded)| {
-            folded
-                .iter()
-                .min()
-                .is_some_and(|first| (*first..lines.len()).any(|i| !folded.contains(&i)))
-        });
+        // What the fold did to the numbering below it (#557). Read from the
+        // folded indices, where the answer is known.
+        let shifts = projected
+            .as_ref()
+            .map(|(_, folded)| FoldShift::of(folded, lines.len()))
+            .unwrap_or(FoldShift::None);
         projected.map(|(view, _)| (view, shifts))
     }
 

--- a/src/ledger/mod.rs
+++ b/src/ledger/mod.rs
@@ -164,7 +164,7 @@ impl FoldShift {
     /// That covers a fold at the head **and** one reaching the end in the same
     /// payload, which an earlier version of this classified as uncorrectable.
     /// Review caught it.
-    fn of(folded: &HashSet<usize>, total: usize, lines: &[&str], view: &str) -> Self {
+    fn of(folded: &HashSet<usize>, total: usize, view: &str) -> Self {
         let survivors: Vec<usize> = (0..total).filter(|i| !folded.contains(i)).collect();
         let (Some(&first), Some(&last)) = (survivors.first(), survivors.last()) else {
             // Nothing survived, so nothing can be misnumbered.
@@ -178,25 +178,26 @@ impl FoldShift {
             // the host will give them are already right.
             return Self::None;
         }
-        // How many lines the view puts above the survivors. Found by locating the
-        // surviving block, which the view carries verbatim, rather than by
-        // assuming one marker per fold: adjacent runs of different origin emit
-        // one marker each.
-        let block: String = lines[first..=last].concat();
-        let Some(at) = view.find(&block) else {
-            // The block is always present, but a projection that ever stopped
-            // being verbatim must not silently produce a wrong number.
+        // The survivors have to run to the end of the payload, so nothing stands
+        // below them and the arithmetic is exact: every view line that is not one
+        // of them is a marker above them.
+        //
+        // The first version searched the view for the surviving block and counted
+        // the newlines before it. Review found the hole: a block whose text also
+        // occurs inside a marker, which `already shown` is, matches there instead
+        // and the count comes out short. There is no way to search content for a
+        // position and be sure, so this does not search.
+        //
+        // The price is a fold at the head *and* one reaching the end in the same
+        // payload, which is correctable in principle and is refused here rather
+        // than computed from a marker count nothing reports.
+        if last + 1 != total {
+            return Self::Interior;
+        }
+        let view_lines = view.lines().count();
+        let Some(markers_above) = view_lines.checked_sub(survivors.len()) else {
             return Self::Interior;
         };
-        // Counted in bytes rather than by slicing the string: `find` returns a
-        // char boundary, but the count does not need the slice and clippy is
-        // right that a slice invites the next edit to use an index that is not.
-        // The block always starts after a newline, so newlines above it is the
-        // line count above it.
-        let markers_above = view.as_bytes()[..at]
-            .iter()
-            .filter(|b| **b == b'\n')
-            .count();
         Self::Leading {
             bump: first.saturating_sub(markers_above),
         }
@@ -443,7 +444,7 @@ impl<'a> Ledger<'a> {
         // folded indices, where the answer is known.
         let shifts = projected
             .as_ref()
-            .map(|(view, folded)| FoldShift::of(folded, lines.len(), &lines, view))
+            .map(|(view, folded)| FoldShift::of(folded, lines.len(), view))
             .unwrap_or(FoldShift::None);
         projected.map(|(view, _)| (view, shifts))
     }

--- a/src/ledger/mod.rs
+++ b/src/ledger/mod.rs
@@ -188,7 +188,15 @@ impl FoldShift {
             // being verbatim must not silently produce a wrong number.
             return Self::Interior;
         };
-        let markers_above = view[..at].lines().count();
+        // Counted in bytes rather than by slicing the string: `find` returns a
+        // char boundary, but the count does not need the slice and clippy is
+        // right that a slice invites the next edit to use an index that is not.
+        // The block always starts after a newline, so newlines above it is the
+        // line count above it.
+        let markers_above = view.as_bytes()[..at]
+            .iter()
+            .filter(|b| **b == b'\n')
+            .count();
         Self::Leading {
             bump: first.saturating_sub(markers_above),
         }

--- a/src/ledger/mod.rs
+++ b/src/ledger/mod.rs
@@ -140,10 +140,15 @@ pub enum FoldShift {
     /// Nothing survives below the fold, so no number moves. A whole-output fold
     /// and any fold reaching the end of the payload are this.
     None,
-    /// The fold starts at the first line and covers `lines` of them, replacing
-    /// them with one marker. Everything below is short by `lines - 1`, and a
-    /// caller that can move its starting number corrects all of it at once.
-    Leading { lines: usize },
+    /// The survivors are one block with folded lines above them. `bump` is what
+    /// the caller must add to its host's starting number so the first survivor
+    /// lands on the line the file gives it, and with it every line below.
+    ///
+    /// Not "folded lines minus one": adjacent runs of different origin emit one
+    /// marker each, so the number of lines standing above the survivors is the
+    /// number of markers, which is what this counts. Review found the earlier
+    /// arithmetic putting every survivor `k - 1` lines too high.
+    Leading { bump: usize },
     /// Content above the fold and content below it. Nothing can correct that,
     /// because one starting number cannot describe two different offsets.
     Interior,
@@ -159,7 +164,7 @@ impl FoldShift {
     /// That covers a fold at the head **and** one reaching the end in the same
     /// payload, which an earlier version of this classified as uncorrectable.
     /// Review caught it.
-    fn of(folded: &HashSet<usize>, total: usize) -> Self {
+    fn of(folded: &HashSet<usize>, total: usize, lines: &[&str], view: &str) -> Self {
         let survivors: Vec<usize> = (0..total).filter(|i| !folded.contains(i)).collect();
         let (Some(&first), Some(&last)) = (survivors.first(), survivors.last()) else {
             // Nothing survived, so nothing can be misnumbered.
@@ -171,9 +176,21 @@ impl FoldShift {
         if first == 0 {
             // The survivors still start where the payload does, so the numbers
             // the host will give them are already right.
-            Self::None
-        } else {
-            Self::Leading { lines: first }
+            return Self::None;
+        }
+        // How many lines the view puts above the survivors. Found by locating the
+        // surviving block, which the view carries verbatim, rather than by
+        // assuming one marker per fold: adjacent runs of different origin emit
+        // one marker each.
+        let block: String = lines[first..=last].concat();
+        let Some(at) = view.find(&block) else {
+            // The block is always present, but a projection that ever stopped
+            // being verbatim must not silently produce a wrong number.
+            return Self::Interior;
+        };
+        let markers_above = view[..at].lines().count();
+        Self::Leading {
+            bump: first.saturating_sub(markers_above),
         }
     }
 }
@@ -418,7 +435,7 @@ impl<'a> Ledger<'a> {
         // folded indices, where the answer is known.
         let shifts = projected
             .as_ref()
-            .map(|(_, folded)| FoldShift::of(folded, lines.len()))
+            .map(|(view, folded)| FoldShift::of(folded, lines.len(), &lines, view))
             .unwrap_or(FoldShift::None);
         projected.map(|(view, _)| (view, shifts))
     }

--- a/src/ledger/mod.rs
+++ b/src/ledger/mod.rs
@@ -150,21 +150,31 @@ pub enum FoldShift {
 }
 
 impl FoldShift {
+    /// The question is not where the folds are, it is whether what survives them
+    /// is one block. Contiguous survivors all sit at the same distance from
+    /// where they started, so a single starting number puts every one of them
+    /// back; split survivors sit at two different distances and no single number
+    /// describes both.
+    ///
+    /// That covers a fold at the head **and** one reaching the end in the same
+    /// payload, which an earlier version of this classified as uncorrectable.
+    /// Review caught it.
     fn of(folded: &HashSet<usize>, total: usize) -> Self {
-        let Some(&first) = folded.iter().min() else {
+        let survivors: Vec<usize> = (0..total).filter(|i| !folded.contains(i)).collect();
+        let (Some(&first), Some(&last)) = (survivors.first(), survivors.last()) else {
+            // Nothing survived, so nothing can be misnumbered.
             return Self::None;
         };
-        if !(first..total).any(|i| !folded.contains(&i)) {
-            return Self::None;
+        if last - first + 1 != survivors.len() {
+            return Self::Interior;
         }
-        // Contiguous from the top: the run is exactly 0..len, so one marker sits
-        // where `len` lines were and the rest of the payload follows it intact.
-        if first == 0 && (0..folded.len()).all(|i| folded.contains(&i)) {
-            return Self::Leading {
-                lines: folded.len(),
-            };
+        if first == 0 {
+            // The survivors still start where the payload does, so the numbers
+            // the host will give them are already right.
+            Self::None
+        } else {
+            Self::Leading { lines: first }
         }
-        Self::Interior
     }
 }
 


### PR DESCRIPTION
#557 stopped a `Read` fold renumbering the lines under it by refusing the fold. That is correct, and it costs the most common shape there is: re-reading a file at a later offset repeats its head, so the run the ledger can fold is exactly the run that has content below it. This gets that back.

The host renders `file.content` with `cat -n` numbering counted from `startLine`, so it numbers whatever lines it is handed. When the repeated run is at the head, one number fixes all of it: move `startLine` by the size of the run minus the marker's own line, and every survivor lands back where the file has it. The marker then carries the number of the last line it replaced, which is the honest label for a run.

That contract was verified against live host transcripts before anything was built on it, rather than assumed, which is the #158 lesson: a `Read` requested at offset 215 comes back with `215` on its first line, offset 86 with `86`, offset 26 with `26`.

A run with content above **and** below it still refuses, because one starting number cannot describe two offsets. The shape comes from the ledger's own folded indices rather than from reading markers out of the output, so a file whose lines begin with `[OMNI:` cannot change the answer.

Measured on four overlapping windows of a markdown file, sized under the host's output cap, same binary either side:

```
main   raw=17,070 B   delivered=17,070 B   saved= 0.0%   fold markers=0
this   raw=17,070 B   delivered=16,276 B   saved= 4.7%   fold markers=1
```

Scope, stated because the number is small and easy to over-read: this only reaches payloads the `readfile` distiller declines. On source files that distiller acts first and nothing changes, measured at 46.6% either way. Above the host's 30 KB cap both arms decline, as they should.

Three tests, and the assertions were driven red before being trusted: the leading fold asserts `startLine` moves to 129 and fails with `left: 100, right: 129` when the move is removed; the interior fold asserts nothing folds; the marker-lookalike file asserts an interior fold is still refused when its content imitates markers. Full suite green, 764 tests. `make ci` green.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR restores safe folding for repeated leading portions of numbered Read results while preserving the surviving file lines’ original numbers.
- Adds fold-shift metadata derived from folded and surviving line indices.
- Adjusts the returned Read `startLine` by the number of removed rendered lines.
- Refuses projections whose survivors cannot be numbered safely with one starting offset.
- Adds regression coverage for multiple markers, interior folds, folds at both ends, and marker-like file content.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/ledger/mod.rs | Introduces index-derived fold-shift classification and safely refuses projections that cannot retain truthful numbering. |
| src/hooks/post_tool.rs | Propagates the computed leading-fold offset into numbered Read responses and adds focused regression tests. |
| changelog.d/leading-fold-keeps-numbering.added.md | Documents the restored leading-fold behavior and its conservative refusal rule. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Project Read output through ledger] --> B{Fold produced?}
    B -- No --> C[Keep original output]
    B -- Yes --> D{Read tool?}
    D -- No --> E[Return folded view]
    D -- Yes --> F{FoldShift}
    F -- None --> E
    F -- Leading --> G[Add bump to startLine]
    G --> E
    F -- Interior --> C
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(ledger): count the lines above the s..."](https://github.com/fajarhide/omni/commit/a7edc2a3e0ac9264f2b7971163860e49db32df35) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53585647)</sub>

<!-- /greptile_comment -->