### PR TITLE
feat(ledger): fold both ends of a Read, and keep the middle numbered right

### DIFF
--- a/changelog.d/573.added.md
+++ b/changelog.d/573.added.md
@@ -1,0 +1,20 @@
+- **A `Read` with repeats at both ends folds both of them, and the middle keeps
+  its line numbers.** Folds above and below the surviving lines leave those lines
+  as one block, still the same distance into the file and into the view, so one
+  `startLine` closes that gap whatever follows them. The previous release refused
+  this because nothing reported how many marker lines stood above the block, and
+  every way of inferring it from the output was wrong: one marker per fold is
+  wrong when adjacent runs of different origin emit one each, searching the view
+  for the surviving text matches inside a marker when the text is something a
+  marker also says, and recognising markers by their prefix is defeated by a file
+  whose own lines start with it. `substitute` reports the count now, which is the
+  only place that knows.
+
+  Sized before it was built, over 4,552 `Read` results in the local transcripts:
+  folds at both ends are 129 of the 1,868 reads that repeat something and carry
+  257 KB, against 3.29 MB reachable before, so roughly 7.8% more folded bytes.
+  End to end on that shape, same binary either side: **0.0% saved before, 33.8%
+  after**, with `startLine` moving from 100 to 124 exactly as the twenty-five
+  folded head lines require. Reads whose survivors sit in two separate blocks,
+  1,020 of the 1,868, stay refused and always will: one starting number cannot
+  describe two offsets. (#573)

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -3095,14 +3095,15 @@ src/distillers/system_ops.rs:849:                is_sensitive_key(key),
         );
     }
 
-    /// #572, review, twice. Folds at the head and at the end leave the survivors
-    /// as one block, and one starting number could in principle put all of them
-    /// back. It is refused anyway, because knowing how many marker lines stand
-    /// above them means either searching the view for their text, which review
-    /// showed can match inside a marker, or a marker count nothing reports. A
-    /// refused fold costs bytes; a wrong number costs an edit in the wrong place.
+    /// #573. Folds at the head and at the end leave the survivors as one block,
+    /// still `first` lines into the file and `markers_above` lines into the view,
+    /// so one starting number closes that gap whatever follows them. #572 refused
+    /// this for want of a marker count; `substitute` reports one now.
+    ///
+    /// Worth 129 of 1,868 repeated reads in the local corpus and 257 KB against
+    /// the 3.29 MB reachable before it.
     #[test]
-    fn refuses_folds_at_both_ends_rather_than_guess_the_offset() {
+    fn folds_at_both_ends_and_still_numbers_the_middle_right() {
         let line = |i: usize| format!("    let unique_marker_{i:03} = \"quokka-{i:03}-xyzzy\";\n");
         let range = |from: usize, to: usize| (from..to).map(line).collect::<String>();
         let payload = |from: usize, to: usize| {
@@ -3126,12 +3127,25 @@ src/distillers/system_ops.rs:849:                is_sensitive_key(key),
         // Two earlier reads, one at each end of the window that follows.
         let _ = process_payload(&payload(100, 130), Some(store.clone()), None);
         let _ = process_payload(&payload(170, 200), Some(store.clone()), None);
-        let out =
-            process_payload(&payload(100, 200), Some(store.clone()), None).unwrap_or_default();
-        assert!(
-            !out.contains("[OMNI:"),
-            "a fold with content standing below it went through, so the number of \
-             lines above the survivors was guessed: {out}"
+        let out = process_payload(&payload(100, 200), Some(store.clone()), None)
+            .expect("both ends repeat, so this folds");
+
+        let v: serde_json::Value = serde_json::from_str(&out).expect("hook json");
+        let file = &v["hookSpecificOutput"]["updatedToolOutput"]["file"];
+        let content = file["content"].as_str().expect("content");
+        assert!(content.contains("[OMNI:"), "neither end was folded: {out}");
+
+        // Thirty lines stood above the survivors and the markers that replaced
+        // them stand there now, so the host starts counting that much later. The
+        // tail fold below them moves nothing.
+        let above = content
+            .lines()
+            .take_while(|l| l.starts_with("[OMNI:"))
+            .count() as u64;
+        assert_eq!(
+            file["startLine"],
+            100 + 30 - above,
+            "the middle block keeps numbers it is no longer at: {out}"
         );
     }
 

--- a/src/ledger/mod.rs
+++ b/src/ledger/mod.rs
@@ -161,10 +161,15 @@ impl FoldShift {
     /// back; split survivors sit at two different distances and no single number
     /// describes both.
     ///
-    /// That covers a fold at the head **and** one reaching the end in the same
-    /// payload, which an earlier version of this classified as uncorrectable.
-    /// Review caught it.
-    fn of(folded: &HashSet<usize>, total: usize, view: &str) -> Self {
+    /// `markers_above` comes from `substitute`, which is the only place that
+    /// knows: a run becomes one marker or stays verbatim. Three attempts to infer
+    /// it from the output were wrong before it was simply reported (#573), and
+    /// each is worth not repeating. `folded.len() - 1` assumes one marker per
+    /// fold and adjacent runs of different origin emit one each. Searching the
+    /// view for the surviving block matches inside a marker when the block's text
+    /// is something a marker also says. Recognising markers by their prefix is
+    /// defeated by a file whose own lines start with it.
+    fn of(folded: &HashSet<usize>, total: usize, markers_above: usize) -> Self {
         let survivors: Vec<usize> = (0..total).filter(|i| !folded.contains(i)).collect();
         let (Some(&first), Some(&last)) = (survivors.first(), survivors.last()) else {
             // Nothing survived, so nothing can be misnumbered.
@@ -178,26 +183,9 @@ impl FoldShift {
             // the host will give them are already right.
             return Self::None;
         }
-        // The survivors have to run to the end of the payload, so nothing stands
-        // below them and the arithmetic is exact: every view line that is not one
-        // of them is a marker above them.
-        //
-        // The first version searched the view for the surviving block and counted
-        // the newlines before it. Review found the hole: a block whose text also
-        // occurs inside a marker, which `already shown` is, matches there instead
-        // and the count comes out short. There is no way to search content for a
-        // position and be sure, so this does not search.
-        //
-        // The price is a fold at the head *and* one reaching the end in the same
-        // payload, which is correctable in principle and is refused here rather
-        // than computed from a marker count nothing reports.
-        if last + 1 != total {
-            return Self::Interior;
-        }
-        let view_lines = view.lines().count();
-        let Some(markers_above) = view_lines.checked_sub(survivors.len()) else {
-            return Self::Interior;
-        };
+        // A fold below the survivors changes nothing about the survivors: they are
+        // still `first` lines into the file and `markers_above` lines into the
+        // view, so one number closes that gap whatever follows them.
         Self::Leading {
             bump: first.saturating_sub(markers_above),
         }
@@ -356,7 +344,7 @@ impl<'a> Ledger<'a> {
         // deterministic for a caller replaying the same session.
         let projected = self
             .substitute(&lines, &hashes, &origin_of)
-            .filter(|(view, _)| view.len() < text.len());
+            .filter(|(view, _, _)| view.len() < text.len());
 
         // Record what the agent was handed, which is not always what it was
         // given (#465). A run replaced by a marker never reached the context, so
@@ -370,7 +358,7 @@ impl<'a> Ledger<'a> {
         // the gain filter above, the caller emits `text` verbatim and every line
         // was delivered. That is the empty-set case and needs no special arm.
         let delivered: Vec<String> = match &projected {
-            Some((_, folded)) => hashes
+            Some((_, folded, _)) => hashes
                 .iter()
                 .enumerate()
                 .filter(|(i, _)| !folded.contains(i))
@@ -382,7 +370,7 @@ impl<'a> Ledger<'a> {
         // like this session's (#533). `PROJECT_FLOOR_MULT` prices cross-agent
         // reuse and was calibrated on the single-agent case, and nothing recorded
         // enough to tell the two apart after the fact.
-        if let Some((_, folded)) = &projected {
+        if let Some((_, folded, _)) = &projected {
             // Every line folded means the agent holds markers and nothing else,
             // which is the case `MIN_WHOLE_OUTPUT_FOLD` refuses below 1 KB. Read
             // here rather than threaded out of `substitute`, because that flag is
@@ -444,9 +432,9 @@ impl<'a> Ledger<'a> {
         // folded indices, where the answer is known.
         let shifts = projected
             .as_ref()
-            .map(|(view, folded)| FoldShift::of(folded, lines.len(), view))
+            .map(|(_, folded, above)| FoldShift::of(folded, lines.len(), *above))
             .unwrap_or(FoldShift::None);
-        projected.map(|(view, _)| (view, shifts))
+        projected.map(|(view, _, _)| (view, shifts))
     }
 
     /// The view, and the indices of the lines it replaced with a marker.
@@ -459,7 +447,7 @@ impl<'a> Ledger<'a> {
         lines: &[&str],
         hashes: &[String],
         origin_of: &dyn Fn(&String) -> Option<Origin>,
-    ) -> Option<(String, HashSet<usize>)> {
+    ) -> Option<(String, HashSet<usize>, usize)> {
         let runs = group_runs(hashes, origin_of);
         if !runs.iter().any(|r| r.seen.is_some()) {
             return None;
@@ -468,6 +456,12 @@ impl<'a> Ledger<'a> {
         let mut out = String::with_capacity(lines.iter().map(|l| l.len()).sum());
         let mut folded: HashSet<usize> = HashSet::new();
         let mut replaced_any = false;
+        // How many marker lines stand above the first line that survives. Counted
+        // here because this is the only place that knows: a run becomes one marker
+        // or stays verbatim, and adjacent runs of different origin are separate
+        // runs. Every attempt to infer it downstream was wrong (#573).
+        let mut markers_above = 0usize;
+        let mut still_above = true;
         for run in runs {
             let body = lines[run.start..run.end].concat();
             // The only question that decides a fold: does this run save more
@@ -524,11 +518,17 @@ impl<'a> Ledger<'a> {
                     }
                     folded.extend(run.start..run.end);
                     replaced_any = true;
+                    if still_above {
+                        markers_above += 1;
+                    }
                 }
-                None => out.push_str(&body),
+                None => {
+                    out.push_str(&body);
+                    still_above = false;
+                }
             }
         }
-        replaced_any.then_some((out, folded))
+        replaced_any.then_some((out, folded, markers_above))
     }
 }
 


### PR DESCRIPTION
#572 folds a repeated `Read` head and moves `startLine` so the surviving lines keep the numbers the file gives them. It only did that when the survivors ran to the end of the payload, because that was the one shape whose offset was a subtraction rather than a guess.

Folds at both ends leave the survivors as one block too, still the same distance into the file and into the view, so one starting number closes that gap whatever follows them. They were refused for one missing fact: how many marker lines stand above the block.

`substitute` reports it now. It is the only place that knows, because a run either becomes one marker or stays verbatim, and adjacent runs of different origin are separate runs. Three lines there replace an inference that could not be made safely anywhere else, and all three attempts on #572 were wrong: one marker per fold, searching the view for the surviving text, and recognising markers by their prefix.

Sized before it was built, over 4,552 `Read` results in the local transcripts:

| shape | count | share | repeated bytes |
| --- | ---: | ---: | ---: |
| whole payload | 629 | 33.7% | 3,242,009 |
| survivors reach the end | 90 | 4.8% | 52,208 |
| **folds at both ends** | **129** | **6.9%** | **257,140** |
| survivors in two blocks | 1,020 | 54.6% | 1,515,519 |

End to end on that shape, same binary either side, three reads under the `readfile` gate:

```
merged main   6,720 of 6,720 B delivered    0.0% saved   0 folds   no rewrite
this          4,446 of 6,720 B delivered   33.8% saved   2 folds   startLine 100 -> 124
```

124 is exactly what twenty-five folded head lines standing as one marker require.

The last row of the table stays refused and always will: one starting number cannot describe two offsets.

Removing the count drives all three fold tests red. Full suite green, `make ci` green.

Closes #573

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends repeated-Read folding to payloads folded at both ends while preserving the source line numbers of the surviving middle block.

- Reports the exact number of substitution markers above the first surviving line.
- Uses that count to calculate the Read output `startLine` adjustment.
- Replaces the prior refusal test with end-to-end coverage for both-end folding and documents the behavior in the changelog.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness or security issues identified.

The substitution loop counts one marker for each folded run above the first survivor, contiguous-survivor validation remains intact, and the resulting startLine adjustment preserves the surviving source lines' original numbers.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/ledger/mod.rs | Threads substitution-time marker counts into FoldShift and safely admits a single contiguous survivor block with folds below it. |
| src/hooks/post_tool.rs | Updates the integration test to verify that folding both ends preserves the surviving middle block's line numbering. |
| changelog.d/573.added.md | Documents the expanded Read-folding behavior, its line-number preservation, and the intentionally unsupported split-survivor shape. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Read payload lines] --> B[Group lines by origin]
    B --> C{Fold run?}
    C -->|Yes, before first survivor| D[Emit marker and increment markers_above]
    C -->|Yes, after first survivor| E[Emit marker]
    C -->|No| F[Emit run verbatim and mark survivor reached]
    D --> G[Collect folded indices]
    E --> G
    F --> G
    G --> H{Survivors contiguous?}
    H -->|No| I[Refuse projected Read]
    H -->|Yes, begin at payload start| J[Keep startLine]
    H -->|Yes, begin later| K[Increase startLine by first minus markers_above]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): record the both-ends fo..."](https://github.com/fajarhide/omni/commit/b538d1ff69373d974c7b1614fcc73e5e423245ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53599465)</sub>

<!-- /greptile_comment -->