### PR TITLE
fix(ledger): say the lines were not shown here, and give the skill a checkable install

### DIFF
--- a/changelog.d/567.fixed.md
+++ b/changelog.d/567.fixed.md
@@ -1,0 +1,20 @@
+- **A project fold said `from an earlier session`, which reads as a claim the
+  reader had already seen the content.** It means the opposite: the project scope
+  only answers for lines the session scope did not, so those lines were never
+  delivered here. Acting on it, a reader took a `claude plugin --help` page whose
+  `Commands:` block had been elided as a complete one and concluded the CLI had no
+  uninstall subcommand. The run form now says `N lines not shown here`, leading
+  with the only thing the reader has to act on and dropping the provenance, which
+  also makes it nine bytes shorter, 72 to 63. Marker length gates folding, so the
+  honest wording is the cheaper one here rather than a trade against it. The
+  whole-output form keeps the provenance and adds `none shown here`, because there
+  the agent holds nothing at all. The manual carries the new wording in both
+  languages, and `bench_replay` counts project markers on `shown here`, which both
+  forms contain and neither session form does. (#567)
+- **The guard that was supposed to catch a marker the manual does not document
+  could not fail.** It compared each template only up to its first placeholder, so
+  it checked `[OMNI: ` and `[OMNI: identical to ` and nothing else, and any page
+  holding any marker satisfied it. The wording after the count, which is the whole
+  of what a reader looks up, was never read. Proved by putting a retired marker
+  back into the page and watching the suite stay green. It now checks every
+  literal fragment of every template, and the same experiment turns it red. (#567)

--- a/changelog.d/567.fixed.md
+++ b/changelog.d/567.fixed.md
@@ -16,5 +16,9 @@
   it checked `[OMNI: ` and `[OMNI: identical to ` and nothing else, and any page
   holding any marker satisfied it. The wording after the count, which is the whole
   of what a reader looks up, was never read. Proved by putting a retired marker
-  back into the page and watching the suite stay green. It now checks every
-  literal fragment of every template, and the same experiment turns it red. (#567)
+  back into the page and watching the suite stay green. A second version, checking
+  each literal fragment independently, let one template borrow another's text: the
+  whole-output session example contains `lines already shown, omni retrieve`, so
+  deleting the ordinary session marker still left it green. It now matches each
+  template whole, with `{lines}` typed as a number and `{handle}` as a hex digest,
+  which is what stops the borrowing. Both experiments turn it red. (#567)

--- a/docs/website/src-id/concepts/the-ledger.md
+++ b/docs/website/src-id/concepts/the-ledger.md
@@ -37,7 +37,7 @@ sedang dibuat.
 | asal | penanda | artinya |
 |---|---|---|
 | sesi | `N lines already shown` | agent masih memegang byte ini, jadi handle-nya gratis kecuali ia memilih membaca ulang |
-| proyek | `N lines from an earlier session` | ini pergi ke sesi lain dari proyek ini dan agent ini **belum pernah melihatnya** |
+| proyek | `N lines not shown here` | ini pergi ke sesi lain dari proyek ini dan agent ini **belum pernah melihatnya** |
 
 Perbedaan itu keseluruhan alasan cakupan proyek ada. Rancangan sebelumnya
 membatalkannya dengan alasan bahwa handle untuk isi sesi lain adalah kebohongan,
@@ -182,10 +182,15 @@ riwayat dan membaca darinya.
 Itu berbagi sebagai efek samping, bukan karena dirancang. Tidak ada bagian ledger
 yang tahu ia sedang bicara dengan agent yang mana, jadi penanda berasal proyek
 bisa menyerahkan ke agent B sebuah handle untuk baris yang cuma pernah
-ditunjukkan ke agent A. Kalimatnya tetap benar, baris-baris itu memang datang
-dari sesi sebelumnya, dan ambang yang lebih tinggi berarti pertukarannya sudah
-dihargai sebagai satu pengambilan. Tapi `from an earlier session` terbaca sebagai
-sesi *Anda* padahal bisa jadi bukan.
+ditunjukkan ke agent A. Ambang yang lebih tinggi berarti pertukarannya sudah
+dihargai sebagai satu pengambilan.
+
+Dulu kalimatnya memperburuk hal itu. `from an earlier session` menyatakan asal
+baris, dan pembaca membacanya sebagai sesi *Anda*, padahal belum tentu, lalu
+sebagai klaim bahwa isinya sudah pernah diterima. Penanda run sekarang berbunyi
+`not shown here` dan menyatakan satu-satunya hal yang perlu ditindaklanjuti
+pembaca, yaitu bahwa byte itu tidak pernah sampai
+([#567](https://github.com/fajarhide/omni/issues/567)).
 
 Sejak [#509](https://github.com/fajarhide/omni/issues/509) agent dicatat di setiap
 baris, dan belum ada yang dikunci padanya. Pengukuran yang memutuskan itu:

--- a/docs/website/src-id/concepts/use-cases.md
+++ b/docs/website/src-id/concepts/use-cases.md
@@ -81,7 +81,7 @@ perubahan, dan keduanya mulai dari nol.
 proyek, bukan pada agent. Agent kedua yang bekerja di direktori yang sama membaca
 pengetahuan proyek yang sama, dan cakupan proyek pada ledger akan memberinya
 handle untuk keluaran yang sudah dihasilkan sesi sebelumnya. Penanda itu berbunyi
-`from an earlier session`, bukan `already shown`, karena agent ini memang belum
+`not shown here`, bukan `already shown`, karena agent ini memang belum
 pernah melihat byte tersebut dan kalimatnya harus benar.
 
 **Angka jujurnya.** Pengulangan lintas sesi adalah **3,7%** dari byte setelah
@@ -89,9 +89,10 @@ penyaringan, berbanding **19,1%** di dalam satu sesi, jadi nilainya sekitar
 seperlima penghematan dalam sesi. Ia nyata, dan ia bukan judulnya.
 
 **Peringatan jujurnya.** Dua agent dalam satu repositori berbagi riwayat itu
-sebagai efek samping, bukan karena dirancang begitu, dan
-`from an earlier session` bisa terbaca sebagai sesi *Anda* padahal itu sesi orang
-lain. [Ledger](the-ledger.md#apa-yang-dibagi-dua-agent-dalam-satu-repo) berterus
+sebagai efek samping, bukan karena dirancang begitu. Penandanya dulu berbunyi
+`from an earlier session`, yang terbaca sebagai sesi *Anda* padahal itu sesi orang
+lain, dan lebih buruk lagi sebagai klaim bahwa isinya sudah sampai; sekarang ia
+berbunyi `not shown here`. [Ledger](the-ledger.md#apa-yang-dibagi-dua-agent-dalam-satu-repo) berterus
 terang soal apa yang hari ini dikunci pada agent dan apa yang tidak.
 
 ## 6. `kubectl get pods -o json | jq`

--- a/docs/website/src-id/reference/cmd/exec.md
+++ b/docs/website/src-id/reference/cmd/exec.md
@@ -41,7 +41,7 @@ Keduanya yang dipakai pre-hook ketika ia menulis ulang sebuah perintah menjadi
 
 `--session` layak diketahui ketika Anda sedang menyelidiki perilaku ledger: ia
 satu-satunya cara menjalankan dua sesi berbeda dengan tangan lalu melihat beda
-antara pelipatan `already shown` dan pelipatan `from an earlier session`.
+antara pelipatan `already shown` dan pelipatan `not shown here`.
 
 ## Isolasi basis datanya saat menyelidik
 

--- a/docs/website/src-id/use/markers.md
+++ b/docs/website/src-id/use/markers.md
@@ -23,7 +23,7 @@ klaimnya adalah agent masih memegangnya dan handle-nya tidak berongkos kecuali i
 memang mau membaca ulang.
 
 ```
-[OMNI: 40 lines from an earlier session, omni retrieve bc7e821a4340073e]
+[OMNI: 40 lines not shown here, omni retrieve bc7e821a4340073e]
 ```
 
 Ledger juga, klaim berbeda. Baris-baris ini pergi ke **sesi lain** dari proyek
@@ -37,7 +37,7 @@ direktorinya, jadi apa pun yang berjalan di repositori ini ikut menyumbang. Liha
 
 ```
 [OMNI: identical to the 40 lines already shown, omni retrieve bc7e821a4340073e]
-[OMNI: identical to 40 lines from an earlier session, omni retrieve bc7e821a4340073e]
+[OMNI: identical to 40 lines from an earlier session, none shown here, omni retrieve bc7e821a4340073e]
 ```
 
 Dua klaim yang sama, untuk jawaban yang terulang **seluruhnya**. Ketika

--- a/docs/website/src/concepts/the-ledger.md
+++ b/docs/website/src/concepts/the-ledger.md
@@ -34,7 +34,7 @@ They are not the same statement and the marker says which one it is making.
 | origin | marker | what it means |
 |---|---|---|
 | session | `N lines already shown` | the agent is still holding these bytes, so the handle is free unless it chooses to re-read |
-| project | `N lines from an earlier session` | these went to a different session of this project and this agent has **never seen them** |
+| project | `N lines not shown here` | these went to a different session of this project and this agent has **never seen them** |
 
 The distinction is the whole reason the project scope exists. An earlier design
 cancelled it on the grounds that a handle for another session's content is a lie,
@@ -165,10 +165,14 @@ running in the same repository write into one history and read from it.
 
 That is sharing by side effect rather than by design. Nothing in the ledger knows
 which agent it is talking to, so a project-origin marker can hand agent B a handle for
-lines only agent A was ever shown. The wording is still true, those lines did come
-from an earlier session, and the higher bar means the trade is priced as a retrieval
-either way. But `from an earlier session` reads as *your* earlier session, and it
-might not be.
+lines only agent A was ever shown. The higher bar means the trade is priced as a
+retrieval either way.
+
+The wording used to make that worse. `from an earlier session` states where the lines
+came from, and a reader took it as *your* earlier session, which it need not be, and
+then as a claim they had already seen the content. A run marker now says
+`not shown here` and states the only thing the reader has to act on, which is that
+these bytes never arrived ([#567](https://github.com/fajarhide/omni/issues/567)).
 
 As of [#509](https://github.com/fajarhide/omni/issues/509) the agent is recorded on
 every line, and nothing keys on it yet. The measurement decides that: keying the scope

--- a/docs/website/src/concepts/use-cases.md
+++ b/docs/website/src/concepts/use-cases.md
@@ -74,7 +74,7 @@ of them start from nothing.
 **What OMNI does.** The store is one SQLite file keyed by project path, not by agent.
 A second agent working in the same directory reads the same project knowledge, and the
 ledger's project scope will hand it a handle for output an earlier session already
-produced. That marker says `from an earlier session` rather than `already shown`,
+produced. That marker says `not shown here` rather than `already shown`,
 because this agent has genuinely never seen those bytes and the wording has to be true.
 
 **The honest number.** Cross-session repetition is **3.7%** of post-filter bytes against
@@ -82,8 +82,9 @@ because this agent has genuinely never seen those bytes and the wording has to b
 It is real, and it is not the headline.
 
 **The honest caveat.** Two agents in one repository share that history by side effect
-rather than by design, and `from an earlier session` can read as *your* earlier session
-when it was someone else's. [The ledger](the-ledger.md#what-two-agents-in-one-repo-share) is
+rather than by design. The marker used to say `from an earlier session`, which reads as
+*your* earlier session when it was someone else's, and worse, as a claim the content had
+already arrived; it now says `not shown here`. [The ledger](the-ledger.md#what-two-agents-in-one-repo-share) is
 straight about what is and is not keyed on the agent today.
 
 ## 6. `kubectl get pods -o json | jq`

--- a/docs/website/src/reference/cmd/exec.md
+++ b/docs/website/src/reference/cmd/exec.md
@@ -39,7 +39,7 @@ Both are what the pre-hook uses when it rewrites a command into `omni exec`.
 
 `--session` is worth knowing when you are investigating ledger behaviour: it is the
 only way to drive two distinct sessions by hand and see the difference between an
-`already shown` fold and a `from an earlier session` fold.
+`already shown` fold and a `not shown here` fold.
 
 ## Isolate the database while probing
 

--- a/docs/website/src/use/markers.md
+++ b/docs/website/src/use/markers.md
@@ -22,7 +22,7 @@ the agent is still holding them and the handle costs nothing unless it wants to
 re-read.
 
 ```
-[OMNI: 40 lines from an earlier session, omni retrieve bc7e821a4340073e]
+[OMNI: 40 lines not shown here, omni retrieve bc7e821a4340073e]
 ```
 
 Also the ledger, different claim. These lines went to a **different session** of this
@@ -36,7 +36,7 @@ on the directory, so anything running in this repository contributes to it. See
 
 ```
 [OMNI: identical to the 40 lines already shown, omni retrieve bc7e821a4340073e]
-[OMNI: identical to 40 lines from an earlier session, omni retrieve bc7e821a4340073e]
+[OMNI: identical to 40 lines from an earlier session, none shown here, omni retrieve bc7e821a4340073e]
 ```
 
 The same two claims, for a reply that is repeated **in full**. When the fold covers

--- a/plugins/claude-code/skills/omni/SKILL.md
+++ b/plugins/claude-code/skills/omni/SKILL.md
@@ -24,15 +24,20 @@ published beside it, then put the binary on the path:
 V=0.7.5; T=x86_64-unknown-linux-musl   # or aarch64-unknown-linux-musl, *-apple-darwin
 B=https://github.com/fajarhide/omni/releases/download/v$V
 curl -fsSLO $B/omni-v$V-$T.tar.gz -O $B/SHA256SUMS
-grep " omni-v$V-$T.tar.gz\$" SHA256SUMS | sha256sum -c - &&
+grep " omni-v$V-$T.tar.gz\$" SHA256SUMS > omni.sha256 &&
+  sha256sum -c omni.sha256 &&
   tar xzf omni-v$V-$T.tar.gz &&
   install -m755 omni ~/.local/bin/omni
 ```
 
-`sha256sum -c` exits non-zero on a mismatch, and the `&&` is what carries that
-into the next command. On its own line the untar would run anyway, since a shell
-pasting these does not stop on a failure unless it was told to. On macOS the command is
-`shasum -a 256 -c -`. There is a `curl … | bash` installer at
+`sha256sum -c` exits non-zero on a mismatch and the `&&` carries that into the
+next command; on its own line the untar would run anyway, since a shell pasting
+these does not stop on a failure unless it was told to. The checksum goes through
+a file rather than a pipe for the same reason: piped into `sha256sum -c -`, a
+`grep` that matches nothing sends an empty stream, and Darwin's `sha256sum` reads
+that as success, so a mistyped target would install unverified. Through a file it
+is `grep`'s own exit code that gates the chain. On macOS the command is
+`shasum -a 256 -c omni.sha256`. There is a `curl … | bash` installer at
 `omni.weekndlabs.com/install` and it is deliberately not the instruction here:
 nothing about it is verifiable before it runs.
 

--- a/plugins/claude-code/skills/omni/SKILL.md
+++ b/plugins/claude-code/skills/omni/SKILL.md
@@ -24,12 +24,14 @@ published beside it, then put the binary on the path:
 V=0.7.5; T=x86_64-unknown-linux-musl   # or aarch64-unknown-linux-musl, *-apple-darwin
 B=https://github.com/fajarhide/omni/releases/download/v$V
 curl -fsSLO $B/omni-v$V-$T.tar.gz -O $B/SHA256SUMS
-grep " omni-v$V-$T.tar.gz\$" SHA256SUMS | sha256sum -c -
-tar xzf omni-v$V-$T.tar.gz && install -m755 omni ~/.local/bin/omni
+grep " omni-v$V-$T.tar.gz\$" SHA256SUMS | sha256sum -c - &&
+  tar xzf omni-v$V-$T.tar.gz &&
+  install -m755 omni ~/.local/bin/omni
 ```
 
-`sha256sum -c` exits non-zero on a mismatch, so chaining the untar behind it is
-what makes the check load bearing rather than decorative. On macOS the command is
+`sha256sum -c` exits non-zero on a mismatch, and the `&&` is what carries that
+into the next command. On its own line the untar would run anyway, since a shell
+pasting these does not stop on a failure unless it was told to. On macOS the command is
 `shasum -a 256 -c -`. There is a `curl … | bash` installer at
 `omni.weekndlabs.com/install` and it is deliberately not the instruction here:
 nothing about it is verifiable before it runs.
@@ -80,7 +82,8 @@ one.
 | `[OMNI: 40 lines omitted, omni retrieve <handle> for full output]` | the distiller kept the signal and archived the rest |
 | `[OMNI: 40 lines already shown, omni retrieve <handle>]` | those lines are in this session's context already |
 | `[OMNI: identical to the 40 lines already shown, omni retrieve <handle>]` | the whole re-run matched an earlier one |
-| `[OMNI: 40 lines from an earlier session, omni retrieve <handle>]` | another session in this project saw them |
+| `[OMNI: 40 lines not shown here, omni retrieve <handle>]` | another session in this project saw them and **this one never did**, so retrieve before relying on them |
+| `[OMNI: identical to 40 lines from an earlier session, none shown here, omni retrieve <handle>]` | the whole reply matched an earlier session's, and none of it arrived here |
 | `[OMNI: 2 sensitive value(s) redacted]` | values under a key that names a credential |
 
 Pull the full bytes with the command the marker prints:

--- a/plugins/claude-code/skills/omni/SKILL.md
+++ b/plugins/claude-code/skills/omni/SKILL.md
@@ -17,8 +17,22 @@ brew install fajarhide/tap/omni
 omni init
 ```
 
-Without Homebrew, put `curl -fsSL omni.weekndlabs.com/install | bash` in place of
-the first line.
+Without Homebrew, take the release archive and check it against the `SHA256SUMS`
+published beside it, then put the binary on the path:
+
+```
+V=0.7.5; T=x86_64-unknown-linux-musl   # or aarch64-unknown-linux-musl, *-apple-darwin
+B=https://github.com/fajarhide/omni/releases/download/v$V
+curl -fsSLO $B/omni-v$V-$T.tar.gz -O $B/SHA256SUMS
+grep " omni-v$V-$T.tar.gz\$" SHA256SUMS | sha256sum -c -
+tar xzf omni-v$V-$T.tar.gz && install -m755 omni ~/.local/bin/omni
+```
+
+`sha256sum -c` exits non-zero on a mismatch, so chaining the untar behind it is
+what makes the check load bearing rather than decorative. On macOS the command is
+`shasum -a 256 -c -`. There is a `curl … | bash` installer at
+`omni.weekndlabs.com/install` and it is deliberately not the instruction here:
+nothing about it is verifiable before it runs.
 
 **Do not name a host you have not established you are running in.** With no
 terminal to draw its menu on, which is the case when an agent runs it, `omni init`

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -3037,7 +3037,7 @@ src/distillers/system_ops.rs:849:                is_sensitive_key(key),
 
         let out = second.unwrap_or_default();
         assert!(
-            out.contains("lines already shown") || out.contains("from an earlier session"),
+            out.contains("lines already shown") || out.contains("shown here"),
             "a repeated Read never reached the ledger: {out}"
         );
     }

--- a/src/ledger/mod.rs
+++ b/src/ledger/mod.rs
@@ -78,8 +78,19 @@ impl Origin {
             Self::Session => {
                 format!("[OMNI: {lines} lines already shown, omni retrieve {handle}]")
             }
+            // #567. `from an earlier session` states provenance and reads as
+            // "you have seen this", which is the opposite of what it means: the
+            // project scope only answers for lines the session scope did not, so
+            // these lines were never delivered here. A reader acted on that,
+            // took a help page missing its `Commands:` block as complete, and
+            // concluded the CLI had no uninstall.
+            //
+            // The actionable half goes first and the provenance is dropped, which
+            // is also nine bytes shorter. Marker length gates folding, and the
+            // session form's trim was worth 0.3 points on its own (#450), so the
+            // honest wording is the cheaper one here rather than a trade.
             Self::Project => {
-                format!("[OMNI: {lines} lines from an earlier session, omni retrieve {handle}]")
+                format!("[OMNI: {lines} lines not shown here, omni retrieve {handle}]")
             }
         }
     }
@@ -100,8 +111,11 @@ impl Origin {
             Self::Session => format!(
                 "[OMNI: identical to the {lines} lines already shown, omni retrieve {handle}]"
             ),
+            // The whole payload, and none of it delivered here, so the agent
+            // holds nothing at all. Worth the extra bytes to say both: this
+            // marker is already gated at `MIN_WHOLE_OUTPUT_FOLD` (#567).
             Self::Project => format!(
-                "[OMNI: identical to {lines} lines from an earlier session, omni retrieve {handle}]"
+                "[OMNI: identical to {lines} lines from an earlier session, none shown here, omni retrieve {handle}]"
             ),
         }
     }
@@ -962,6 +976,52 @@ mod tests {
         assert!(
             !view.contains("already shown"),
             "a project repeat was reported as a session repeat: {view}"
+        );
+    }
+
+    /// #567. The run marker said `from an earlier session`, which states where the
+    /// lines came from and reads as "you have seen this". It means the opposite:
+    /// the project scope only answers for lines the session scope did not, so
+    /// those lines were never delivered here.
+    ///
+    /// A reader acted on it, took a help page missing its `Commands:` block as a
+    /// complete one, and concluded the CLI had no uninstall. The run form had no
+    /// test of its wording at all: every existing assertion on the phrase is
+    /// satisfied by the whole-output marker, so the string could be changed with
+    /// the suite green.
+    #[test]
+    fn a_project_run_marker_says_the_lines_were_not_shown_here() {
+        let (store, _d) = temp_store();
+        // Repeated lines first, then lines nobody has seen, so the fold is a run
+        // inside a payload rather than the whole of it. That is the shape the
+        // report hit and the one the whole-output marker never covers.
+        let repeated: String = (0..60)
+            .map(|i| format!("2026-08-10T00:00:00Z  handler finished request {i} in 12ms\n"))
+            .collect();
+        let fresh: String = (0..60)
+            .map(|i| format!("2026-08-10T00:00:00Z  cache probe {i} missed and refilled\n"))
+            .collect();
+
+        Ledger::new(&store, "s1")
+            .with_project("/repo")
+            .project(&repeated);
+
+        let view = Ledger::new(&store, "s2")
+            .with_project("/repo")
+            .project(&format!("{repeated}{fresh}"))
+            .expect("a project repeat above the floor is projectable");
+
+        assert!(
+            view.contains("not shown here"),
+            "the marker did not say the lines were never delivered here: {view}"
+        );
+        assert!(
+            !view.contains("already shown"),
+            "a project run claimed a sighting this session never had: {view}"
+        );
+        assert!(
+            view.contains(&fresh),
+            "this has to be a run inside a payload, not a whole-output fold: {view}"
         );
     }
 

--- a/tests/bench_replay.rs
+++ b/tests/bench_replay.rs
@@ -805,7 +805,12 @@ fn replay_execution_traces_net_savings() {
             Some(view) => {
                 ledger_calls += 1;
                 mark_session += view.matches("lines already shown").count() as u64;
-                mark_project += view.matches("from an earlier session").count() as u64;
+                // `shown here` and not the whole phrase: a project run says
+                // `not shown here` and a project whole-output fold says
+                // `none shown here`, while neither session form contains it
+                // (#567). Counting the old phrase would silently drop every run
+                // marker from the tally.
+                mark_project += view.matches("shown here").count() as u64;
                 view.len() as u64
             }
             None => o,

--- a/tests/docs_match_the_code.rs
+++ b/tests/docs_match_the_code.rs
@@ -270,12 +270,17 @@ fn every_documented_count_matches_the_code() {
 /// the cheapest of the three to guard, because the templates are string
 /// literals in one file.
 ///
-/// Matched on **every** literal fragment of each template, not just the part
-/// before the first `{`. That earlier version compared `[OMNI: ` and
-/// `[OMNI: identical to ` and nothing else, so any page holding any marker
-/// satisfied it: the wording after the count, which is the whole of what a
-/// reader looks up, was never checked. Proved by putting a retired marker back
-/// into the page and watching this pass (#567).
+/// Each template is matched **whole**, with its placeholders turned into the
+/// shape they hold at runtime: `{lines}` is a number and `{handle}` is a hex
+/// digest. Two weaker versions were caught before this one. Comparing the text
+/// before the first `{` checked `[OMNI: ` and `[OMNI: identical to ` and nothing
+/// else, so any page holding any marker satisfied it. Comparing literal
+/// fragments independently let one template borrow another's: the whole-output
+/// session example contains `lines already shown, omni retrieve`, so deleting
+/// the ordinary session marker from the page left the guard green (#567).
+///
+/// Typed placeholders are what stop the same borrowing here: `\d+` after
+/// `[OMNI: ` cannot match `identical to the 40`.
 #[test]
 fn every_marker_the_ledger_can_print_is_documented() {
     let root = repo_root();
@@ -295,24 +300,30 @@ fn every_marker_the_ledger_can_print_is_documented() {
         templates.len()
     );
 
-    // A template is `[OMNI: {lines} lines not shown here, omni retrieve {handle}]`.
-    // Split on the placeholders and every remaining fragment is fixed text the
-    // page has to carry. The one-character tail is dropped as noise.
-    let missing: Vec<(&String, String)> = templates
+    let placeholder = regex::Regex::new(r"\{[a-z_]+\}").expect("valid regex");
+    let missing: Vec<&String> = templates
         .iter()
-        .flat_map(|t| {
-            regex::Regex::new(r"\{[a-z_]+\}")
-                .expect("valid regex")
-                .split(t)
-                .filter(|f| f.len() > 3)
-                .filter(|f| !page.contains(*f))
-                .map(move |f| (t, f.to_string()))
-                .collect::<Vec<_>>()
+        .filter(|t| {
+            let mut pattern = String::new();
+            let mut last = 0;
+            for m in placeholder.find_iter(t) {
+                pattern.push_str(&regex::escape(&t[last..m.start()]));
+                pattern.push_str(match m.as_str() {
+                    "{lines}" => r"\d+",
+                    "{handle}" => "[0-9a-f]+",
+                    _ => ".+",
+                });
+                last = m.end();
+            }
+            pattern.push_str(&regex::escape(&t[last..]));
+            !regex::Regex::new(&pattern)
+                .expect("template makes a valid regex")
+                .is_match(&page)
         })
         .collect();
     assert!(
         missing.is_empty(),
-        "`use/markers.md` is missing wording the ledger prints: {missing:?}\n\
+        "the ledger can print markers `use/markers.md` never shows: {missing:?}\n\
          A reader meets these in their own output and has nowhere to look them up."
     );
 }

--- a/tests/docs_match_the_code.rs
+++ b/tests/docs_match_the_code.rs
@@ -270,8 +270,12 @@ fn every_documented_count_matches_the_code() {
 /// the cheapest of the three to guard, because the templates are string
 /// literals in one file.
 ///
-/// Matched on the stable half of each template, before the first `{`, since the
-/// rest is a runtime count and a handle.
+/// Matched on **every** literal fragment of each template, not just the part
+/// before the first `{`. That earlier version compared `[OMNI: ` and
+/// `[OMNI: identical to ` and nothing else, so any page holding any marker
+/// satisfied it: the wording after the count, which is the whole of what a
+/// reader looks up, was never checked. Proved by putting a retired marker back
+/// into the page and watching this pass (#567).
 #[test]
 fn every_marker_the_ledger_can_print_is_documented() {
     let root = repo_root();
@@ -282,12 +286,7 @@ fn every_marker_the_ledger_can_print_is_documented() {
     let templates: BTreeSet<String> = regex::Regex::new(r#""(\[OMNI: [^"]*)""#)
         .expect("valid regex")
         .captures_iter(&ledger)
-        .map(|c| {
-            let t = c.get(1).expect("group 1").as_str();
-            // "[OMNI: {lines} lines already shown, …" → "[OMNI: "
-            // "[OMNI: identical to {lines} …"         → "[OMNI: identical to "
-            t.split('{').next().unwrap_or(t).to_string()
-        })
+        .map(|c| c.get(1).expect("group 1").as_str().to_string())
         .collect();
 
     assert!(
@@ -296,10 +295,24 @@ fn every_marker_the_ledger_can_print_is_documented() {
         templates.len()
     );
 
-    let missing: Vec<&String> = templates.iter().filter(|t| !page.contains(*t)).collect();
+    // A template is `[OMNI: {lines} lines not shown here, omni retrieve {handle}]`.
+    // Split on the placeholders and every remaining fragment is fixed text the
+    // page has to carry. The one-character tail is dropped as noise.
+    let missing: Vec<(&String, String)> = templates
+        .iter()
+        .flat_map(|t| {
+            regex::Regex::new(r"\{[a-z_]+\}")
+                .expect("valid regex")
+                .split(t)
+                .filter(|f| f.len() > 3)
+                .filter(|f| !page.contains(*f))
+                .map(move |f| (t, f.to_string()))
+                .collect::<Vec<_>>()
+        })
+        .collect();
     assert!(
         missing.is_empty(),
-        "the ledger can print markers `use/markers.md` never shows: {missing:?}\n\
+        "`use/markers.md` is missing wording the ledger prints: {missing:?}\n\
          A reader meets these in their own output and has nowhere to look them up."
     );
 }


### PR DESCRIPTION
Two issues, unrelated in file and in risk, batched into one CI cycle.

**#567, the marker.** `from an earlier session` states where the lines came from and reads as a claim the reader has already seen them. It means the opposite: the project scope only answers for lines the session scope did not, so those lines were never delivered here. Acting on it, a reader took a help page whose `Commands:` block had been elided as a complete one and concluded the CLI had no uninstall subcommand.

The issue offered two fixes. This is the second, the wording, and not the first, narrowing the scope to the session: project scope carries 54% of folded bytes over 16.3 hours here, so narrowing it is expensive and the false claim is what actually hurt.

A run now says `N lines not shown here`. It leads with the only thing the reader has to act on, drops the provenance, and is nine bytes shorter, 72 to 63. Marker length gates folding and the session form's trim was worth 0.3 points on its own (#450), so the honest wording is the cheaper one rather than a trade. The whole-output form keeps the provenance and adds `none shown here`, because there the agent holds nothing at all and that marker is already gated at `MIN_WHOLE_OUTPUT_FOLD`.

Two things this turned up that were not in the issue:

- The run wording had **no test**. Every existing assertion on the phrase is satisfied by the whole-output marker, so the string could be changed with the suite green. It has one now, on a run inside a payload.
- The guard that exists to catch a marker the manual does not document **could not fail**. It compared each template only up to its first placeholder, so it checked `[OMNI: ` and `[OMNI: identical to ` and nothing else. Putting the retired marker back into the page left the suite green; it now checks every literal fragment and the same experiment turns it red naming the missing text.

`bench_replay` counted project markers by the old phrase and would have silently dropped every run marker from its tally. It counts `shown here`, which both project forms contain and neither session form does.

**#558, the install line.** Two audits of the published skill on 2026-08-14 landed on the same `curl | bash`: Gen Agent Trust Hub failed it at risk HIGH, Snyk warned at MEDIUM under W012. Every release already publishes `SHA256SUMS` beside the five archives, so a checked install existed and the skill was the one surface that did not mention it.

It now names the archive, the checksum file and the verification, with the untar chained behind `sha256sum -c` so a mismatch stops the install rather than being printed beside it. Run against the real 0.7.5 release before being written down, then again with the archive deliberately corrupted:

```
omni-v0.7.5-aarch64-apple-darwin.tar.gz: OK          -> tar runs, omni 0.7.5
omni-v0.7.5-aarch64-apple-darwin.tar.gz: FAILED      -> rc=1, no binary written
```

The pipe installer still exists and is named as the thing this is not. README and docs carry the same line and are out of scope here, as the issue says: the auditors only read the skill.

`make ci` green.

Closes #567
Closes #558

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR clarifies cross-session ledger markers and replaces the skill’s pipe installer guidance with checksum-gated release installation.
- Changes project-scope run markers to say that lines were not shown in the current session.
- Strengthens documentation checks by matching complete marker templates with typed placeholders.
- Updates marker consumers, documentation, benchmark accounting, and the bundled skill.
- Chains checksum verification, extraction, and installation while making a missing checksum entry fail the chain.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| plugins/claude-code/skills/omni/SKILL.md | The checksum is selected through a file and verification now gates extraction and installation; the marker table also matches both emitted project forms. |
| tests/docs_match_the_code.rs | The documentation guard now checks each complete runtime marker with typed line-count and handle placeholders, preventing cross-template matches. |
| src/ledger/mod.rs | Project run and whole-output markers now explicitly state that their folded content was not shown in the current session. |
| tests/bench_replay.rs | Project marker accounting now recognizes both project-scope forms through their shared, scope-specific wording. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(skill): gate the install on grep, no..."](https://github.com/fajarhide/omni/commit/2e01d27975dcf2aefd5ce4122b6a9e94beba84ee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53602344)</sub>

<!-- /greptile_comment -->