### PR TITLE
docs(skill): drop the installer URL both skills.sh scanners read as the install

### DIFF
--- a/changelog.d/578.fixed.md
+++ b/changelog.d/578.fixed.md
@@ -1,0 +1,11 @@
+- **The skill still failed both skills.sh audits after #558, because a scanner
+  reads a URL and not the sentence disowning it.** #558 replaced the
+  `curl | bash` install with a release archive checked against `SHA256SUMS`, and
+  left one line saying where the pipe installer lives and why it is not the
+  instruction. Gen Agent Trust Hub called that URL "the installation process" and
+  returned Fail at HIGH; Snyk returned Warn at MEDIUM W012, quoting a
+  fetch-and-execute command that was no longer anywhere in the file. Both re-ran
+  on the corrected version, at 12:16Z and 12:15Z on 2026-08-15, so this was the
+  wording and not a stale copy. The three lines are gone. A reader loses nothing:
+  the sentence documented a route it told them not to take, and `README.md` still
+  carries the pipe for anyone who wants it. (#578)

--- a/plugins/claude-code/skills/omni/SKILL.md
+++ b/plugins/claude-code/skills/omni/SKILL.md
@@ -37,9 +37,7 @@ a file rather than a pipe for the same reason: piped into `sha256sum -c -`, a
 `grep` that matches nothing sends an empty stream, and Darwin's `sha256sum` reads
 that as success, so a mistyped target would install unverified. Through a file it
 is `grep`'s own exit code that gates the chain. On macOS the command is
-`shasum -a 256 -c omni.sha256`. There is a `curl … | bash` installer at
-`omni.weekndlabs.com/install` and it is deliberately not the instruction here:
-nothing about it is verifiable before it runs.
+`shasum -a 256 -c omni.sha256`.
 
 **Do not name a host you have not established you are running in.** With no
 terminal to draw its menu on, which is the case when an agent runs it, `omni init`


### PR DESCRIPTION
Both skills.sh auditors re-ran on the post-#558 skill and still failed it, because
neither reads the sentence that disowns the URL. Gen Agent Trust Hub calls
`omni.weekndlabs.com/install` "the installation process" (Fail, HIGH); Snyk quotes
`curl -fsSL omni.weekndlabs.com/install | bash` (Warn, MEDIUM W012), a command that
is not in the file. They did read the corrected version: Gen Agent's report cites
`omni doctor` and `.vscode/mcp.json`, which only #575 added.

So the three lines are gone. A reader loses nothing, since they documented a route
the same sentence told them not to take, and `README.md:172` still carries the pipe.

Verified: `cargo test --test docs_match_the_code --test changelog_cut`, 8 and 4
passing. Re-auditing is not something we can trigger; skills.sh re-ran these audits
by itself minutes after an install, so the badge should follow the next daily sync
of `fajarhide/skills`.

Closes #578

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Removes the installer URL from the Omni skill so automated auditors no longer interpret it as an installation instruction.
- Deletes the three-line reference to the unverifiable pipe installer from `SKILL.md`.
- Adds a changelog entry documenting the audit failures and rationale for the removal.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The change only removes a misleading installer reference from documentation, leaving the recommended verified installation procedure intact and accurately recording the rationale in the changelog.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| plugins/claude-code/skills/omni/SKILL.md | Removes the disowned pipe-installer URL while retaining the verified release-archive installation guidance. |
| changelog.d/578.fixed.md | Documents why the installer URL was removed and identifies the audit behavior addressed by the change. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(skill): drop the installer URL both..."](https://github.com/fajarhide/omni/commit/79312ac0203f847b6ed9441e9a6fd807248d48f3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53625001)</sub>

<!-- /greptile_comment -->