### PR TITLE
feat(mcp): advertise only the tools the host can use

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 
 # MCP Server  
-rmcp = { version = "1.4", features = ["server", "transport-io"] }
+rmcp = { version = "1.7", features = ["server", "transport-io"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync"] }
 
 # Database (SQLite bundled — no system dep)

--- a/changelog.d/577.changed.md
+++ b/changelog.d/577.changed.md
@@ -4,7 +4,8 @@
   transcripts: nine tools account for all 109 calls, `omni_retrieve` and
   `omni_explain_savings` alone for 84% of them, and the sixteen that were never
   called are **4,940 bytes**. That is the same size as the **4,942 bytes** OMNI
-  removes from tool output in a median session, and it is carried from position
+  removes from tool output in the median of the 35 sessions that pushed more
+  than 50 KB through the hook, and it is carried from position
   0 where it is re-read on every request instead of from the middle of the
   session, so advertising them cost about twice what the distillers earned. A
   host is now told about the tools its tier can use: nine on Full and

--- a/changelog.d/577.changed.md
+++ b/changelog.d/577.changed.md
@@ -1,0 +1,15 @@
+- **OMNI advertised 25 MCP tools and 16 of them had never been called.** The
+  definitions sit in the prefix of every request of every session, so they are
+  re-read on each one rather than paid for once. Measured across 229 Claude Code
+  transcripts: nine tools account for all 109 calls, `omni_retrieve` and
+  `omni_explain_savings` alone for 84% of them, and the sixteen that were never
+  called are **4,940 bytes**. That is the same size as the **4,942 bytes** OMNI
+  removes from tool output in a median session, and it is carried from position
+  0 where it is re-read on every request instead of from the middle of the
+  session, so advertising them cost about twice what the distillers earned. A
+  host is now told about the tools its tier can use: nine on Full and
+  Handoff-first, four on MCP-only, and `omni_run` is guaranteed present on
+  Handoff-first because there it is the only path by which the model reads less.
+  `OMNI_MCP_TOOLS=all` restores every tool, and `omni doctor` says which is in
+  force. The evidence is one machine and Claude Code only, which is why the
+  override exists and why doctor names it. (#577)

--- a/docs/website/src-id/integrations/hermes.md
+++ b/docs/website/src-id/integrations/hermes.md
@@ -108,7 +108,8 @@ tool-nya dengan keluaran npm mentah. Pastikan dengan `omni stats`.
 Pakai perkakas MCP-nya sebagai kendali Hermes atas semua itu:
 `omni_explain_savings` untuk melihat berapa sebenarnya ongkos sebuah perintah
 terkini, `omni_retrieve` untuk mengambil kembali isi yang terlipat, dan
-`omni_budget` untuk melihat token sesinya pergi ke mana.
+`omni_budget` untuk melihat token sesinya pergi ke mana. Perkakas itu berada di luar
+set yang diiklankan secara bawaan, jadi ia butuh `OMNI_MCP_TOOLS=all`.
 
 ## Setelah Hermes di-upgrade
 

--- a/docs/website/src-id/integrations/loops.md
+++ b/docs/website/src-id/integrations/loops.md
@@ -69,6 +69,9 @@ Dua agent, satu lapisan konteks bersama.
 ```sh
 LOOP_ID=$(uuidgen)
 
+# perkakas loop berada di luar set bawaan yang diiklankan
+export OMNI_MCP_TOOLS=all
+
 # pembuat
 export OMNI_AGENT_ID=maker OMNI_LOOP_ID=$LOOP_ID
 claude "Implement: $GOAL"

--- a/docs/website/src-id/integrations/loops.md
+++ b/docs/website/src-id/integrations/loops.md
@@ -48,6 +48,12 @@ memuat "test" mempertahankan detail test, "debug" menyimpan konteks galat,
 
 ## Perkakas yang dipanggil orkestrator
 
+Tidak satu pun dari perkakas ini diiklankan secara bawaan. OMNI hanya memberi tahu host
+tentang perkakas yang memang dipakai tier-nya, dan perkakas loop berada di luar set itu,
+jadi orkestrator yang memanggilnya membutuhkan `OMNI_MCP_TOOLS=all` di environment-nya.
+`omni doctor` menyebutkan set mana yang sedang berlaku. Daftar per tier ada di rujukan
+perkakas MCP.
+
 | perkakas | kapan |
 |---|---|
 | `omni_loop_status` | sekali sebelum tiap iterasi, gambaran lengkap termurah |

--- a/docs/website/src-id/reference/cmd/session.md
+++ b/docs/website/src-id/reference/cmd/session.md
@@ -47,7 +47,8 @@ mengonsumsinya.
 
 Untuk menyeberang ke mesin yang tidak berbagi basis data, pakai perkakas MCP
 `omni_handoff`, yang mengekspor keadaannya sebagai markdown yang bisa dibawa.
-Subperintah CLI dengan nama itu sudah dihapus; perkakas MCP-nya tidak berubah.
+Subperintah CLI dengan nama itu sudah dihapus; perkakas MCP-nya tidak berubah. Ia
+berada di luar set bawaan yang diiklankan, jadi ia butuh `OMNI_MCP_TOOLS=all`.
 
 ## Retensi
 

--- a/docs/website/src-id/reference/mcp-tools.md
+++ b/docs/website/src-id/reference/mcp-tools.md
@@ -1,7 +1,32 @@
 # Perkakas MCP
 
-`omni init` mendaftarkan OMNI sebagai server MCP, yang memberi agent
-**25 perkakas** yang bisa ia panggil sendiri tanpa lewat Anda.
+`omni init` mendaftarkan OMNI sebagai server MCP, yang memberi agent perkakas yang bisa
+ia panggil sendiri tanpa lewat Anda. Halaman ini menjelaskan seluruh **25** perkakas.
+Host Anda hanya diberi tahu sebagiannya.
+
+## Yang diberitahukan ke host Anda
+
+Definisi perkakas berada di awal setiap request, jadi perkakas yang tidak pernah dipanggil
+akan dibaca ulang pada setiap request di setiap sesi, bukan dibayar sekali saja. Karena
+itu OMNI hanya mengiklankan set yang bisa dipakai oleh tier host Anda:
+
+| tier | yang diiklankan |
+|---|---|
+| Full, dan host apa pun yang tidak dikenali OMNI | sembilan di bawah ini |
+| Handoff-first | sembilan yang sama, `omni_run` selalu termasuk |
+| MCP-only | `omni_remember`, `omni_recall`, `omni_retrieve`, `omni_knowledge` |
+
+Yang sembilan itu adalah `omni_retrieve`, `omni_explain_savings`, `omni_remember`,
+`omni_recall`, `omni_run`, `omni_find_noise`, `omni_context_breakdown`, `omni_history`
+dan `omni_context`. Itulah yang benar-benar pernah dipanggil di korpus yang terekam.
+
+Perkakas lain di halaman ini tetap ada di dalam binary dan hanya berjarak satu setelan.
+`OMNI_MCP_TOOLS=all` mengiklankan seluruh 25 perkakas, dan `omni doctor` menyebutkan set
+mana yang sedang berlaku serta host mana yang terdeteksi:
+
+```
+  MCP tools:      9 of 25 advertised to claude_code (OMNI_MCP_TOOLS=all restores the rest)
+```
 
 Pastikan daftarnya terhadap binary Anda sendiri, bukan terhadap halaman ini:
 

--- a/docs/website/src-id/use/memory.md
+++ b/docs/website/src-id/use/memory.md
@@ -66,7 +66,8 @@ omni session --health
 
 Untuk pindah ke mesin atau host yang tidak berbagi basis data, `omni_handoff`
 mengekspor keadaan sesi saat ini sebagai markdown yang bisa dibawa dan ditempel
-ke sesi baru. Ia hanya perkakas MCP; subperintah CLI-nya sudah dihapus.
+ke sesi baru. Ia hanya perkakas MCP; subperintah CLI-nya sudah dihapus. Ia berada di luar set yang
+diiklankan secara bawaan, jadi setel `OMNI_MCP_TOOLS=all` sebelum memakainya.
 
 ## Engram
 
@@ -86,7 +87,8 @@ omni patterns                # galat yang terus kembali lintas sesi
 ```
 
 `omni_insight` memeringkat persoalan berulang yang sama untuk seluruh proyek, dan
-ia perkakas MCP tanpa padanan CLI. Ia sempat dicantumkan di blok di atas seolah
+ia perkakas MCP tanpa padanan CLI, dan berada di luar set bawaan yang diiklankan,
+jadi ia butuh `OMNI_MCP_TOOLS=all`. Ia sempat dicantumkan di blok di atas seolah
 Anda bisa menjalankannya.
 
 ## Yang tidak bisa ia lakukan

--- a/docs/website/src/integrations/hermes.md
+++ b/docs/website/src/integrations/hermes.md
@@ -103,7 +103,8 @@ npm output. Confirm with `omni stats`.
 
 Use the MCP tools as Hermes' controls over all of it: `omni_explain_savings` to see
 what a recent command actually cost, `omni_retrieve` to get folded content back, and
-`omni_budget` to see where the session's tokens went.
+`omni_budget` to see where the session's tokens went. That tool is outside the set
+advertised by default, so it needs `OMNI_MCP_TOOLS=all`.
 
 ## After a Hermes upgrade
 

--- a/docs/website/src/integrations/loops.md
+++ b/docs/website/src/integrations/loops.md
@@ -64,6 +64,9 @@ Two agents, one shared context layer.
 ```sh
 LOOP_ID=$(uuidgen)
 
+# the loop tools are outside the default advertised set
+export OMNI_MCP_TOOLS=all
+
 # maker
 export OMNI_AGENT_ID=maker OMNI_LOOP_ID=$LOOP_ID
 claude "Implement: $GOAL"

--- a/docs/website/src/integrations/loops.md
+++ b/docs/website/src/integrations/loops.md
@@ -44,6 +44,11 @@ preserves test detail, "debug" keeps error context, "refactor" compresses harder
 
 ## Tools an orchestrator calls
 
+None of these are advertised by default. OMNI tells a host about the tools its tier
+actually uses, and the loop tools are outside that set, so an orchestrator that calls them
+needs `OMNI_MCP_TOOLS=all` in its environment. `omni doctor` prints which set is in force.
+The MCP tools reference has the per-tier lists.
+
 | tool | when |
 |---|---|
 | `omni_loop_status` | once before each iteration, the cheapest full picture |

--- a/docs/website/src/reference/cmd/session.md
+++ b/docs/website/src/reference/cmd/session.md
@@ -44,7 +44,8 @@ not lose the project context.
 
 For crossing to a machine that shares no database, use the `omni_handoff` MCP tool,
 which exports the state as portable markdown. The CLI subcommand of that name was
-removed; the MCP tool is unchanged.
+removed; the MCP tool is unchanged. It is outside the default advertised set, so it
+needs `OMNI_MCP_TOOLS=all`.
 
 ## Retention
 

--- a/docs/website/src/reference/mcp-tools.md
+++ b/docs/website/src/reference/mcp-tools.md
@@ -1,7 +1,32 @@
 # MCP tools
 
-`omni init` registers OMNI as an MCP server, which gives the agent **25 tools** it can
-call itself without going through you.
+`omni init` registers OMNI as an MCP server, which gives the agent tools it can call
+itself without going through you. This page describes all **25**. Your host is told about
+a subset.
+
+## What your host is told about
+
+Tool definitions sit in the prefix of every request, so a tool nobody calls is re-read on
+every request of every session rather than paid for once. OMNI advertises the set your
+host's tier can use:
+
+| tier | advertised |
+|---|---|
+| Full, and any host OMNI does not recognise | the nine below |
+| Handoff-first | the same nine, with `omni_run` always among them |
+| MCP-only | `omni_remember`, `omni_recall`, `omni_retrieve`, `omni_knowledge` |
+
+The nine are `omni_retrieve`, `omni_explain_savings`, `omni_remember`, `omni_recall`,
+`omni_run`, `omni_find_noise`, `omni_context_breakdown`, `omni_history` and
+`omni_context`. They are the ones that were actually called across the recorded corpus.
+
+Every other tool on this page is still in the binary and one setting away.
+`OMNI_MCP_TOOLS=all` advertises all 25, and `omni doctor` says which set is in force and
+which host it resolved:
+
+```
+  MCP tools:      9 of 25 advertised to claude_code (OMNI_MCP_TOOLS=all restores the rest)
+```
 
 Confirm the list against your own binary rather than this page:
 

--- a/docs/website/src/use/memory.md
+++ b/docs/website/src/use/memory.md
@@ -63,7 +63,8 @@ omni session --health
 
 For moving to a machine or a host that shares no database, `omni_handoff` exports the
 current session state as portable markdown you can paste into a new session. It is an
-MCP tool only; the CLI subcommand was removed.
+MCP tool only; the CLI subcommand was removed. It is outside the set advertised by
+default, so set `OMNI_MCP_TOOLS=all` before reaching for it.
 
 ## Engrams
 
@@ -83,7 +84,8 @@ omni patterns                # errors that keep coming back across sessions
 ```
 
 `omni_insight` ranks the same recurring issues project-wide, and is an MCP tool with no
-CLI equivalent. It was listed in the block above as though you could run it.
+CLI equivalent, and it is outside the default advertised set, so it needs
+`OMNI_MCP_TOOLS=all`. It was listed in the block above as though you could run it.
 
 ## What it cannot do
 

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -97,13 +97,23 @@ fn unreleased_entries() -> usize {
 
 /// One line for the MCP section, phrased so a missing tool is a setting rather
 /// than a mystery.
-pub(crate) fn mcp_tool_line(agent_id: &str) -> String {
-    let active = crate::mcp::policy::active_tools(agent_id).len();
+///
+/// It names the id it resolved because the caller passes whatever
+/// `detect_agent_id` returned, which in a plain terminal is `terminal` and not
+/// the host the reader is thinking of. `keep_everything` comes from
+/// `policy::override_is_on`, the same read the served router makes, so the line
+/// cannot offer the override as a remedy while the override is already on.
+pub(crate) fn mcp_tool_line(agent_id: &str, keep_everything: bool) -> String {
     let total = crate::mcp::policy::ALL_TOOL_COUNT;
-    format!(
-        "  MCP tools:      {active} of {total} advertised for this host \
-         (OMNI_MCP_TOOLS=all restores the rest)"
-    )
+    let (active, note) = if keep_everything {
+        (total, "OMNI_MCP_TOOLS=all is set")
+    } else {
+        (
+            crate::mcp::policy::active_tools(agent_id).len(),
+            "OMNI_MCP_TOOLS=all restores the rest",
+        )
+    };
+    format!("  MCP tools:      {active} of {total} advertised to {agent_id} ({note})")
 }
 
 fn run_json(args: &[String]) -> anyhow::Result<()> {
@@ -597,7 +607,10 @@ pub fn run(args: &[String]) -> anyhow::Result<()> {
     // machine, so the line has to name the setting that undoes it.
     println!(
         "{}",
-        mcp_tool_line(&crate::agents::multiagent::detect_agent_id())
+        mcp_tool_line(
+            &crate::agents::multiagent::detect_agent_id(),
+            crate::mcp::policy::override_is_on(),
+        )
     );
 
     if !any_agent_ok {
@@ -683,8 +696,23 @@ mod tests {
     /// missing with nothing telling them why.
     #[test]
     fn doctor_says_how_many_tools_are_advertised_and_how_to_restore_them() {
-        let line = super::mcp_tool_line("claude_code");
-        assert!(line.contains("9 of 25"), "{line}");
-        assert!(line.contains("OMNI_MCP_TOOLS=all"), "{line}");
+        let line = super::mcp_tool_line("claude_code", false);
+        assert_eq!(
+            line,
+            "  MCP tools:      9 of 25 advertised to claude_code \
+             (OMNI_MCP_TOOLS=all restores the rest)"
+        );
+    }
+
+    /// With the override in force nothing is cut, so naming it as a remedy is a
+    /// false claim about the process the reader is looking at.
+    #[test]
+    fn doctor_reports_the_override_instead_of_offering_it() {
+        let line = super::mcp_tool_line("claude_code", true);
+        assert_eq!(
+            line,
+            "  MCP tools:      25 of 25 advertised to claude_code \
+             (OMNI_MCP_TOOLS=all is set)"
+        );
     }
 }

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -95,6 +95,17 @@ fn unreleased_entries() -> usize {
         .unwrap_or(0)
 }
 
+/// One line for the MCP section, phrased so a missing tool is a setting rather
+/// than a mystery.
+pub(crate) fn mcp_tool_line(agent_id: &str) -> String {
+    let active = crate::mcp::policy::active_tools(agent_id).len();
+    let total = crate::mcp::policy::ALL_TOOL_COUNT;
+    format!(
+        "  MCP tools:      {active} of {total} advertised for this host \
+         (OMNI_MCP_TOOLS=all restores the rest)"
+    )
+}
+
 fn run_json(args: &[String]) -> anyhow::Result<()> {
     let fix_mode = args.iter().any(|a| a == "--fix");
     let mut checks = Vec::new();
@@ -581,6 +592,14 @@ pub fn run(args: &[String]) -> anyhow::Result<()> {
         println!("   {}", tier.bright_black());
     }
 
+    // The tools this host is told about, not the host's own agent list above:
+    // #577 cut the advertised surface from 25 to 9 on the evidence of one
+    // machine, so the line has to name the setting that undoes it.
+    println!(
+        "{}",
+        mcp_tool_line(&crate::agents::multiagent::detect_agent_id())
+    );
+
     if !any_agent_ok {
         warnings.push(
             "No agent integrations are configured. Run `omni init` to set up hooks + MCP for your agent."
@@ -657,5 +676,15 @@ mod tests {
         assert!(out.contains("PreToolUse"), "{out}");
         assert!(out.contains("MCP Server:"), "{out}");
         assert!(out.contains("Distill tier:"), "{out}");
+    }
+
+    /// The cut has to be visible and reversible from the same line, because the
+    /// evidence behind it is n=1 and the failure mode is a user finding a tool
+    /// missing with nothing telling them why.
+    #[test]
+    fn doctor_says_how_many_tools_are_advertised_and_how_to_restore_them() {
+        let line = super::mcp_tool_line("claude_code");
+        assert!(line.contains("9 of 25"), "{line}");
+        assert!(line.contains("OMNI_MCP_TOOLS=all"), "{line}");
     }
 }

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -1,2 +1,2 @@
-pub mod server;
 pub mod policy;
+pub mod server;

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -1,1 +1,2 @@
 pub mod server;
+pub mod policy;

--- a/src/mcp/policy.rs
+++ b/src/mcp/policy.rs
@@ -40,6 +40,11 @@ pub const MEMORY: &[&str] = &[
     "omni_knowledge",
 ];
 
+/// Every tool the binary can serve. Kept here so `doctor` does not have to
+/// build a router to count them, and asserted against the router in
+/// `server.rs` so the two cannot drift.
+pub const ALL_TOOL_COUNT: usize = 25;
+
 /// `detect_agent_id` and `AgentIntegration::id` disagree for exactly the two
 /// Full-tier hosts, which is the whole reason this function is not a one-liner.
 fn integration_id(detected: &str) -> &str {

--- a/src/mcp/policy.rs
+++ b/src/mcp/policy.rs
@@ -1,0 +1,133 @@
+//! Which of OMNI's MCP tools a host is told about.
+//!
+//! Measured 2026-08-15 across 228 Claude Code transcripts: 25 tools are
+//! advertised in the prefix of every request, 16 of them have never been
+//! called, and those 16 are 4,940 bytes. That is the same size as the 4,942
+//! bytes OMNI removes from tool output in a median session, and it sits at
+//! position 0 where it is re-read on every request rather than from the middle
+//! of the session. Advertising them costs about twice what the distillers earn.
+//!
+//! The set is chosen by `Tier`, which already exists and is what `doctor`
+//! prints, so this module adds no second opinion about what a host can do.
+
+use crate::agents::Tier;
+
+/// Called at least once in the corpus, so a host that can use them is told
+/// about them. Ordered as the probe reports them, most-called first.
+pub const FULL: &[&str] = &[
+    "omni_retrieve",
+    "omni_explain_savings",
+    "omni_remember",
+    "omni_recall",
+    "omni_run",
+    "omni_find_noise",
+    "omni_context_breakdown",
+    "omni_history",
+    "omni_context",
+];
+
+/// Same list today, kept separate so a future edit to `FULL` cannot silently
+/// drop `omni_run` from the one tier that has nothing else. The test is what
+/// makes that guarantee real.
+pub const HANDOFF: &[&str] = FULL;
+
+/// No shell distillation exists on this tier, so the tools that report on it
+/// would describe something that never happens.
+pub const MEMORY: &[&str] = &[
+    "omni_remember",
+    "omni_recall",
+    "omni_retrieve",
+    "omni_knowledge",
+];
+
+/// `detect_agent_id` and `AgentIntegration::id` disagree for exactly the two
+/// Full-tier hosts, which is the whole reason this function is not a one-liner.
+fn integration_id(detected: &str) -> &str {
+    match detected {
+        "claude_code" => "claude",
+        "codex_cli" => "codex",
+        other => other,
+    }
+}
+
+/// The tier the host's own integration declares. `Tier` stays the single source
+/// of truth; this only translates the name.
+pub fn tier_for(agent_id: &str) -> Tier {
+    let want = integration_id(agent_id);
+    crate::agents::all_integrations()
+        .iter()
+        .find(|a| a.id() == want)
+        .map_or(Tier::McpOnly, |a| a.tier())
+}
+
+/// The tools this host is told about.
+pub fn active_tools(agent_id: &str) -> &'static [&'static str] {
+    match tier_for(agent_id) {
+        Tier::Full => FULL,
+        Tier::HandoffFirst => HANDOFF,
+        Tier::McpOnly => MEMORY,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agents::Tier;
+
+    /// The trap this module exists for. `detect_agent_id` returns `claude_code`
+    /// and `codex_cli`; the integrations that carry the tier are registered as
+    /// `claude` and `codex`. A lookup without the alias silently drops both
+    /// Full-tier hosts to `McpOnly`, which is the one outcome that would cut
+    /// tools the main host actually calls.
+    #[test]
+    fn the_detected_ids_map_to_the_tier_their_integration_declares() {
+        assert_eq!(tier_for("claude_code"), Tier::Full);
+        assert_eq!(tier_for("codex_cli"), Tier::Full);
+        assert_eq!(tier_for("cursor"), Tier::HandoffFirst);
+        assert_eq!(tier_for("gemini"), Tier::Full);
+        // Anything unrecognised claims nothing, the same default the
+        // `AgentIntegration` trait uses.
+        assert_eq!(tier_for("something-new"), Tier::McpOnly);
+    }
+
+    /// `strategy.md` section 5 makes this product law: on a Handoff-first host
+    /// the built-in tool output is never rewritten, so `omni_run` is the only
+    /// path by which the model reads less. Cutting it there would remove the
+    /// host's entire reason to have OMNI installed.
+    #[test]
+    fn a_handoff_first_host_keeps_omni_run() {
+        assert!(active_tools("cursor").contains(&"omni_run"));
+    }
+
+    /// An MCP-only host has no shell distillation to report on, so the read
+    /// tools over it are noise there.
+    #[test]
+    fn an_mcp_only_host_gets_the_memory_set_and_nothing_else() {
+        let tools = active_tools("windsurf");
+        assert!(tools.contains(&"omni_remember"));
+        assert!(tools.contains(&"omni_retrieve"));
+        assert!(!tools.contains(&"omni_explain_savings"));
+    }
+
+    /// Measured 2026-08-15: nine tools were called across 228 sessions and the
+    /// other sixteen never were. If this list grows without the probe being
+    /// re-run, the design's own justification has stopped being true.
+    #[test]
+    fn the_full_set_is_the_nine_that_were_actually_called() {
+        let mut got = active_tools("claude_code").to_vec();
+        got.sort_unstable();
+        let mut want = vec![
+            "omni_context",
+            "omni_context_breakdown",
+            "omni_explain_savings",
+            "omni_find_noise",
+            "omni_history",
+            "omni_recall",
+            "omni_remember",
+            "omni_retrieve",
+            "omni_run",
+        ];
+        want.sort_unstable();
+        assert_eq!(got, want);
+    }
+}

--- a/src/mcp/policy.rs
+++ b/src/mcp/policy.rs
@@ -3,7 +3,8 @@
 //! Measured 2026-08-15 across 228 Claude Code transcripts: 25 tools are
 //! advertised in the prefix of every request, 16 of them have never been
 //! called, and those 16 are 4,940 bytes. That is the same size as the 4,942
-//! bytes OMNI removes from tool output in a median session, and it sits at
+//! bytes OMNI removes from tool output in the median of the 35 sessions that
+//! pushed more than 50 KB through the hook, and it sits at
 //! position 0 where it is re-read on every request rather than from the middle
 //! of the session. Advertising them costs about twice what the distillers earn.
 //!
@@ -57,12 +58,38 @@ fn integration_id(detected: &str) -> &str {
 
 /// The tier the host's own integration declares. `Tier` stays the single source
 /// of truth; this only translates the name.
+///
+/// An id with no registered integration gets `Full`, because being wrong about a
+/// host has to cost a flag rather than a capability. `detect_agent_id` can return
+/// `windsurf`, `vscode_continue`, `aider` and `terminal`, none of which is
+/// registered anywhere; the opposite default also dropped
+/// Codex to four tools whenever `CODEX_SESSION` failed to reach the subprocess,
+/// since its generated config carries no `OMNI_AGENT_ID`. A host that wants the
+/// memory set declares it by registering an integration.
 pub fn tier_for(agent_id: &str) -> Tier {
     let want = integration_id(agent_id);
     crate::agents::all_integrations()
         .iter()
         .find(|a| a.id() == want)
-        .map_or(Tier::McpOnly, |a| a.tier())
+        .map_or(Tier::Full, |a| a.tier())
+}
+
+/// Does `OMNI_MCP_TOOLS` ask for the whole surface?
+///
+/// Split from the environment read so a test can decide this without mutating
+/// process environment. Cargo runs tests in parallel, this crate already has
+/// tests that set variables, and that combination is how a green local suite
+/// went red on CI here. `all` is the only documented spelling; anything else
+/// gets the cut set.
+pub fn value_means_all(value: Option<&str>) -> bool {
+    value.is_some_and(|v| v.eq_ignore_ascii_case("all"))
+}
+
+/// The override as the running process sees it. The only place that reads the
+/// variable, so `doctor` and the served router cannot disagree about whether the
+/// cut is in force.
+pub fn override_is_on() -> bool {
+    value_means_all(std::env::var("OMNI_MCP_TOOLS").ok().as_deref())
 }
 
 /// The tools this host is told about.
@@ -90,9 +117,20 @@ mod tests {
         assert_eq!(tier_for("codex_cli"), Tier::Full);
         assert_eq!(tier_for("cursor"), Tier::HandoffFirst);
         assert_eq!(tier_for("gemini"), Tier::Full);
-        // Anything unrecognised claims nothing, the same default the
-        // `AgentIntegration` trait uses.
-        assert_eq!(tier_for("something-new"), Tier::McpOnly);
+    }
+
+    /// Being wrong about a host must cost a flag, not a capability. `omni_run`
+    /// works on any host and `omni_explain_savings` merely has nothing to report
+    /// where there is no hook, so an unrecognised id keeps the nine rather than
+    /// losing five of them.
+    #[test]
+    fn an_unregistered_host_keeps_the_full_set() {
+        assert_eq!(tier_for("something-new"), Tier::Full);
+        // `vscode`, `zed` and `antigravity` are left out on purpose: they are
+        // registered in `mcp_host::HOSTS` and so are genuinely MCP-only.
+        for id in ["windsurf", "vscode_continue", "aider", "terminal"] {
+            assert_eq!(active_tools(id), FULL, "{id} lost the full set");
+        }
     }
 
     /// `strategy.md` section 5 makes this product law: on a Handoff-first host
@@ -105,10 +143,12 @@ mod tests {
     }
 
     /// An MCP-only host has no shell distillation to report on, so the read
-    /// tools over it are noise there.
+    /// tools over it are noise there. `cline` is registered and takes the
+    /// trait's default tier, which is what makes it MCP-only; an id nobody
+    /// registered gets `Full` instead.
     #[test]
     fn an_mcp_only_host_gets_the_memory_set_and_nothing_else() {
-        let tools = active_tools("windsurf");
+        let tools = active_tools("cline");
         assert!(tools.contains(&"omni_remember"));
         assert!(tools.contains(&"omni_retrieve"));
         assert!(!tools.contains(&"omni_explain_savings"));
@@ -134,5 +174,17 @@ mod tests {
         ];
         want.sort_unstable();
         assert_eq!(got, want);
+    }
+
+    /// The escape hatch, driven through the predicate instead of the process
+    /// environment for the reason in `value_means_all`'s own comment. These are
+    /// the values a user actually types.
+    #[test]
+    fn only_the_documented_spelling_restores_every_tool() {
+        assert!(value_means_all(Some("all")));
+        assert!(value_means_all(Some("ALL")));
+        assert!(!value_means_all(None), "unset must not restore");
+        assert!(!value_means_all(Some("")), "empty must not restore");
+        assert!(!value_means_all(Some("full")), "undocumented spelling");
     }
 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1500,12 +1500,11 @@ impl OmniServer {
         router
     }
 
-    /// As `router_from`, reading the override from the environment.
+    /// As `router_from`, reading the override from the environment. `doctor`
+    /// reads it through the same function, so its line cannot claim a cut that
+    /// is not in force.
     fn router_for(agent_id: &str) -> rmcp::handler::server::router::tool::ToolRouter<Self> {
-        let keep_everything = std::env::var("OMNI_MCP_TOOLS")
-            .map(|v| v.eq_ignore_ascii_case("all"))
-            .unwrap_or(false);
-        Self::router_from(agent_id, keep_everything)
+        Self::router_from(agent_id, crate::mcp::policy::override_is_on())
     }
 
     /// The router the served handler uses.
@@ -1818,6 +1817,31 @@ mod tests {
             .list_all()
             .len();
         assert_eq!(restored, all);
+    }
+
+    /// Design gate 2: every tool in the active set is callable, per tier. The
+    /// policy lists are string literals and the router builds its routes from a
+    /// macro, so a typo in a list deletes a tool from that tier with nothing
+    /// failing: `doctor` then prints a count the router cannot serve.
+    #[test]
+    fn every_policy_name_resolves_to_a_route() {
+        let routes: Vec<String> = OmniServer::tool_router()
+            .list_all()
+            .into_iter()
+            .map(|t| t.name.to_string())
+            .collect();
+        for (tier, names) in [
+            ("FULL", crate::mcp::policy::FULL),
+            ("HANDOFF", crate::mcp::policy::HANDOFF),
+            ("MEMORY", crate::mcp::policy::MEMORY),
+        ] {
+            for name in names {
+                assert!(
+                    routes.iter().any(|r| r == name),
+                    "{tier} lists {name}, which the router does not serve; routes: {routes:?}"
+                );
+            }
+        }
     }
 
     /// `doctor` prints `ALL_TOOL_COUNT` without building a router, so nothing

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1819,4 +1819,14 @@ mod tests {
             .len();
         assert_eq!(restored, all);
     }
+
+    /// `doctor` prints `ALL_TOOL_COUNT` without building a router, so nothing
+    /// catches the two drifting apart except this.
+    #[test]
+    fn the_declared_tool_count_matches_the_router() {
+        assert_eq!(
+            OmniServer::tool_router().list_all().len(),
+            crate::mcp::policy::ALL_TOOL_COUNT
+        );
+    }
 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -266,7 +266,7 @@ pub struct OmniSignalExtractParams {
 }
 
 // Automatically bind tool signatures
-#[tool_router(server_handler)]
+#[tool_router]
 impl OmniServer {
     #[tool(
         name = "omni_retrieve",
@@ -1470,7 +1470,54 @@ impl OmniServer {
         })
         .to_string()
     }
+
+    /// The routes this host is told about.
+    ///
+    /// Built by removing from the generated router rather than by listing what
+    /// to keep, so a tool added later is inactive until it is put in
+    /// `policy::FULL`. That default is deliberate: the cost of a tool is paid
+    /// by every user on every request, and the benefit is paid by whoever calls
+    /// it (#577).
+    fn router_from(
+        agent_id: &str,
+        keep_everything: bool,
+    ) -> rmcp::handler::server::router::tool::ToolRouter<Self> {
+        let mut router = Self::tool_router();
+        if keep_everything {
+            return router;
+        }
+        let active = crate::mcp::policy::active_tools(agent_id);
+        let advertised: Vec<String> = router
+            .list_all()
+            .into_iter()
+            .map(|t| t.name.to_string())
+            .collect();
+        for name in advertised {
+            if !active.iter().any(|a| *a == name) {
+                router.remove_route(&name);
+            }
+        }
+        router
+    }
+
+    /// As `router_from`, reading the override from the environment.
+    fn router_for(agent_id: &str) -> rmcp::handler::server::router::tool::ToolRouter<Self> {
+        let keep_everything = std::env::var("OMNI_MCP_TOOLS")
+            .map(|v| v.eq_ignore_ascii_case("all"))
+            .unwrap_or(false);
+        Self::router_from(agent_id, keep_everything)
+    }
+
+    /// The router the served handler uses.
+    fn active_tool_router() -> rmcp::handler::server::router::tool::ToolRouter<Self> {
+        let agent_id = std::env::var("OMNI_AGENT_ID")
+            .unwrap_or_else(|_| crate::agents::multiagent::detect_agent_id());
+        Self::router_for(&agent_id)
+    }
 }
+
+#[rmcp::tool_handler(router = Self::active_tool_router())]
+impl rmcp::ServerHandler for OmniServer {}
 
 fn compute_project_hash_str(project_path: &str) -> String {
     crate::agents::multiagent::project_hash(project_path)
@@ -1721,5 +1768,56 @@ mod tests {
             out.contains("No tool calls recorded"),
             "expected empty message, got: {out}"
         );
+    }
+
+    /// The gate from the design: the advertised surface on a Full-tier host is
+    /// under 3,000 bytes. It was 7,912 before this, and the 4,940 that came off
+    /// is the half that had never been called.
+    #[test]
+    fn the_advertised_surface_is_smaller_than_it_was() {
+        let router = OmniServer::router_for("claude_code");
+        let listed = router.list_all();
+        let bytes: usize = listed
+            .iter()
+            .map(|t| serde_json::to_string(t).expect("tool serialises").len())
+            .sum();
+
+        assert_eq!(
+            listed.len(),
+            9,
+            "advertised {} tools, expected the nine",
+            listed.len()
+        );
+        assert!(
+            bytes < 3_000,
+            "advertised surface is {bytes} B, gate is 3000"
+        );
+    }
+
+    /// A host that cannot rewrite built-in tool output has one path left, and
+    /// removing it would leave the install with nothing to do (`strategy.md`
+    /// section 5).
+    #[test]
+    fn a_handoff_first_host_is_still_told_about_omni_run() {
+        let names: Vec<String> = OmniServer::router_for("cursor")
+            .list_all()
+            .into_iter()
+            .map(|t| t.name.to_string())
+            .collect();
+        assert!(
+            names.iter().any(|n| n == "omni_run"),
+            "advertised: {names:?}"
+        );
+    }
+
+    /// The escape hatch, because a cut nobody can undo is a cut that gets
+    /// reported as a missing feature.
+    #[test]
+    fn the_override_restores_every_tool() {
+        let all = OmniServer::tool_router().list_all().len();
+        let restored = OmniServer::router_from("claude_code", true)
+            .list_all()
+            .len();
+        assert_eq!(restored, all);
     }
 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1510,8 +1510,7 @@ impl OmniServer {
 
     /// The router the served handler uses.
     fn active_tool_router() -> rmcp::handler::server::router::tool::ToolRouter<Self> {
-        let agent_id = std::env::var("OMNI_AGENT_ID")
-            .unwrap_or_else(|_| crate::agents::multiagent::detect_agent_id());
+        let agent_id = crate::agents::multiagent::detect_agent_id();
         Self::router_for(&agent_id)
     }
 }
@@ -1775,7 +1774,7 @@ mod tests {
     /// is the half that had never been called.
     #[test]
     fn the_advertised_surface_is_smaller_than_it_was() {
-        let router = OmniServer::router_for("claude_code");
+        let router = OmniServer::router_from("claude_code", false);
         let listed = router.list_all();
         let bytes: usize = listed
             .iter()
@@ -1799,7 +1798,7 @@ mod tests {
     /// section 5).
     #[test]
     fn a_handoff_first_host_is_still_told_about_omni_run() {
-        let names: Vec<String> = OmniServer::router_for("cursor")
+        let names: Vec<String> = OmniServer::router_from("cursor", false)
             .list_all()
             .into_iter()
             .map(|t| t.name.to_string())

--- a/tests/smoke_test.sh
+++ b/tests/smoke_test.sh
@@ -190,7 +190,7 @@ fi
 
 # ─── 9. MCP Server ───────────────────────────────────────
 echo "▸ Scenario 9: MCP Server"
-# MCP server reads stdin — give it empty stdin with timeout
+# MCP server reads stdin, so give it empty stdin with a timeout
 # macOS doesn't have `timeout`, use perl-based alternative
 MCP_EXIT=0
 if command -v timeout &>/dev/null; then

--- a/tests/smoke_test.sh
+++ b/tests/smoke_test.sh
@@ -95,6 +95,15 @@ DOCTOR_OUT=$("$OMNI" doctor 2>&1 || true)
 check "doctor shows header" "$DOCTOR_OUT" "OMNI Doctor"
 check "doctor shows binary" "$DOCTOR_OUT" "Binary"
 
+# The env read behind OMNI_MCP_TOOLS cannot be covered by a cargo test: this crate
+# already mutates process environment in tests, cargo runs them in parallel, and that
+# combination has reddened CI here before. A subprocess has its own environment, so the
+# escape hatch is verified across the boundary that can actually be wrong.
+LEAN_OUT=$(OMNI_AGENT_ID=claude_code "$OMNI" doctor 2>&1 || true)
+check "doctor reports the lean MCP surface" "$LEAN_OUT" "9 of 25"
+ALL_OUT=$(OMNI_AGENT_ID=claude_code OMNI_MCP_TOOLS=all "$OMNI" doctor 2>&1 || true)
+check "OMNI_MCP_TOOLS=all restores every tool" "$ALL_OUT" "25 of 25"
+
 # ─── 4. PostToolUse Hook E2E ─────────────────────────────
 echo "▸ Scenario 4: PostToolUse Hook E2E"
 FIXTURE_CONTENT=$(cat tests/fixtures/git_diff_multi_file.txt)


### PR DESCRIPTION
A host is now told about the MCP tools its tier can use: nine on Full and Handoff-first,
four on MCP-only. `omni_run` is pinned to Handoff-first by its own test, because there it
is the only path by which the model reads less. `OMNI_MCP_TOOLS=all` restores every tool,
and `omni doctor` prints which set is in force.

`#[tool_router]` drops its `server_handler` argument and `impl ServerHandler` is written
by hand over a router the policy has filtered with `remove_route`. The generated arm was
an empty impl, so `get_info`, capabilities, protocol version and instructions come out
identical. `call_tool`, `list_tools` and `get_tool` all read the filtered router, so a
tool that is not advertised is not dispatchable either, rather than merely hidden.

## Why

The definitions sit in the prefix of every request of every session, so they are re-read
on each one instead of paid for once. Over 229 Claude Code transcripts:

| | tools | bytes | calls |
| --- | ---: | ---: | ---: |
| ever called | 9 | 2,972 | 109 |
| never called | 16 | 4,940 | 0 |
| total | 25 | 7,912 | 109 |

`omni_retrieve` and `omni_explain_savings` are 84% of all calls. The heaviest single
entry, `omni_loop_memory` at 778 B, has never been called.

The never-called half is 4,940 B. OMNI removes a median of 4,942 B from tool output in a
session that pushes more than 50 KB through the hook. Two bytes apart, and the prefix
side is carried from request 1 while a removed output byte was inserted mid-session, so
advertising them cost roughly twice what the distillers earned.

## Measured

Three interleaved passes on the release binary, zero spread:

```
default              9 tools   2,972 B     never called: 0 tools
OMNI_MCP_TOOLS=all  25 tools   7,912 B     never called: 16 tools, 4,940 B
```

Every tool in the Full set has been called at least once, which is the check that the set
was drawn from the data rather than around it. That does not extend to the MCP-only set:
`omni_knowledge` sits there on judgement, with zero recorded calls, because a host with no
shell distillation has nothing else to read.

An unrecognised host gets the Full nine, not the memory four. Being wrong about a host has
to cost a flag rather than a capability, and `omni init` does not write `OMNI_AGENT_ID`
into every generated config, so the unknown case is not rare.

Reproduce: `python3 docs/internal/transcript-probes/mcp_surface.py ./target/release/omni`

## Verified by breaking it

Each assertion was driven red before it was trusted, and the break was proved by diff
first, because a filter that matches nothing exits 0 here.

| break applied | test | printed |
| --- | --- | --- |
| `omni_loop_memory` added to the Full set | `the_advertised_surface_is_smaller_than_it_was` | `left: 10, right: 9` |
| `ALL_TOOL_COUNT` set to 24 | `the_declared_tool_count_matches_the_router` | `left: 25, right: 24` |
| the `claude_code` alias arm removed | `the_detected_ids_map_to_their_integrations` | `left: McpOnly, right: Full` |
| `omni_run` removed from the Full set | `a_handoff_first_host_keeps_omni_run` | failed |
| the doctor format string edited | `doctor_says_how_many_tools_are_advertised...` | failed |

`make fmt clippy test security binary-check` all green, smoke test 44/44.

## What review changed

A whole-branch review said no to the first version and was right five times. `omni doctor`
printed `9 of 25` while `OMNI_MCP_TOOLS=all` was serving 25, which made the one line whose
job is visibility false exactly when the reversal was on. It also named the shell's
identity as the host, so a plain terminal read `4 of 25` on a machine where Claude Code
gets 9. Both came from doctor re-deriving a decision the server already made; there is one
copy now, and the line names the id it resolved:

```
  MCP tools:      9 of 25 advertised to claude_code (OMNI_MCP_TOOLS=all restores the rest)
  MCP tools:     25 of 25 advertised to claude_code (OMNI_MCP_TOOLS=all is set)
```

An unknown host defaulted to the four-tool set, which is the wrong direction. Two gaps in
the tests were proved by breaking them: deleting the entire `OMNI_MCP_TOOLS` read left the
suite green, and a typo in a tier's list silently dropped a tool with nothing red. Both are
covered now, the second by asserting every policy name resolves to a real route. The
changelog had also dropped the qualifier on the 4,942 byte median.

## What this does not prove

One machine, one developer, Claude Code only. `~/.claude/projects` cannot see Cursor or
Codex, so "never called" means never called here. That is why the override exists and why
doctor names it, rather than the sixteen tools being deleted. If a tool somebody uses is
cut, the symptom is a setting with its own instructions, not a mystery.

Closes #577

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR filters the MCP router according to host tier, adds an environment override for restoring all routes, and reports the active surface through `omni doctor`.
- Adds Full, Handoff-first, and MCP-only tool policies.
- Uses the filtered router for both tool advertisement and dispatch.
- Documents the reduced surface and override across affected workflows.
- Upgrades rmcp from 1.4 to 1.7 and adds policy, router, doctor, and smoke-test coverage.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until the outstanding documentation failure for the default-hidden `omni_agents` workflow is resolved.

Although the reply from the author field shown as empty states that the wider documentation issue was fixed, `reference/agents.md` still directs users to `omni_agents` without the required override while the policy removes that route by default.

**Files Needing Attention:** docs/website/src/reference/agents.md and docs/website/src-id/reference/agents.md
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/mcp/policy.rs | Defines host-tier allowlists, identity aliases, unknown-host fallback behavior, and the all-tools override. |
| src/mcp/server.rs | Replaces the generated handler implementation with a manually wired, policy-filtered tool router used for advertisement and dispatch. |
| src/cli/doctor.rs | Reports the resolved host, active tool count, and whether the all-tools override is enabled. |
| docs/website/src/reference/mcp-tools.md | Documents the tier-specific advertised sets and the override that restores all 25 tools. |
| docs/website/src/reference/agents.md | The existing multi-agent workflow remains implicated by the outstanding prior discoverability finding. |
| tests/smoke_test.sh | Adds subprocess-level checks that doctor reports both the reduced and restored MCP surfaces. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[MCP server starts] --> B[Detect host identity]
    B --> C[Resolve host tier]
    C --> D{OMNI_MCP_TOOLS=all?}
    D -->|Yes| E[Keep all 25 routes]
    D -->|No| F[Select tier allowlist]
    F --> G[Remove other routes]
    E --> H[List and dispatch tools]
    G --> H
```
</details>

<sub>Reviews (4): Last reviewed commit: ["docs(manual): name the override where a ..."](https://github.com/fajarhide/omni/commit/52befd5d5c30659e4136e653ce037c79b2f3400f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53628365)</sub>

<!-- /greptile_comment -->