### PR TITLE
Update benchmark savings percentages in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 <h1>OMNI</h1>
 <p align="center">
-    <em><b>Stop paying to re-read the same output.</b> OMNI turns repeated bytes into retrievable handles: 97.2% off a file your agent reads twice, 74.9% across 6,656 real commands. Nothing deleted, nothing invented, and every number replays on your own corpus.</em>
+    <em><b>Stop paying to re-read the same output.</b> OMNI turns repeated bytes into retrievable handles: 97.2% off a file your agent reads twice, 14.9% across 6,656 real commands. Nothing deleted, nothing invented, and every number replays on your own corpus.</em>
 </p>
 
 [🇺🇸 English](README.md) | [🇯🇵 日本語](i18n/README-ja.md) | [🇨🇳 简体中文](i18n/README-zh.md) | [🇸🇦 العربية](i18n/README-ar.md) | [🇮🇩 Bahasa Indonesia](i18n/README-id.md) | [🇻🇳 Tiếng Việt](i18n/README-vi.md) | [🇰🇷 한국어](i18n/README-ko.md)

--- a/docs/website/src/develop/benchmarks.md
+++ b/docs/website/src/develop/benchmarks.md
@@ -87,8 +87,8 @@ Identical bytes into every arm. Versions: rtk 0.45.0, lean-ctx 3.9.18, caveman 1
 
 | | bytes | saved | claimed |
 |---|---|---:|---|
-| rtk `pipe` | 23,086,649 to 22,967,550 | **20.5%** | 623 of 5,984, marked a cut in 16 |
-| caveman `tools compress` | 23,086,649 to 21,702,637 | **6.0%** | 149 of 5,984, no command hint |
+| rtk `pipe` | 23,086,649 to 22,967,550 | **6.2%** | 623 of 5,984, marked a cut in 16 |
+| caveman `tools compress` | 23,086,649 to 21,702,637 | **6.8%** | 149 of 5,984, no command hint |
 | omni, filters only | 23,086,649 to 15,557,823 | **32.6%** | |
 | lean-ctx `compress` | 23,086,649 to 11,678,975 | **49.4%** | 425 of 5,984 |
 | headroom dedup, our filters | 23,086,649 to 7,905,764 | **65.8%** | |

--- a/docs/website/src/develop/benchmarks.md
+++ b/docs/website/src/develop/benchmarks.md
@@ -87,8 +87,8 @@ Identical bytes into every arm. Versions: rtk 0.45.0, lean-ctx 3.9.18, caveman 1
 
 | | bytes | saved | claimed |
 |---|---|---:|---|
-| rtk `pipe` | 23,086,649 to 22,967,550 | **6.2%** | 623 of 5,984, marked a cut in 16 |
-| caveman `tools compress` | 23,086,649 to 21,702,637 | **6.8%** | 149 of 5,984, no command hint |
+| rtk `pipe` | 23,086,649 to 21,655,277 | **6.2%** | |
+| caveman `tools compress` | 23,086,649 to 21,516,757 | **6.8%** | |
 | omni, filters only | 23,086,649 to 15,557,823 | **32.6%** | |
 | lean-ctx `compress` | 23,086,649 to 11,678,975 | **49.4%** | 425 of 5,984 |
 | headroom dedup, our filters | 23,086,649 to 7,905,764 | **65.8%** | |
@@ -103,35 +103,6 @@ and nothing else.
 **lean-ctx beats our filters by 16.8 points**, 49.4% against 32.6%, over 425 calls to
 our 236. That is not argued away: this corpus is a few enormous repetitive payloads,
 which is exactly the shape a deep-and-narrow compressor is built for.
-
-**rtk reads 20.5% because its filters only fire on a command it recognises**, and this
-corpus is 89.5% commands it does not:
-
-| command | bytes | rtk filter |
-|---|---:|---|
-| `tail` | 9,558,272 | none |
-| `zsh` | 8,391,102 | none |
-| `cd` | 1,503,873 | none |
-| `cat` | 770,972 | none |
-| `export` | 429,265 | none |
-| `grep` | 410,575 | `grep` |
-
-Not a stale binary and not a broken arm: 0.45.0 is current, it claimed 623 calls, and
-the harness names are checked against rtk's own `resolve_filter`. Of its 25 filters we
-map 18; six of the rest have zero traces here, and `log` stays unmapped because rtk's
-own hook maps no command to it either.
-
-**Read our own rows with the most suspicion.** A corpus that hands OMNI a 32 point
-lead over rtk is evidence about the corpus. The ledger reads any payload; rtk's
-filters need a name they know, and on these bytes that difference is the whole result.
-
-Two things that tilt this **towards rtk**, stated because a benchmark listing only its
-own handicaps is an advertisement: it is handed the exact filter name its own hook
-must infer, and anything it has no filter for counts as passthrough rather than a
-miss. caveman gets less than either: no command hint at all.
-
-The counts are not like for like. rtk's is a mapped filter, saving or not. lean-ctx
-and caveman report no filter name, so theirs is an actual reduction.
 
 No `lean-ctx + our ledger` row: its preview reports `compressed_bytes` and never emits
 the text, so that row could only be estimated.


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR corrects published benchmark savings figures and removes the obsolete explanation based on the previous rtk result.
- Updates the README’s aggregate savings figure from 74.9% to 14.9%.
- Updates rtk and caveman benchmark totals and percentages.
- Removes the stale rtk analysis tied to the former 20.5% figure.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Updates the headline aggregate savings percentage to 14.9%. |
| docs/website/src/develop/benchmarks.md | Corrects rtk and caveman benchmark values; the displayed byte totals now round to 6.2% and 6.8%, respectively, and the obsolete 20.5% explanation is removed. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Revise benchmark data for rtk and cavema..."](https://github.com/fajarhide/omni/commit/d1d2b08ed5a63e8c020083cbf39556a9eafc14b1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53721862)</sub>

<!-- /greptile_comment -->