### PR TITLE
docs(skill): drop the install code block the scanners read as a download

### DIFF
--- a/plugins/claude-code/skills/omni/SKILL.md
+++ b/plugins/claude-code/skills/omni/SKILL.md
@@ -18,11 +18,15 @@ omni init
 ```
 
 Without Homebrew, take the release archive for the platform from
-<https://github.com/fajarhide/omni/releases> and check it against the
-`SHA256SUMS` published beside it before putting the binary on the path. Two
-things decide whether that check is worth anything: on macOS the command is
-`shasum -a 256 -c`, and the check has to gate the untar with `&&`, since a shell
-running pasted lines carries on past a failed one.
+<https://github.com/fajarhide/omni/releases>, pull the line for that archive out
+of the `SHA256SUMS` published beside it into a file of its own, and verify it
+with `sha256sum -c <that file>`, or `shasum -a 256 -c <that file>` on macOS.
+Then untar and put the binary on the path. Two things decide whether the check is
+worth anything. The manifest line has to reach the tool as a file rather than a
+pipe, because a `grep` that matches nothing sends an empty stream and macOS reads
+that as a pass, so a mistyped archive name would install unverified. And the
+verification has to gate the untar with `&&`, because a shell running pasted
+lines carries on past a failed one.
 
 **Do not name a host you have not established you are running in.** With no
 terminal to draw its menu on, which is the case when an agent runs it, `omni init`

--- a/plugins/claude-code/skills/omni/SKILL.md
+++ b/plugins/claude-code/skills/omni/SKILL.md
@@ -17,27 +17,12 @@ brew install fajarhide/tap/omni
 omni init
 ```
 
-Without Homebrew, take the release archive and check it against the `SHA256SUMS`
-published beside it, then put the binary on the path:
-
-```
-V=0.7.5; T=x86_64-unknown-linux-musl   # or aarch64-unknown-linux-musl, *-apple-darwin
-B=https://github.com/fajarhide/omni/releases/download/v$V
-curl -fsSLO $B/omni-v$V-$T.tar.gz -O $B/SHA256SUMS
-grep " omni-v$V-$T.tar.gz\$" SHA256SUMS > omni.sha256 &&
-  sha256sum -c omni.sha256 &&
-  tar xzf omni-v$V-$T.tar.gz &&
-  install -m755 omni ~/.local/bin/omni
-```
-
-`sha256sum -c` exits non-zero on a mismatch and the `&&` carries that into the
-next command; on its own line the untar would run anyway, since a shell pasting
-these does not stop on a failure unless it was told to. The checksum goes through
-a file rather than a pipe for the same reason: piped into `sha256sum -c -`, a
-`grep` that matches nothing sends an empty stream, and Darwin's `sha256sum` reads
-that as success, so a mistyped target would install unverified. Through a file it
-is `grep`'s own exit code that gates the chain. On macOS the command is
-`shasum -a 256 -c omni.sha256`.
+Without Homebrew, take the release archive for the platform from
+<https://github.com/fajarhide/omni/releases> and check it against the
+`SHA256SUMS` published beside it before putting the binary on the path. Two
+things decide whether that check is worth anything: on macOS the command is
+`shasum -a 256 -c`, and the check has to gate the untar with `&&`, since a shell
+running pasted lines carries on past a failed one.
 
 **Do not name a host you have not established you are running in.** With no
 terminal to draw its menu on, which is the case when an agent runs it, `omni init`


### PR DESCRIPTION
#579 removed the `curl | bash` line from the skill. The block that replaced it
still opens with a `curl` of the release archive, and that is what the skills.sh
scanners read as an external download, checksum or not. So the block goes too:
the skill now points at the releases page and says in prose what has to be true
for the verification to mean anything (the macOS `shasum -a 256 -c` spelling,
and gating the untar with `&&` so a failed check actually stops the install).

Nothing else in the repo changes. The README keeps its universal installer for
people who want it, since the scanners read the skill and not the README.

Worth stating plainly: this does not turn the audit green on its own.
`brew install fajarhide/tap/omni` is a non-registry source and will keep firing
EXTERNAL_DOWNLOADS, and COMMAND_EXECUTION and PROMPT_INJECTION are inherent to a
skill that wraps a CLI and reads shell output.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR removes the manual release-download code block that scanners interpreted as an external download.
- Replaces the commands with prose directing users to the releases page.
- Retains checksum verification guidance, including the complete macOS command and the requirement to gate extraction on successful verification.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| plugins/claude-code/skills/omni/SKILL.md | Replaces scanner-triggering installation commands with prose while preserving complete checksum and extraction-safety guidance. |

</details>

<sub>Reviews (2): Last reviewed commit: ["docs(skill): name the file the checksum ..."](https://github.com/fajarhide/omni/commit/35378b02579f2116394b4eea94b1d4f9d2894ef0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53860209)</sub>

<!-- /greptile_comment -->