### PR TITLE
fix(ledger): reserve one handle for worked examples so a real marker can be told apart

### DIFF
--- a/changelog.d/583.fixed.md
+++ b/changelog.d/583.fixed.md
@@ -1,0 +1,13 @@
+- **A marker OMNI emitted and a marker printed as an example were byte-identical, so
+  nothing could verify OMNI had run.** The examples in the source and the manual were
+  not invented, they were harvested from real sessions: four of the seven distinct
+  handles still resolved on the maintainer's machine, including the canonical one that
+  appears in 99 places. That defeated both ways of asking whether anything was folded,
+  since grepping for the marker shape counted our own documentation and resolving the
+  handle counted it too. Measuring a 0.7.5 A/B it scored an `OMNI_PASSTHROUGH=1` arm as
+  having folded eight times and briefly declared a valid control run invalid. Every
+  example now uses one reserved handle, `0000000000000000`; `store_rewind` can never
+  mint it, and `omni retrieve` refuses it by name instead of blaming the 30 day prune,
+  which for an example is a cause the code cannot know. `omni retrieve` already exited 1
+  for an unknown handle, so the check existed and our own strings were what broke it.
+  (#583)

--- a/docs/website/src-id/concepts/nothing-is-deleted.md
+++ b/docs/website/src-id/concepts/nothing-is-deleted.md
@@ -5,11 +5,11 @@ SHA-256 miliknya. Agent menerima penanda yang membawa handle 16 karakter, dan
 handle itu mengembalikan aslinya persis byte demi byte.
 
 ```
-[OMNI: 406 lines omitted, omni retrieve 3f7bfd89bc5d7cee for full output]
+[OMNI: 406 lines omitted, omni retrieve 0000000000000000 for full output]
 ```
 
 ```sh
-omni retrieve 3f7bfd89bc5d7cee
+omni retrieve 0000000000000000
 ```
 
 Itu jalan dari shell mana pun, di sesi mana pun, di host mana pun, dan ia tidak

--- a/docs/website/src-id/concepts/nothing-is-deleted.md
+++ b/docs/website/src-id/concepts/nothing-is-deleted.md
@@ -9,7 +9,7 @@ handle itu mengembalikan aslinya persis byte demi byte.
 ```
 
 ```sh
-omni retrieve 0000000000000000
+omni retrieve <handle>
 ```
 
 Itu jalan dari shell mana pun, di sesi mana pun, di host mana pun, dan ia tidak

--- a/docs/website/src-id/concepts/the-ledger.md
+++ b/docs/website/src-id/concepts/the-ledger.md
@@ -20,7 +20,7 @@ penanda yang menyebut jumlahnya dan sebuah handle. Sisanya lewat persis byte dem
 byte.
 
 ```
-[OMNI: 40 lines already shown, omni retrieve bc7e821a4340073e]
+[OMNI: 40 lines already shown, omni retrieve 0000000000000000]
 ```
 
 Ia menjangkau kelas yang tidak bisa dijangkau apa pun. Pembacaan berkas adalah
@@ -131,7 +131,7 @@ sendiri di kesempatan berikutnya.
 ### Ambil kembali
 
 ```sh
-omni retrieve 3f7bfd89bc5d7cee
+omni retrieve 0000000000000000
 ```
 
 Pencarian persis pada alamat isi. Tidak ada himpunan kandidat, tidak ada

--- a/docs/website/src-id/concepts/the-ledger.md
+++ b/docs/website/src-id/concepts/the-ledger.md
@@ -131,7 +131,7 @@ sendiri di kesempatan berikutnya.
 ### Ambil kembali
 
 ```sh
-omni retrieve 0000000000000000
+omni retrieve <handle>
 ```
 
 Pencarian persis pada alamat isi. Tidak ada himpunan kandidat, tidak ada

--- a/docs/website/src-id/index.md
+++ b/docs/website/src-id/index.md
@@ -38,7 +38,7 @@ Yang dibaca agent Anda adalah ini:
 cargo test: 411 passed, 1 failed
   FAILED ledger::tests::renders_identical_bytes_for_identical_state
   assertion `left == right` failed at src/ledger/mod.rs:601
-[OMNI: 406 lines omitted, omni retrieve 3f7bfd89bc5d7cee for full output]
+[OMNI: 406 lines omitted, omni retrieve 0000000000000000 for full output]
 ```
 
 Kegagalannya selamat. 406 baris `ok` tidak. Dan handle di baris terakhir itu
@@ -58,7 +58,7 @@ dua-duanya.
 OMNI ingat. Bacaan kedua kembali sebagai satu baris:
 
 ```
-[OMNI: 178 lines already shown, omni retrieve 77a0c474f2e55351]
+[OMNI: 178 lines already shown, omni retrieve 0000000000000000]
 ```
 
 **Berkas 7,6 KB yang dibaca dua kali berharga 7,6 KB lalu 214 byte. Itu 97,2%

--- a/docs/website/src-id/reference/cmd/retrieve.md
+++ b/docs/website/src-id/reference/cmd/retrieve.md
@@ -3,14 +3,14 @@
 Mencetak isi yang diarsipkan sebuah penanda.
 
 ```sh
-omni retrieve 3f7bfd89bc5d7cee
+omni retrieve 0000000000000000
 ```
 
 Handle-nya adalah 16 karakter di dalam sebuah penanda:
 
 ```
-[OMNI: 406 lines omitted, omni retrieve 3f7bfd89bc5d7cee for full output]
-[OMNI: 40 lines already shown, omni retrieve bc7e821a4340073e]
+[OMNI: 406 lines omitted, omni retrieve 0000000000000000 for full output]
+[OMNI: 40 lines already shown, omni retrieve 0000000000000000]
 ```
 
 Ia mengembalikan byte aslinya. Bukan ringkasan, bukan menjalankan ulang perintah

--- a/docs/website/src-id/reference/cmd/retrieve.md
+++ b/docs/website/src-id/reference/cmd/retrieve.md
@@ -3,7 +3,7 @@
 Mencetak isi yang diarsipkan sebuah penanda.
 
 ```sh
-omni retrieve 0000000000000000
+omni retrieve <handle>
 ```
 
 Handle-nya adalah 16 karakter di dalam sebuah penanda:

--- a/docs/website/src-id/use/markers.md
+++ b/docs/website/src-id/use/markers.md
@@ -104,3 +104,22 @@ bisa memanggil `omni_retrieve` sendiri tanpa bertanya ke Anda.
 Satu batas yang tidak bisa dijanjikan sebuah handle: arsipnya jendela bergulir 30
 hari, jadi `omni retrieve` atas isi yang lebih tua dari itu tidak akan ketemu.
 Jejak apa adanya bahkan lebih pendek, tujuh hari.
+
+## Membedakan penanda asli dari penanda yang sekadar dicetak
+
+Penanda juga muncul di dalam prosa. Halaman ini penuh dengannya, begitu pula source
+OMNI sendiri, dan begitu pula laporan bug mana pun yang mengutipnya. Itu penting
+ketika Anda mengukur apakah OMNI aktif pada suatu run, karena mencari bentuk penanda
+di dalam transkrip akan menemukan contohnya semudah menemukan lipatan aslinya.
+
+Handle-nya yang membedakan. Setiap contoh di manual ini dan di source OMNI memakai
+satu nilai cadangan, `0000000000000000`, yang tidak akan pernah diberikan kepada
+lipatan sungguhan:
+
+```sh
+omni retrieve 0000000000000000   # exit 1, "the documentation example"
+omni retrieve <handle-yang-Anda-temukan> # exit 0 jika OMNI benar-benar melipatnya
+```
+
+Jadi exit code-nya yang menjawab pertanyaan itu, dan penanda yang disalin dari
+dokumentasi tidak bisa disalahartikan sebagai bukti bahwa ada yang dipendekkan.

--- a/docs/website/src-id/use/markers.md
+++ b/docs/website/src-id/use/markers.md
@@ -7,15 +7,15 @@ mencurigainya.
 ## Bentuk-bentuknya
 
 ```
-[OMNI: 406 lines omitted, omni retrieve 3f7bfd89bc5d7cee for full output]
+[OMNI: 406 lines omitted, omni retrieve 0000000000000000 for full output]
 ```
 
 Ada isi yang dipotong dan diarsipkan. Enam belas karakter itu sebuah handle:
-`omni retrieve 3f7bfd89bc5d7cee` mencetak aslinya kembali, persis byte demi byte,
+`omni retrieve 0000000000000000` mencetak aslinya kembali, persis byte demi byte,
 dari shell mana pun di sesi mana pun.
 
 ```
-[OMNI: 40 lines already shown, omni retrieve bc7e821a4340073e]
+[OMNI: 40 lines already shown, omni retrieve 0000000000000000]
 ```
 
 Ledger. Baris-baris ini sudah dikeluarkan sebelumnya **di sesi ini**, jadi
@@ -23,7 +23,7 @@ klaimnya adalah agent masih memegangnya dan handle-nya tidak berongkos kecuali i
 memang mau membaca ulang.
 
 ```
-[OMNI: 40 lines not shown here, omni retrieve bc7e821a4340073e]
+[OMNI: 40 lines not shown here, omni retrieve 0000000000000000]
 ```
 
 Ledger juga, klaim berbeda. Baris-baris ini pergi ke **sesi lain** dari proyek
@@ -36,8 +36,8 @@ direktorinya, jadi apa pun yang berjalan di repositori ini ikut menyumbang. Liha
 [apa yang dibagi dua agent](../concepts/the-ledger.md#apa-yang-dibagi-dua-agent-dalam-satu-repo).
 
 ```
-[OMNI: identical to the 40 lines already shown, omni retrieve bc7e821a4340073e]
-[OMNI: identical to 40 lines from an earlier session, none shown here, omni retrieve bc7e821a4340073e]
+[OMNI: identical to the 40 lines already shown, omni retrieve 0000000000000000]
+[OMNI: identical to 40 lines from an earlier session, none shown here, omni retrieve 0000000000000000]
 ```
 
 Dua klaim yang sama, untuk jawaban yang terulang **seluruhnya**. Ketika
@@ -95,7 +95,7 @@ keluarannya langsung. Itu pipeline yang bekerja, bukan gagal. Itu terjadi ketika
 ## Mengambil isinya kembali
 
 ```sh
-omni retrieve 3f7bfd89bc5d7cee
+omni retrieve 0000000000000000
 ```
 
 Bekerja di semua host, dengan atau tanpa MCP. Agent yang server MCP-nya terpasang

--- a/docs/website/src-id/use/markers.md
+++ b/docs/website/src-id/use/markers.md
@@ -11,7 +11,7 @@ mencurigainya.
 ```
 
 Ada isi yang dipotong dan diarsipkan. Enam belas karakter itu sebuah handle:
-`omni retrieve 0000000000000000` mencetak aslinya kembali, persis byte demi byte,
+`omni retrieve <handle>` mencetak aslinya kembali, persis byte demi byte,
 dari shell mana pun di sesi mana pun.
 
 ```
@@ -95,7 +95,7 @@ keluarannya langsung. Itu pipeline yang bekerja, bukan gagal. Itu terjadi ketika
 ## Mengambil isinya kembali
 
 ```sh
-omni retrieve 0000000000000000
+omni retrieve <handle>
 ```
 
 Bekerja di semua host, dengan atau tanpa MCP. Agent yang server MCP-nya terpasang

--- a/docs/website/src/concepts/nothing-is-deleted.md
+++ b/docs/website/src/concepts/nothing-is-deleted.md
@@ -9,7 +9,7 @@ brings the original back byte for byte.
 ```
 
 ```sh
-omni retrieve 0000000000000000
+omni retrieve <handle>
 ```
 
 That works from any shell, in any session, on any host, and it does not re-run your

--- a/docs/website/src/concepts/nothing-is-deleted.md
+++ b/docs/website/src/concepts/nothing-is-deleted.md
@@ -5,11 +5,11 @@ SHA-256. The agent gets a marker carrying a 16 character handle, and the handle
 brings the original back byte for byte.
 
 ```
-[OMNI: 406 lines omitted, omni retrieve 3f7bfd89bc5d7cee for full output]
+[OMNI: 406 lines omitted, omni retrieve 0000000000000000 for full output]
 ```
 
 ```sh
-omni retrieve 3f7bfd89bc5d7cee
+omni retrieve 0000000000000000
 ```
 
 That works from any shell, in any session, on any host, and it does not re-run your

--- a/docs/website/src/concepts/the-ledger.md
+++ b/docs/website/src/concepts/the-ledger.md
@@ -119,7 +119,7 @@ entirely new still writes its lines, and pays for itself the next time.
 ### Retrieve
 
 ```sh
-omni retrieve 0000000000000000
+omni retrieve <handle>
 ```
 
 An exact lookup on a content address. There is no candidate set, no ranking, no

--- a/docs/website/src/concepts/the-ledger.md
+++ b/docs/website/src/concepts/the-ledger.md
@@ -18,7 +18,7 @@ A run of consecutive lines that were all emitted earlier becomes one marker nami
 the count and a handle. Everything else passes through byte for byte.
 
 ```
-[OMNI: 40 lines already shown, omni retrieve bc7e821a4340073e]
+[OMNI: 40 lines already shown, omni retrieve 0000000000000000]
 ```
 
 It reaches the class nothing else can. File reads are the largest class in the
@@ -119,7 +119,7 @@ entirely new still writes its lines, and pays for itself the next time.
 ### Retrieve
 
 ```sh
-omni retrieve 3f7bfd89bc5d7cee
+omni retrieve 0000000000000000
 ```
 
 An exact lookup on a content address. There is no candidate set, no ranking, no

--- a/docs/website/src/index.md
+++ b/docs/website/src/index.md
@@ -36,7 +36,7 @@ Here is what your agent reads instead:
 cargo test: 411 passed, 1 failed
   FAILED ledger::tests::renders_identical_bytes_for_identical_state
   assertion `left == right` failed at src/ledger/mod.rs:601
-[OMNI: 406 lines omitted, omni retrieve 3f7bfd89bc5d7cee for full output]
+[OMNI: 406 lines omitted, omni retrieve 0000000000000000 for full output]
 ```
 
 The failure survived. The 406 lines of `ok` did not. And that handle on the last line
@@ -53,7 +53,7 @@ nothing remembered the first read. You pay full price both times.
 OMNI remembers. The second read comes back as one line:
 
 ```
-[OMNI: 178 lines already shown, omni retrieve 77a0c474f2e55351]
+[OMNI: 178 lines already shown, omni retrieve 0000000000000000]
 ```
 
 **A 7.6 KB file read twice costs 7.6 KB and then 214 bytes. That is 97.2% off the

--- a/docs/website/src/reference/cmd/retrieve.md
+++ b/docs/website/src/reference/cmd/retrieve.md
@@ -3,14 +3,14 @@
 Prints the content a marker archived.
 
 ```sh
-omni retrieve 3f7bfd89bc5d7cee
+omni retrieve 0000000000000000
 ```
 
 The handle is the 16 characters inside a marker:
 
 ```
-[OMNI: 406 lines omitted, omni retrieve 3f7bfd89bc5d7cee for full output]
-[OMNI: 40 lines already shown, omni retrieve bc7e821a4340073e]
+[OMNI: 406 lines omitted, omni retrieve 0000000000000000 for full output]
+[OMNI: 40 lines already shown, omni retrieve 0000000000000000]
 ```
 
 It returns the original bytes. Not a summary, not a re-run of your command, and not an

--- a/docs/website/src/reference/cmd/retrieve.md
+++ b/docs/website/src/reference/cmd/retrieve.md
@@ -3,7 +3,7 @@
 Prints the content a marker archived.
 
 ```sh
-omni retrieve 0000000000000000
+omni retrieve <handle>
 ```
 
 The handle is the 16 characters inside a marker:

--- a/docs/website/src/use/markers.md
+++ b/docs/website/src/use/markers.md
@@ -100,3 +100,22 @@ Works on every host, with or without MCP. Agents with the MCP server wired can c
 One boundary a handle cannot promise: the archive is a rolling 30 day window, so
 `omni retrieve` on content older than that will not resolve. Verbatim traces are
 shorter still at seven days.
+
+## Telling a real marker from a printed one
+
+Markers appear in prose too. This page is full of them, so is OMNI's source, and so
+is any bug report that quotes one. That matters if you are measuring whether OMNI
+was active on a run, because searching a transcript for the marker shape will find
+the examples as readily as the folds.
+
+The handle is what separates them. Every worked example in this manual and in OMNI's
+own source uses one reserved value, `0000000000000000`, which no real fold can ever
+be assigned:
+
+```sh
+omni retrieve 0000000000000000   # exit 1, "the documentation example"
+omni retrieve <handle-you-found> # exit 0 if OMNI really folded it
+```
+
+So the exit code answers the question, and a marker copied out of documentation
+cannot be mistaken for evidence that anything was shortened.

--- a/docs/website/src/use/markers.md
+++ b/docs/website/src/use/markers.md
@@ -10,7 +10,7 @@ them is the difference between trusting the tool and suspecting it.
 ```
 
 Content was cut and archived. The 16 characters are a handle:
-`omni retrieve 0000000000000000` prints the original back, byte for byte, from any
+`omni retrieve <handle>` prints the original back, byte for byte, from any
 shell in any session.
 
 ```
@@ -91,7 +91,7 @@ That is the pipeline working, not failing. It happens when:
 ## Getting content back
 
 ```sh
-omni retrieve 0000000000000000
+omni retrieve <handle>
 ```
 
 Works on every host, with or without MCP. Agents with the MCP server wired can call

--- a/docs/website/src/use/markers.md
+++ b/docs/website/src/use/markers.md
@@ -6,15 +6,15 @@ them is the difference between trusting the tool and suspecting it.
 ## The shapes
 
 ```
-[OMNI: 406 lines omitted, omni retrieve 3f7bfd89bc5d7cee for full output]
+[OMNI: 406 lines omitted, omni retrieve 0000000000000000 for full output]
 ```
 
 Content was cut and archived. The 16 characters are a handle:
-`omni retrieve 3f7bfd89bc5d7cee` prints the original back, byte for byte, from any
+`omni retrieve 0000000000000000` prints the original back, byte for byte, from any
 shell in any session.
 
 ```
-[OMNI: 40 lines already shown, omni retrieve bc7e821a4340073e]
+[OMNI: 40 lines already shown, omni retrieve 0000000000000000]
 ```
 
 The ledger. These lines were emitted earlier **in this session**, so the claim is that
@@ -22,7 +22,7 @@ the agent is still holding them and the handle costs nothing unless it wants to
 re-read.
 
 ```
-[OMNI: 40 lines not shown here, omni retrieve bc7e821a4340073e]
+[OMNI: 40 lines not shown here, omni retrieve 0000000000000000]
 ```
 
 Also the ledger, different claim. These lines went to a **different session** of this
@@ -35,8 +35,8 @@ on the directory, so anything running in this repository contributes to it. See
 [what two agents share](../concepts/the-ledger.md#what-two-agents-in-one-repo-share).
 
 ```
-[OMNI: identical to the 40 lines already shown, omni retrieve bc7e821a4340073e]
-[OMNI: identical to 40 lines from an earlier session, none shown here, omni retrieve bc7e821a4340073e]
+[OMNI: identical to the 40 lines already shown, omni retrieve 0000000000000000]
+[OMNI: identical to 40 lines from an earlier session, none shown here, omni retrieve 0000000000000000]
 ```
 
 The same two claims, for a reply that is repeated **in full**. When the fold covers
@@ -91,7 +91,7 @@ That is the pipeline working, not failing. It happens when:
 ## Getting content back
 
 ```sh
-omni retrieve 3f7bfd89bc5d7cee
+omni retrieve 0000000000000000
 ```
 
 Works on every host, with or without MCP. Agents with the MCP server wired can call

--- a/src/cli/retrieve.rs
+++ b/src/cli/retrieve.rs
@@ -27,7 +27,11 @@ fn print_help() {
     println!("  omni {} {}", "retrieve".cyan(), "<handle>".bright_black());
     println!(
         "\nA handle is the 16 characters inside a marker, for example\n  {}\n",
-        "[OMNI: 50 lines already shown, omni retrieve cd900c16a4a94eb2]".bright_black()
+        format!(
+            "[OMNI: 50 lines already shown, omni retrieve {}]",
+            crate::util::text::EXAMPLE_HANDLE
+        )
+        .bright_black()
     );
 }
 
@@ -57,6 +61,15 @@ pub fn run(args: &[String], store: &Store) -> Result<()> {
         .trim_start_matches("omni_retrieve(")
         .trim_end_matches(')')
         .trim_matches('"');
+
+    // Said before the lookup, because the generic miss below blames pruning and
+    // that would be a cause this code cannot know. A reader who pasted the
+    // manual's example deserves to be told it was an example (#583).
+    if handle == crate::util::text::EXAMPLE_HANDLE {
+        anyhow::bail!(
+            "`{handle}` is the documentation example, not a real handle. Copy the 16 characters from a marker in your own output instead"
+        );
+    }
 
     match store.retrieve_rewind(handle) {
         Some(content) => {
@@ -110,6 +123,34 @@ mod tests {
         assert!(run(&args(&["omni", "retrieve", &handle]), &store).is_ok());
     }
 
+    /// #583. Four of the seven example handles in our own source and manual
+    /// still resolved on the maintainer's machine, so a checker asking "does
+    /// this handle resolve" counted our documentation as evidence of folding.
+    /// The reserved one has to be refused, and refused for the right reason:
+    /// the generic miss blames the 30 day prune, which for an example is a
+    /// cause this code cannot know.
+    #[test]
+    fn the_documentation_example_is_refused_and_not_blamed_on_pruning() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Store::open_path(&dir.path().join("omni.db")).expect("store");
+
+        let err = run(
+            &args(&["omni", "retrieve", crate::util::text::EXAMPLE_HANDLE]),
+            &store,
+        )
+        .expect_err("the documentation example must not resolve");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("documentation example"),
+            "the reader has to be told it was an example: {msg}"
+        );
+        assert!(
+            !msg.contains("pruned"),
+            "an example was never archived, so pruning cannot be the reason: {msg}"
+        );
+    }
+
     /// #512. `get_retrieve_rate` backs off the route thresholds for a command
     /// family whose full output keeps being needed, and it reads
     /// `retrieve_events`. Only the MCP tool wrote there, while the marker sends
@@ -158,12 +199,15 @@ mod tests {
         }
     }
 
+    /// The fixture moved off all-zeros in #583. That value is now the reserved
+    /// documentation handle and is refused earlier with a different reason, so
+    /// leaving it here would have quietly stopped testing the prune message.
     #[test]
     fn says_why_a_missing_handle_is_missing() {
         let dir = tempfile::tempdir().expect("tempdir");
         let store = Store::open_path(&dir.path().join("omni.db")).expect("store");
 
-        let err = run(&args(&["omni", "retrieve", "0000000000000000"]), &store)
+        let err = run(&args(&["omni", "retrieve", "ffffffffffffffff"]), &store)
             .expect_err("an unknown handle is an error");
 
         assert!(err.to_string().contains("30 days"), "{err}");

--- a/src/hooks/pipe.rs
+++ b/src/hooks/pipe.rs
@@ -1008,7 +1008,7 @@ omni";
             &mut err,
             None,
             None,
-            Some("omni retrieve eb888d2874dfc9ab"),
+            Some("omni retrieve 0000000000000000"),
         )
         .expect("must succeed");
 

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -1355,9 +1355,9 @@ mod tests {
     #[test]
     fn never_distils_the_command_that_undoes_distillation() {
         for cmd in [
-            "omni retrieve eb888d2874dfc9ab",
-            "/opt/homebrew/bin/omni retrieve eb888d2874dfc9ab",
-            "cd /tmp && omni retrieve eb888d2874dfc9ab",
+            "omni retrieve 0000000000000000",
+            "/opt/homebrew/bin/omni retrieve 0000000000000000",
+            "cd /tmp && omni retrieve 0000000000000000",
             "omni diff",
         ] {
             assert!(returns_archived_bytes(cmd), "{cmd} must pass through");
@@ -1407,7 +1407,7 @@ mod tests {
         );
 
         let retrieval = process_payload(
-            &payload("omni retrieve eb888d2874dfc9ab"),
+            &payload("omni retrieve 0000000000000000"),
             Some(store.clone()),
             None,
         );

--- a/src/pipeline/fidelity.rs
+++ b/src/pipeline/fidelity.rs
@@ -46,14 +46,14 @@ mod tests {
     #[test]
     fn rejects_an_output_that_lost_the_only_error_line() {
         let folded = "23 | const first = data.rows[0].id;\n\
-                      [OMNI: 3 lines already shown, omni retrieve d90f8788f718212a]\n";
+                      [OMNI: 3 lines already shown, omni retrieve 0000000000000000]\n";
 
         assert!(!preserves_failures(FAILING, folded));
     }
 
     #[test]
     fn accepts_an_output_that_kept_it() {
-        let kept = "[OMNI: 1 lines already shown, omni retrieve d90f8788f718212a]\n\
+        let kept = "[OMNI: 1 lines already shown, omni retrieve 0000000000000000]\n\
                     TypeError: undefined is not an object (evaluating 'data.rows[0]')\n";
 
         assert!(preserves_failures(FAILING, kept));

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -1263,8 +1263,12 @@ impl SqliteBackend {
     pub fn store_rewind(&self, content: &str) -> Option<String> {
         let mut hasher = Sha256::new();
         hasher.update(content.as_bytes());
-        let rewind_key =
-            crate::util::text::safe_slice(&hex::encode(hasher.finalize()), 16).to_string();
+        // The reserved example handle must never name real content, or the
+        // documented "an example never resolves" check would be wrong for
+        // whichever payload happened to hash to it (#583).
+        let rewind_key = crate::util::text::avoid_example_handle(
+            crate::util::text::safe_slice(&hex::encode(hasher.finalize()), 16).to_string(),
+        );
 
         let conn = self.pool.get().ok()?;
 

--- a/src/util/text.rs
+++ b/src/util/text.rs
@@ -88,6 +88,32 @@ pub fn truncate_with_marker(
     s.replace_range(head_end..tail_start, &marker);
 }
 
+/// The handle every worked example in our source and manual must use.
+///
+/// #583: the examples were harvested from real sessions, so four of the seven
+/// distinct ones still resolved on the maintainer's machine, including the
+/// manual's canonical `3f7bfd89bc5d7cee`. That defeats both ways of asking
+/// whether OMNI folded anything: grepping for the marker shape counts our own
+/// documentation, and resolving the handle counts it too. Reserving one value
+/// and refusing it in `store_rewind` is what makes "this handle never resolves"
+/// a guarantee rather than a 1-in-2^64 coincidence.
+pub const EXAMPLE_HANDLE: &str = "0000000000000000";
+
+/// Moves a freshly minted handle off the one value the examples reserve.
+///
+/// Split from `store_rewind` so it can be driven directly: the branch it
+/// protects fires once in 2^64 real payloads, so a test that went through the
+/// hasher would never reach it and would be decorative.
+pub fn avoid_example_handle(key: String) -> String {
+    if key != EXAMPLE_HANDLE {
+        return key;
+    }
+    use sha2::{Digest, Sha256};
+    let mut again = Sha256::new();
+    again.update(key.as_bytes());
+    safe_slice(&hex::encode(again.finalize()), 16).to_string()
+}
+
 /// The `, omni retrieve <hash>` clause, or an honest statement that there is
 /// none.
 ///
@@ -229,11 +255,11 @@ mod tests {
 
         truncate_with_marker(&mut s, 500, |dropped| {
             archived = dropped.to_string();
-            Some("deadbeefdeadbeef".to_string())
+            Some(EXAMPLE_HANDLE.to_string())
         });
 
         assert!(
-            s.contains("omni retrieve deadbeefdeadbeef"),
+            s.contains("omni retrieve 0000000000000000"),
             "the marker must name the handle: {s}"
         );
         assert!(
@@ -317,5 +343,23 @@ mod tests {
         let s = "Hello, 🌍!";
         let res = safe_slice(s, 8);
         assert_eq!(res, "Hello, ");
+    }
+
+    /// #583. The whole point of reserving a handle is that it can never name
+    /// real content, so a checker can exclude our own worked examples by value.
+    /// A payload that hashed to it would break that, and the odds are too long
+    /// to reach through the hasher, so the mapping is driven directly.
+    #[test]
+    fn a_minted_handle_is_never_the_one_the_examples_reserve() {
+        assert_ne!(
+            avoid_example_handle(EXAMPLE_HANDLE.to_string()),
+            EXAMPLE_HANDLE,
+            "a real payload was allowed to mint the documentation handle"
+        );
+        assert_eq!(
+            avoid_example_handle("a1b2c3d4e5f60718".to_string()),
+            "a1b2c3d4e5f60718",
+            "every other handle must pass through untouched"
+        );
     }
 }

--- a/src/util/text.rs
+++ b/src/util/text.rs
@@ -99,19 +99,26 @@ pub fn truncate_with_marker(
 /// a guarantee rather than a 1-in-2^64 coincidence.
 pub const EXAMPLE_HANDLE: &str = "0000000000000000";
 
+/// Where the one payload in 2^64 that hashes to `EXAMPLE_HANDLE` is sent.
+///
+/// A literal rather than a rehash. Review on #588 pointed out that rehashing
+/// the digest could only ever run on `EXAMPLE_HANDLE` itself, so it returned a
+/// single fixed value anyway, recomputed on every call, and minted a second
+/// special handle that nothing named or documented. Collision odds are 2^-64
+/// against any one value whether it was derived or typed, so the derivation
+/// bought nothing and cost an unaudited constant.
+const COLLIDED_EXAMPLE_HANDLE: &str = "0000000000000001";
+
 /// Moves a freshly minted handle off the one value the examples reserve.
 ///
 /// Split from `store_rewind` so it can be driven directly: the branch it
 /// protects fires once in 2^64 real payloads, so a test that went through the
 /// hasher would never reach it and would be decorative.
 pub fn avoid_example_handle(key: String) -> String {
-    if key != EXAMPLE_HANDLE {
-        return key;
+    if key == EXAMPLE_HANDLE {
+        return COLLIDED_EXAMPLE_HANDLE.to_string();
     }
-    use sha2::{Digest, Sha256};
-    let mut again = Sha256::new();
-    again.update(key.as_bytes());
-    safe_slice(&hex::encode(again.finalize()), 16).to_string()
+    key
 }
 
 /// The `, omni retrieve <hash>` clause, or an honest statement that there is

--- a/tests/docs_match_the_code.rs
+++ b/tests/docs_match_the_code.rs
@@ -350,3 +350,79 @@ fn the_scan_reaches_the_manual_and_the_readme() {
         "no commands found in any shell block, so the fence scan is broken"
     );
 }
+
+/// The handle `src/util/text.rs` reserves for worked examples.
+///
+/// Read out of the source rather than repeated here, for the reason
+/// `real_subcommands` gives: a second copy of a constant is the defect this file
+/// exists to catch, not a convenience.
+fn reserved_example_handle() -> String {
+    let src = std::fs::read_to_string(repo_root().join("src/util/text.rs")).expect("read text.rs");
+    let decl = src
+        .split_once("pub const EXAMPLE_HANDLE: &str = \"")
+        .expect("EXAMPLE_HANDLE was renamed or moved")
+        .1;
+    let handle = decl
+        .split_once('"')
+        .expect("EXAMPLE_HANDLE literal is unterminated")
+        .0
+        .to_string();
+    assert_eq!(handle.len(), 16, "a handle is 16 characters: {handle}");
+    handle
+}
+
+/// #583. A marker OMNI emitted and a marker printed as an example were
+/// byte-identical, and the examples were not even fake: four of the seven
+/// distinct handles in our source and manual still resolved on the maintainer's
+/// machine, the canonical one in 99 places. So neither way of asking whether
+/// OMNI folded anything worked, because grepping for the shape and resolving the
+/// handle both counted our own documentation.
+///
+/// One reserved value in every example is what makes the resolve check sound.
+/// This guard is here because the convention already existed in one file and had
+/// rotted everywhere else.
+#[test]
+fn every_worked_example_uses_the_reserved_handle() {
+    let reserved = reserved_example_handle();
+    let root = repo_root();
+    let mut files: Vec<PathBuf> = walkdir::WalkDir::new(root.join("src"))
+        .into_iter()
+        .filter_map(Result::ok)
+        .filter(|e| e.path().extension().is_some_and(|x| x == "rs"))
+        .map(|e| e.path().to_path_buf())
+        .collect();
+    files.extend(doc_files());
+
+    let mut offenders = Vec::new();
+    let mut seen = 0usize;
+    for path in &files {
+        let Ok(text) = std::fs::read_to_string(path) else {
+            continue;
+        };
+        for (n, line) in text.lines().enumerate() {
+            for (idx, _) in line.match_indices("omni retrieve ") {
+                let rest = &line[idx + "omni retrieve ".len()..];
+                let handle: String = rest.chars().take_while(|c| c.is_ascii_hexdigit()).collect();
+                if handle.len() != 16 {
+                    continue;
+                }
+                seen += 1;
+                if handle != reserved {
+                    let rel = path.strip_prefix(&root).unwrap_or(path);
+                    offenders.push(format!("{}:{} {handle}", rel.display(), n + 1));
+                }
+            }
+        }
+    }
+
+    assert!(
+        seen > 10,
+        "found only {seen} worked examples, so this scan is broken rather than clean"
+    );
+    assert!(
+        offenders.is_empty(),
+        "these examples use a handle that may resolve to real archived content, \
+         which is what defeats every check for whether OMNI ran (#583):\n  {}",
+        offenders.join("\n  ")
+    );
+}

--- a/tests/docs_match_the_code.rs
+++ b/tests/docs_match_the_code.rs
@@ -385,13 +385,24 @@ fn reserved_example_handle() -> String {
 fn every_worked_example_uses_the_reserved_handle() {
     let reserved = reserved_example_handle();
     let root = repo_root();
-    let mut files: Vec<PathBuf> = walkdir::WalkDir::new(root.join("src"))
-        .into_iter()
+
+    // Wider than `doc_files()` on purpose, and the extra roots are not padding.
+    // `i18n/` is the one that would have bitten: CONTRIBUTING requires a README
+    // change to reach all six translations, so an example added to the guarded
+    // README propagates into six unguarded files by policy. `plugins/` ships a
+    // skill file with `omni retrieve` in it, and `tests/` is where a fixture
+    // would go. None of the three carries a handle today, so this is a fence
+    // rather than a fix, which is the point of a guard (#588 review).
+    let mut files: Vec<PathBuf> = ["src", "tests", "i18n", "plugins"]
+        .iter()
+        .flat_map(|dir| walkdir::WalkDir::new(root.join(dir)).into_iter())
         .filter_map(Result::ok)
-        .filter(|e| e.path().extension().is_some_and(|x| x == "rs"))
+        .filter(|e| e.path().extension().is_some_and(|x| x == "rs" || x == "md"))
         .map(|e| e.path().to_path_buf())
         .collect();
     files.extend(doc_files());
+    files.sort();
+    files.dedup();
 
     let mut offenders = Vec::new();
     let mut seen = 0usize;
@@ -399,6 +410,10 @@ fn every_worked_example_uses_the_reserved_handle() {
         let Ok(text) = std::fs::read_to_string(path) else {
             continue;
         };
+        // Line at a time, so a marker wrapped across two lines is invisible to
+        // this scan. No `omni retrieve` literal in the tree is broken that way
+        // today, and a scan over joined text would match prose that happens to
+        // end in those words. Stated rather than handled (#588 review).
         for (n, line) in text.lines().enumerate() {
             for (idx, _) in line.match_indices("omni retrieve ") {
                 let rest = &line[idx + "omni retrieve ".len()..];


### PR DESCRIPTION
A real `[OMNI: ...]` marker and one printed as an example were byte-identical, so no check could tell whether OMNI had folded anything on a run.

The examples were worse than identical. They were harvested from real sessions rather than invented, so four of the seven distinct handles in our source and manual still resolved on this machine:

| handle | occurrences | `omni retrieve` |
| --- | ---: | --- |
| `3f7bfd89bc5d7cee` | 99 | resolves, 307 lines |
| `bc7e821a4340073e` | 66 | rc=1 |
| `77a0c474f2e55351` | 11 | resolves, 178 lines |
| `eb888d2874dfc9ab` | 5 | resolves, 261 lines |
| `d90f8788f718212a` | 2 | rc=1 |
| `cd900c16a4a94eb2` | 2 | resolves, 50 lines |
| `deadbeefdeadbeef` | 1 | rc=1 |

That defeats both options the issue proposed. Grepping for the marker shape counts our documentation, and so does resolving the handle. The one in `cli/retrieve.rs` help text reads "50 lines" and resolves to 50 lines of unrelated personal content, which is how we know it was pasted rather than written.

`omni retrieve` already exits 1 for an unknown handle, so the discriminator existed and our own strings were what broke it. All 40 examples now use one reserved handle, `store_rewind` can never mint it, and `retrieve` refuses it by name rather than blaming the 30 day prune, which for an example is a cause the code cannot know.

Part of this is finishing a convention instead of inventing one: `util/text.rs` already used a handle that does not resolve and nothing kept the rest of the tree honest. A guard over `src`, `tests`, `i18n`, `plugins` and both manuals does now.

`i18n` is the root that justifies the width. `i18n/README-id.md:241` already describes `omni retrieve <handle>` in prose, in a file nothing checked, and `CONTRIBUTING.md` requires a README change to reach all six translations. So an example added to the guarded README propagates into six unguarded files by policy. None of those roots carries a handle today, which makes this a fence rather than a fix.

The reserved handle is right where a marker is being **shown**, because that is a sample of output, and wrong where the reader is told to **run** something. Ten occurrences moved to `<handle>`, eight in `sh` fences and two in sentences promising the command prints the original back; the other 22 are displayed markers and keep the reserved value.

## Verified

```
0000000000000000  rc=1  the documentation example, not a real handle
ffffffffffffffff  rc=1  no archived content ... 30 days
<a real handle>   rc=0  307 lines
```

Measure that without a pipeline. `omni retrieve <handle> | head` reports `head`'s exit code, which is 0 whatever the retrieve did, so the discriminator reads as broken. Two of us hit that independently while checking this, and in both cases the wrong answer looked authoritative. Redirect to a file instead.

Each new assertion was driven red before it was trusted, with the break proved by diff first.

| break | test | printed |
| --- | --- | --- |
| `avoid_example_handle` returns its input | `a_minted_handle_is_never_the_one_the_examples_reserve` | `a real payload was allowed to mint the documentation handle` |
| the refusal in `retrieve` removed | `the_documentation_example_is_refused_and_not_blamed_on_pruning` | fell through to `... older ones are pruned` |
| `3f7bfd89bc5d7cee` put back in `markers.md` | `every_worked_example_uses_the_reserved_handle` | `docs/website/src/use/markers.md:9` |

`make fmt clippy test security binary-check` all green, 1,740 tests, smoke 46/46.

A pre-existing test used all-zeros as its unknown-handle fixture and went red, which is the change working: that value now means something specific. Its fixture moved and it still covers the prune message.

## Not in this PR

The prefix sentinel the issue lists first. It is the only option that also covers user content quoting a marker, and it is about 25 emission sites plus every manual page, so it deserves its own decision rather than riding along here.

Closes #583

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR reserves an unmistakable handle for worked marker examples so documentation cannot be mistaken for evidence of a real fold.
- Replaces harvested handles in source and manuals with `0000000000000000`.
- Prevents stored payloads from receiving the reserved handle and gives it a specific retrieval error.
- Adds documentation guards and focused tests for the convention.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/cli/retrieve.rs | Rejects the reserved documentation handle with a specific diagnostic while retaining normal retrieval behavior. |
| src/store/sqlite.rs | Remaps the reserved hash before storing content so real archived payloads never use the example handle. |
| src/util/text.rs | Defines the reserved handle and its deterministic collision remapping. |
| tests/docs_match_the_code.rs | Enforces consistent use of the reserved handle across source and manuals. |
| docs/website/src/use/markers.md | Distinguishes sample markers from real markers and uses placeholders for commands that promise retrieval. |

</details>

<sub>Reviews (3): Last reviewed commit: ["docs(manual): use a placeholder where th..."](https://github.com/fajarhide/omni/commit/6b53d6b357d02f85176b40a1e9eef56b020b865e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53862870)</sub>

<!-- /greptile_comment -->


Closes #583.
