### PR TITLE
fix(ledger): scope the session ledger to the reader, not the session id

### DIFF
--- a/changelog.d/581.fixed.md
+++ b/changelog.d/581.fixed.md
@@ -1,0 +1,12 @@
+- **A subagent was told the parent's bytes were already shown.** Claude Code hands a
+  subagent the parent's `session_id`, so keying the ledger on the session alone answered
+  a subagent's first read with the parent's history: a 200 line payload came back as
+  `identical to the 200 lines already shown` to a context that had received none of it.
+  The host does distinguish them, through a top-level `agent_id` that is unset for the
+  main agent, and OMNI was not reading it. The scope is now the reader rather than the
+  session. The fold is kept and only the claim changes: a subagent falls through to the
+  project scope, whose wording since #575 says `none shown here`, so it still gets a
+  marker and a handle. The main agent has no `agent_id`, so its scope is unchanged and no
+  history is orphaned by the upgrade. Not fixed, and recorded on the issue rather than
+  left implied: after compaction the same premise fails with no signal in the payload to
+  detect it. (#581)

--- a/src/hooks/normalize.rs
+++ b/src/hooks/normalize.rs
@@ -54,6 +54,21 @@ pub struct NormalizedInput {
     /// payload carries no such key (pipe mode, Aider, older hosts), and the
     /// caller falls back to the local id rather than losing the row.
     pub host_session_id: Option<String>,
+    /// The host's subagent identifier, read from the payload's top-level
+    /// `agent_id`, and `None` when the main agent made the call.
+    ///
+    /// Not to be confused with `agent_id` above, which names the host family
+    /// (`claude_code`, `codex_cli`) and is detected rather than parsed.
+    ///
+    /// Claude Code gives a subagent **the parent's `session_id`** and
+    /// distinguishes it only here. Verified two ways on 2026-08-17: a sidechain
+    /// transcript carries the parent's `sessionId`, and the CLI builds every
+    /// hook payload as `{session_id, transcript_path, cwd, prompt_id,
+    /// permission_mode, agent_id, agent_type, effort}` with `agent_id` unset for
+    /// the main agent. Without this the ledger's session scope answers a
+    /// subagent with the parent's history and claims "already shown" about bytes
+    /// that context never received (#581).
+    pub host_agent_id: Option<String>,
 }
 
 /// Detect agent format dari raw JSON string
@@ -139,6 +154,7 @@ pub fn normalize(input: &str) -> Option<NormalizedInput> {
     // is top-level metadata beside `tool_name`, so it does not vary with the
     // tool-payload shape those functions exist to tell apart.
     normalized.host_session_id = extract_host_session_id(input);
+    normalized.host_agent_id = extract_top_level_str(input, "agent_id", "agentId");
     Some(normalized)
 }
 
@@ -147,10 +163,15 @@ pub fn normalize(input: &str) -> Option<NormalizedInput> {
 /// Both spellings are accepted for the same reason `hooks::session_start` accepts
 /// both: the hosts disagree, and guessing one costs the grouping silently.
 fn extract_host_session_id(input: &str) -> Option<String> {
+    extract_top_level_str(input, "session_id", "sessionId")
+}
+
+/// One top-level string key, under either spelling the hosts use.
+fn extract_top_level_str(input: &str, snake: &str, camel: &str) -> Option<String> {
     let value: Value = serde_json::from_str(input).ok()?;
     let obj = value.as_object()?;
-    obj.get("session_id")
-        .or_else(|| obj.get("sessionId"))
+    obj.get(snake)
+        .or_else(|| obj.get(camel))
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|s| !s.is_empty())
@@ -333,6 +354,7 @@ fn normalize_claude_code(input: &str, agent_id: String) -> Option<NormalizedInpu
         raw_response: parsed.tool_response,
         // Set by `normalize` for every agent; see the field's doc comment.
         host_session_id: None,
+        host_agent_id: None,
     })
 }
 
@@ -432,6 +454,7 @@ fn normalize_pi(input: &str, agent_id: String) -> Option<NormalizedInput> {
         raw_response: None,
         // Set by `normalize` for every agent; see the field's doc comment.
         host_session_id: None,
+        host_agent_id: None,
     })
 }
 
@@ -494,6 +517,7 @@ fn normalize_opencode(input: &str, agent_id: String) -> Option<NormalizedInput> 
         raw_response: None,
         // Set by `normalize` for every agent; see the field's doc comment.
         host_session_id: None,
+        host_agent_id: None,
     })
 }
 
@@ -568,6 +592,7 @@ fn normalize_vscode_continue(input: &str, agent_id: String) -> Option<Normalized
         raw_response: None,
         // Set by `normalize` for every agent; see the field's doc comment.
         host_session_id: None,
+        host_agent_id: None,
     })
 }
 
@@ -612,6 +637,7 @@ fn normalize_codex(input: &str, agent_id: String) -> Option<NormalizedInput> {
         raw_response: None,
         // Set by `normalize` for every agent; see the field's doc comment.
         host_session_id: None,
+        host_agent_id: None,
     })
 }
 
@@ -634,6 +660,7 @@ fn normalize_aider(input: &str, agent_id: String) -> Option<NormalizedInput> {
         raw_response: None,
         // Set by `normalize` for every agent; see the field's doc comment.
         host_session_id: None,
+        host_agent_id: None,
     })
 }
 
@@ -676,6 +703,7 @@ fn normalize_generic_mcp(input: &str, agent_id: String) -> Option<NormalizedInpu
         raw_response: None,
         // Set by `normalize` for every agent; see the field's doc comment.
         host_session_id: None,
+        host_agent_id: None,
     })
 }
 

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -415,9 +415,10 @@ fn fold_cross_turn(
     normalized: &crate::hooks::normalize::NormalizedInput,
     text: String,
 ) -> (String, usize) {
-    let (Some(s), Some(scope)) = (store, normalized.host_session_id.as_deref()) else {
+    let (Some(s), Some(session)) = (store, normalized.host_session_id.as_deref()) else {
         return (text, 0);
     };
+    let scope = crate::ledger::scope_for(session, normalized.host_agent_id.as_deref());
     if crate::pipeline::format::sniff(&text).is_some() {
         return (text, 0);
     }
@@ -763,6 +764,9 @@ pub fn process_payload(
     // Scoping the ledger by that would let it tell a session it had already been
     // shown output that went to a different one, which is a false claim, not a
     // missed saving. No host id, no ledger.
+    //
+    // The host's subagent id joins it, because the session id alone is not one
+    // reader: Claude Code hands a subagent the parent's session id (#581).
     // What the **distiller** produced, taken before the ledger folds anything.
     //
     // These describe the distiller's cut and nothing else, and the rewind marker
@@ -775,9 +779,10 @@ pub fn process_payload(
     let distilled_lines = final_out.lines().count();
     let distilled_len = final_out.len();
 
-    if let (Some(s), Some(scope)) = (store.as_ref(), normalized.host_session_id.as_deref())
+    if let (Some(s), Some(session)) = (store.as_ref(), normalized.host_session_id.as_deref())
         && crate::pipeline::format::sniff(&final_out).is_none()
-        && let Some(view) = crate::ledger::Ledger::new(s, scope)
+        && let scope = crate::ledger::scope_for(session, normalized.host_agent_id.as_deref())
+        && let Some(view) = crate::ledger::Ledger::new(s, &scope)
             .with_project(crate::paths::project_key(std::path::Path::new(
                 &project_path,
             )))
@@ -3233,6 +3238,77 @@ src/distillers/system_ops.rs:849:                is_sensitive_key(key),
             !out.contains("[OMNI:"),
             "a fold with content on both sides renumbered the lines under it: {out}"
         );
+    }
+
+    /// #581. Claude Code hands a subagent **the parent's** `session_id` and
+    /// distinguishes it only by a top-level `agent_id`, which the ledger did not
+    /// read. So a subagent's first read of a file the parent had read came back
+    /// as `identical to the 200 lines already shown`, about bytes that context
+    /// had never received.
+    ///
+    /// The fold itself is not the defect and is kept: the subagent still gets a
+    /// marker and a handle, now through the project scope, whose wording says
+    /// plainly that nothing was shown here (#567, #575). What changes is the
+    /// claim, not the saving.
+    #[test]
+    fn a_subagent_is_not_told_the_parents_bytes_were_already_shown() {
+        let (parent, sub) = two_reads_of_one_file("parent-session-581", Some("aca4e7ff"));
+
+        assert!(
+            !parent.contains("[OMNI:"),
+            "the parent's own first read must be delivered whole: {parent}"
+        );
+        assert!(
+            !sub.contains("already shown"),
+            "a subagent was told bytes it never received were already shown: {sub}"
+        );
+        assert!(
+            sub.contains("none shown here") || sub.contains("not shown here"),
+            "the subagent's fold must say the lines were not delivered here: {sub}"
+        );
+    }
+
+    /// The other half of #581, and the one a scope change would break silently:
+    /// the main agent has no `agent_id`, so its scope is unchanged and a repeat
+    /// inside one session still folds as `already shown`, which is true there.
+    #[test]
+    fn the_main_agent_still_folds_its_own_repeats_as_already_shown() {
+        let (_, second) = two_reads_of_one_file("solo-session-581", None);
+
+        assert!(
+            second.contains("already shown"),
+            "the session scope stopped folding for the reader that does hold the bytes: {second}"
+        );
+    }
+
+    /// Two `Read`s of one file, the second optionally by a subagent carrying the
+    /// same host session id. Returns what the host was handed each time.
+    fn two_reads_of_one_file(session: &str, agent: Option<&str>) -> (String, String) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Arc::new(Store::open_path(&dir.path().join("omni.db")).expect("store"));
+        // 200 distinct lines clears MIN_LEDGER_INPUT and the run gain; a shorter
+        // payload returns cleanly and would prove nothing.
+        let body: String = (0..200)
+            .map(|i| format!("2026-08-12T00:00:00Z  handler finished request {i} in 12ms\n"))
+            .collect();
+
+        let payload = |agent: Option<&str>| {
+            let mut v = json!({
+                "session_id": session,
+                "tool_name": "Read",
+                "tool_input": {"path": "notes.txt"},
+                "tool_response": {"content": body},
+            });
+            if let Some(a) = agent {
+                v["agent_id"] = json!(a);
+            }
+            v.to_string()
+        };
+
+        let first = process_payload(&payload(None), Some(store.clone()), None).unwrap_or_default();
+        let second =
+            process_payload(&payload(agent), Some(store.clone()), None).unwrap_or_default();
+        (first, second)
     }
 
     /// #557, review. An earlier guard read the output back and called any line

--- a/src/hooks/pre_tool.rs
+++ b/src/hooks/pre_tool.rs
@@ -57,6 +57,16 @@ struct PreHookInput {
     /// field `hooks::normalize` reads for the post-hook.
     #[serde(rename = "session_id", alias = "sessionId", default)]
     session_id: Option<String>,
+    /// The host's subagent id, unset when the main agent made the call.
+    ///
+    /// Forwarded for the same reason the session id is, and it has to be, since
+    /// the session id alone is not one reader: Claude Code hands a subagent the
+    /// parent's session id. Without this the rewritten `omni exec` child runs
+    /// the pipe ledger under the parent's scope and tells a subagent its bytes
+    /// were already shown, which is the defect this branch fixes on the
+    /// post-hook path and would have left standing on this one (#581).
+    #[serde(rename = "agent_id", alias = "agentId", default)]
+    agent_id: Option<String>,
 }
 
 #[derive(Deserialize, Serialize, Clone)]
@@ -124,9 +134,15 @@ fn process_payload(
     // the only chance to tell the child, which inherits nothing else (#360).
     let host = host_from_payload(parsed.hook_event_name.as_deref(), parsed.turn_id.is_some());
 
-    if let Some(rewritten) =
-        crate::cli::rewrite::rewrite_logic(cmd_str, host, parsed.session_id.as_deref())
-    {
+    // Composed here rather than in the child, so the reader is decided once and
+    // `--session` keeps meaning "the scope this run belongs to". `host_session()`
+    // feeds nothing but the ledger scope, so there is no second meaning to break.
+    let scope = parsed
+        .session_id
+        .as_deref()
+        .map(|s| crate::ledger::scope_for(s, parsed.agent_id.as_deref()));
+
+    if let Some(rewritten) = crate::cli::rewrite::rewrite_logic(cmd_str, host, scope.as_deref()) {
         let mut updated_input = parsed.tool_input.clone();
         updated_input.command = Some(rewritten);
 
@@ -312,6 +328,44 @@ fn extract_target_file(cmd: &str) -> Option<String> {
                 .map(|s| s.to_string())
         }
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod subagent_scope_581 {
+    use super::*;
+
+    /// #581, review on #588's sibling PR. The post-hook fix left the pipe path
+    /// keying on the bare session id, so a subagent running an allow-listed
+    /// command through the rewritten `omni exec` would still have been told the
+    /// parent's bytes were already shown. The two paths are one pipeline behind
+    /// two doors and this repo has shipped a one-door fix three times.
+    #[test]
+    fn the_rewritten_child_carries_the_subagents_scope() {
+        let payload = |agent: Option<&str>| {
+            let mut v = serde_json::json!({
+                "session_id": "parent-1",
+                "hook_event_name": "PreToolUse",
+                "tool_name": "Bash",
+                "tool_input": {"command": "git status"},
+            });
+            if let Some(a) = agent {
+                v["agent_id"] = serde_json::json!(a);
+            }
+            v.to_string()
+        };
+
+        let main = process_payload(&payload(None), None).unwrap_or_default();
+        assert!(
+            main.contains("--session parent-1"),
+            "the main agent's scope must stay the bare session id: {main}"
+        );
+
+        let sub = process_payload(&payload(Some("agent-9")), None).unwrap_or_default();
+        assert!(
+            sub.contains("--session parent-1/agent-9"),
+            "the subagent's scope never reached the rewritten child: {sub}"
+        );
     }
 }
 

--- a/src/ledger/mod.rs
+++ b/src/ledger/mod.rs
@@ -605,6 +605,22 @@ pub fn line_key(line: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    /// #581. The main agent's scope has to stay the bare session id, byte for
+    /// byte. Composing it differently still folds correctly inside one run,
+    /// because both calls agree, so the hook-level tests cannot see a change
+    /// here. What it would break is an upgrade: rows written by the previous
+    /// binary are keyed on the bare id, and a new formula orphans them mid
+    /// session and silently stops folding against them.
+    #[test]
+    fn the_main_agents_scope_is_the_session_id_unchanged() {
+        assert_eq!(super::scope_for("sess-1", None), "sess-1");
+        assert_eq!(super::scope_for("sess-1", Some("")), "sess-1");
+        assert_eq!(
+            super::scope_for("sess-1", Some("agent-9")),
+            "sess-1/agent-9"
+        );
+    }
+
     use super::*;
 
     fn temp_store() -> (Store, tempfile::TempDir) {

--- a/src/ledger/mod.rs
+++ b/src/ledger/mod.rs
@@ -206,6 +206,30 @@ impl FoldShift {
     }
 }
 
+/// The session scope for one reader, which is not the same as one session.
+///
+/// The scope answers "has this reader already been shown these bytes", and
+/// `Origin::Session`'s marker asserts exactly that. A subagent runs in its own
+/// context and carries **the parent's** `session_id`, so keying on the session
+/// alone answered a subagent with the parent's history and told it 200 lines
+/// were "already shown" when that context had received none of them (#581).
+///
+/// The main agent has no `agent_id`, so its scope is unchanged and no history is
+/// orphaned by this. What a subagent loses is only the parent's lines; its own
+/// repeats still fold under its own scope, and genuinely repeated project bytes
+/// still fold through the project scope, whose marker says "not shown here" and
+/// is honest for a reader that never held them (#567, #575).
+///
+/// This does not fix the other reader the premise fails for: after compaction
+/// the session id is unchanged and the context is gone, and nothing in the hook
+/// payload says so.
+pub fn scope_for(session: &str, agent: Option<&str>) -> String {
+    match agent {
+        Some(a) if !a.is_empty() => format!("{session}/{a}"),
+        _ => session.to_string(),
+    }
+}
+
 /// Addresses the ledger for one session, and optionally for its project.
 ///
 /// Cross-session repetition measures 3.7% of post-filter bytes against 19.1%


### PR DESCRIPTION
A subagent's first read of a file the parent had read came back as bytes it was told it already had:

```
[OMNI: identical to the 200 lines already shown, omni retrieve 33f48cf1181ccdde]
```

That context had received none of them. Reproduced on `main` through `process_payload` before anything was changed, not inferred from the report.

## Why it happened

Claude Code hands a subagent **the parent's `session_id`**, and `post_tool.rs` keyed the ledger on the session alone, so `in_session` hit the parent's history and `Origin::Session`'s marker asserts "already shown".

The host does distinguish them and we were not reading it. Verified two ways rather than assumed:

- a sidechain transcript carries the parent's `sessionId`, so the id genuinely is shared;
- the CLI builds every hook payload as `{session_id, transcript_path, cwd, prompt_id, permission_mode, agent_id, agent_type, effort}`, with `agent_id` unset for the main agent.

## What changed

The ledger scope is the reader, not the session. A subagent now falls through to the project scope, whose wording since #575 is honest for a reader that never held the bytes:

```
[OMNI: identical to 200 lines from an earlier session, none shown here, omni retrieve 33f48cf1181ccdde]
```

The fold is kept, so the saving stands and only the claim changes. The main agent has no `agent_id`, so its scope stays the bare session id and no history is orphaned by the upgrade.

## The half review caught

The post-hook was scoped to the reader and the pipe path was not, so a subagent running an allow-listed command through the rewritten `omni exec` would still have been told the parent's bytes were already shown. `post_tool` and `pipe` are two doors into one pipeline, and this repo has shipped a one-door fix three times, in #452, #454 and #456.

The pre-hook now composes the scope with the same `scope_for` and forwards it through the existing `--session` flag rather than a new one. That is safe because `host_session()` feeds nothing but the ledger scope, so there is no second meaning of that value to break, and the composition stays in one function.

## Verified by breaking it

| break | test | result |
| --- | --- | --- |
| drop the agent id from the scope | `a_subagent_is_not_told_the_parents_bytes_were_already_shown` | red, printing the old `already shown` marker |
| compose the main agent's scope differently | `the_main_agents_scope_is_the_session_id_unchanged` | red, `left: "sess-1/main"`, `right: "sess-1"` |
| drop the subagent id in the pre-hook | `the_rewritten_child_carries_the_subagents_scope` | red, emitted `--session parent-1` instead of `--session parent-1/agent-9` |

The second test exists because the first break-test found a hole in my own coverage. Changing the main agent's formula left the hook-level guard green, since both calls in it go through the same formula and still agree. What that would break is an upgrade rather than a run: rows written by the previous binary are keyed on the bare id, and a new composition orphans them mid session with no symptom. The pure function is asserted directly for that reason.

`make fmt clippy test security binary-check` all green, 1,746 tests, smoke 46/46.

## Scope, and what this does not close

The issue's own framing was wrong and I wrote it, so the correction is on the issue: this is **not** a regression of #567. PR #575 chose the wording over narrowing the scope, deliberately and with a measurement, and cross-session project folding is decided behaviour. Most of the evidence on the issue was also against 0.7.5, which predates #575 and carries zero occurrences of `not shown here`.

Two things stay open and should not be folded into a scope change:

- after compaction the same premise fails with no signal in the payload to detect it;
- `omni retrieve` output is itself fold-eligible, so following the marker can return the marker.

Refs #581

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR scopes ledger history to the actual reader while preserving the main agent’s existing session key.
- Parses the host-provided subagent identifier from hook payloads.
- Uses a composed session/subagent scope in both post-tool and rewritten `omni exec` paths.
- Adds regression coverage for subagent isolation and upgrade-compatible main-agent scope.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the previously reported pipe-ledger path now forwards the subagent-specific scope through `omni exec`, while the main agent retains its upgrade-compatible bare session scope.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/hooks/normalize.rs | Extracts the top-level host agent identifier alongside the existing host session identifier. |
| src/hooks/post_tool.rs | Applies reader-specific scope consistently to non-Bash and Bash ledger folding. |
| src/hooks/pre_tool.rs | Forwards the composed reader scope through rewritten commands so the pipe ledger no longer remains parent-session scoped. |
| src/ledger/mod.rs | Centralizes scope composition while preserving the bare session identifier for the main agent. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Hook payload] --> B{agent_id present?}
    B -- No --> C[Scope: session_id]
    B -- Yes --> D[Scope: session_id/agent_id]
    C --> E[Session ledger]
    D --> E
    E --> F[Reader-specific fold decision]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(hooks): carry the subagent scope int..."](https://github.com/fajarhide/omni/commit/23a5901eec0d6ec4d02fcc3269897655fb54c97c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53870698)</sub>

<!-- /greptile_comment -->
