### PR TITLE
fix(stats): report the bytes OMNI counted, not bytes over a GPT constant

### DIFF
--- a/changelog.d/589.fixed.md
+++ b/changelog.d/589.fixed.md
@@ -3,8 +3,11 @@
   encoding. It now reports the bytes it counted. The percentage beside it is unchanged and
   always was sound: the divisor cancels in a ratio, so `(raw/k - filtered/k) / (raw/k)` is
   `(raw - filtered) / raw` for any `k`. The banner's own bars moved with the figure they
-  gate, 500 and 1000 becoming 1800 and 3600 at the same 3.6, so it fires exactly as often
-  as before rather than 3.6 times more. `omni stats` also printed `Tokens Reduced`
+  gate, 500 and 1000 becoming 1800 and 3600 at the same 3.6, so it does not fire 3.6 times more
+  often, which leaving them would have caused. The translation is close rather than
+  exact: the old bar subtracted two independently rounded estimates and disagrees with
+  the new one over savings of 1,797 to 1,799 B, always in the direction of the old bar
+  firing and the new one staying silent. `omni stats` also printed `Tokens Reduced`
   directly under `Data Distilled`, the same quantity in exact units, and that line is
   deleted rather than converted. This makes #212's guard stricter: the banner now prints
   the `distillations` row's own two columns subtracted, with no estimator between the

--- a/changelog.d/589.fixed.md
+++ b/changelog.d/589.fixed.md
@@ -1,0 +1,12 @@
+- **The savings banner reported a unit OMNI cannot defend.** `-500tok this call` was a
+  byte count divided by 3.6, a constant calibrated against `cl100k_base`, which is GPT's
+  encoding. It now reports the bytes it counted. The percentage beside it is unchanged and
+  always was sound: the divisor cancels in a ratio, so `(raw/k - filtered/k) / (raw/k)` is
+  `(raw - filtered) / raw` for any `k`. The banner's own bars moved with the figure they
+  gate, 500 and 1000 becoming 1800 and 3600 at the same 3.6, so it fires exactly as often
+  as before rather than 3.6 times more. `omni stats` also printed `Tokens Reduced`
+  directly under `Data Distilled`, the same quantity in exact units, and that line is
+  deleted rather than converted. This makes #212's guard stricter: the banner now prints
+  the `distillations` row's own two columns subtracted, with no estimator between the
+  banner and the record it has to agree with. `omni stats` still labels other figures in
+  the same derived unit and this does not touch them. (#589)

--- a/src/cli/stats.rs
+++ b/src/cli/stats.rs
@@ -1107,13 +1107,10 @@ fn run_detail(args: &[String], store: &Store) -> Result<()> {
         format_bytes(output_total).green()
     );
 
-    println!(
-        "  {:<20} {} {} {}",
-        "Tokens Reduced:".bright_black(),
-        format_exact_tokens(raw_tokens).red(),
-        "→".bright_black(),
-        format_exact_tokens(filtered_tokens).green()
-    );
+    // #589. `Tokens Reduced` used to sit here and was the line above divided by
+    // 3.6, a constant calibrated against `cl100k_base`. It added no information
+    // that `Data Distilled` did not already state exactly, and it stated it in a
+    // unit we cannot defend, so it is gone rather than relabelled.
 
     let ratio_msg = format!("{:.1}% reduction", reduction_pct);
     let ratio_colored = if reduction_pct > 70.0 {

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -1263,10 +1263,17 @@ fn build_additional_context(
     // F-10: Inject for significant single-call savings.
     //
     // The bars moved from tokens to bytes with the figures they gate, at the 3.6
-    // bytes per token the estimator used, so the banner fires exactly as often
-    // as it did. Converting them was not optional: leaving `>= 500` while the
-    // quantity became bytes would have fired the banner on a saving 3.6 times
-    // smaller, which is more markers rather than fewer (#589).
+    // bytes per token the estimator used. Converting them was not optional:
+    // leaving `>= 500` while the quantity became bytes would have fired the
+    // banner on a saving 3.6 times smaller, which is more markers rather than
+    // fewer (#589).
+    //
+    // Not an exact translation, and review on #592 was right to say so. The old
+    // gate subtracted two independently `ceil`ed estimates, so it disagrees with
+    // this one over savings of 1,797 to 1,799 B, a three byte window, measured
+    // rather than reasoned about. The disagreement is one-way: the old bar fired
+    // and this one is silent, never the reverse, so the banner can only have got
+    // quieter.
     if saved_bytes_this_call >= 1800 {
         msgs.push(format!(
             "[OMNI: -{} this call | -{} session | {savings:.0}% compression]",
@@ -2014,6 +2021,48 @@ mod tests {
         assert!(
             build_additional_context(&result, &None).is_none(),
             "a 1.2 KB saving is under the bar and must not reach the agent's context"
+        );
+    }
+
+    /// The three byte window where the converted bar and the old one disagree,
+    /// pinned so the claim in the changelog stays true if either moves.
+    ///
+    /// Review on #592 pointed out that subtracting two independently `ceil`ed
+    /// estimates is not the same comparison as subtracting the bytes, and it is
+    /// right. What makes it acceptable is the direction rather than the size: a
+    /// saving in the window fired the old bar and is silent now, never the
+    /// reverse, so the conversion cannot make OMNI write into the agent's
+    /// context more often than it used to.
+    #[test]
+    fn the_converted_bar_is_never_noisier_than_the_one_it_replaced() {
+        let old_fires = |i: usize, o: usize| {
+            use crate::util::token_estimate::{ContentHint, estimate_tokens};
+            estimate_tokens(i, ContentHint::Mixed)
+                .saturating_sub(estimate_tokens(o, ContentHint::Mixed))
+                >= 500
+        };
+        let new_fires = |i: usize, o: usize| i.saturating_sub(o) >= 1800;
+
+        let mut disagreements = 0;
+        for delta in 1_700..=1_900usize {
+            for out in 0..40usize {
+                let input = out + delta;
+                if old_fires(input, out) != new_fires(input, out) {
+                    disagreements += 1;
+                    assert!(
+                        old_fires(input, out) && !new_fires(input, out),
+                        "the converted bar fired where the old one did not, at {delta} B saved"
+                    );
+                    assert!(
+                        (1_797..=1_799).contains(&delta),
+                        "the disagreement escaped the measured window at {delta} B saved"
+                    );
+                }
+            }
+        }
+        assert!(
+            disagreements > 0,
+            "no disagreement found at all, so this scan is broken rather than clean"
         );
     }
 

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -1150,16 +1150,23 @@ fn build_additional_context(
     // 16,983 - 1,209 = 15,774. Two live estimators, neither reconciled, one of
     // them printed into the agent's context (#212). `raw_tokens` and
     // `filtered_tokens` are already counted for this result, use them.
-    let saved_this_call = result.raw_tokens.saturating_sub(result.filtered_tokens);
+    // #589. What the banner prints is bytes, which are counted, rather than the
+    // token figures above, which are those bytes over a constant calibrated
+    // against `cl100k_base`. The percentage is unaffected either way: the
+    // divisor cancels in a ratio, so it was the one defensible number on the
+    // line all along.
+    let saved_bytes_this_call = result.input_bytes.saturating_sub(result.output_bytes);
 
-    let mut session_total = 0;
+    let mut session_bytes_total: u64 = 0;
     let mut command_count = 0;
     let mut pressure_msg = None;
 
     if let Some(lock) = session
         && let Ok(mut s) = lock.lock()
     {
-        session_total = s.estimated_tokens_saved();
+        session_bytes_total = s
+            .cumulative_input_bytes
+            .saturating_sub(s.cumulative_output_bytes);
         command_count = s.command_count;
 
         // Feature A: Context Pressure System
@@ -1253,16 +1260,25 @@ fn build_additional_context(
         }
     }
 
-    // F-10: Inject for significant single-call savings (>= 500 tokens)
-    if saved_this_call >= 500 {
+    // F-10: Inject for significant single-call savings.
+    //
+    // The bars moved from tokens to bytes with the figures they gate, at the 3.6
+    // bytes per token the estimator used, so the banner fires exactly as often
+    // as it did. Converting them was not optional: leaving `>= 500` while the
+    // quantity became bytes would have fired the banner on a saving 3.6 times
+    // smaller, which is more markers rather than fewer (#589).
+    if saved_bytes_this_call >= 1800 {
         msgs.push(format!(
-            "[OMNI: -{saved_this_call}tok this call | -{session_total}tok session | {savings:.0}% compression]",
+            "[OMNI: -{} this call | -{} session | {savings:.0}% compression]",
+            crate::cli::stats::format_bytes(saved_bytes_this_call as u64),
+            crate::cli::stats::format_bytes(session_bytes_total),
             savings = result.savings_pct()
         ));
-    } else if command_count > 0 && command_count.is_multiple_of(10) && session_total >= 1000 {
+    } else if command_count > 0 && command_count.is_multiple_of(10) && session_bytes_total >= 3600 {
         // F-10: Inject milestone summary every 10 commands if total savings significant
         msgs.push(format!(
-            "[OMNI session milestone: -{session_total}tok saved across {command_count} commands]"
+            "[OMNI session milestone: -{} saved across {command_count} commands]",
+            crate::cli::stats::format_bytes(session_bytes_total)
         ));
     }
 
@@ -1996,9 +2012,18 @@ mod tests {
 
         let banner = build_additional_context(&result, &None).expect("banner for a large saving");
 
+        // 30,000 - 2,129 = 27,871 B, which `format_bytes` renders as `27.2 KB`.
+        // Written out by hand from that function's rules rather than by calling
+        // it, so this asserts the string a reader sees rather than agreeing with
+        // whatever the formatter happens to do.
+        //
+        // #589 made this stricter rather than looser. The banner used to report
+        // a token figure derived from these same bytes, so "agrees with the row"
+        // meant "agrees after an estimator". It now prints the row's own two
+        // columns subtracted, with nothing in between.
         assert!(
-            banner.contains("-15774tok this call"),
-            "banner must report raw_tokens - filtered_tokens, got: {banner}"
+            banner.contains("-27.2 KB this call"),
+            "banner must report input_bytes - output_bytes, got: {banner}"
         );
     }
 

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -1984,6 +1984,39 @@ mod tests {
         );
     }
 
+    /// #589. The banner's bar was expressed in the same estimated unit as the
+    /// figure it gates, so moving the figure to bytes without moving the bar
+    /// would have fired it on a saving 3.6 times smaller, quietly tripling how
+    /// often OMNI writes into the agent's context. Nothing guarded that, which
+    /// is why a saving in the gap between the old number and the new one is
+    /// asserted silent here.
+    #[test]
+    fn a_saving_under_the_converted_bar_writes_no_banner() {
+        let result = crate::pipeline::DistillResult {
+            output: String::new(),
+            route: Route::Keep,
+            filter_name: "cat".to_string(),
+            score: 0.0,
+            context_score: 0.0,
+            // 1,200 B saved: over the old bar of 500, under the converted 1,800.
+            input_bytes: 4_000,
+            output_bytes: 2_800,
+            latency_ms: 1,
+            rewind_hash: None,
+            segments_kept: 0,
+            segments_dropped: 0,
+            collapse_savings: None,
+            raw_tokens: 1_112,
+            filtered_tokens: 778,
+            delivered_bytes: 2_800,
+        };
+
+        assert!(
+            build_additional_context(&result, &None).is_none(),
+            "a 1.2 KB saving is under the bar and must not reach the agent's context"
+        );
+    }
+
     /// #212: the banner and the `distillations` row describe the same call and
     /// disagreed about it, the banner ran a bytes-per-token heuristic over the
     /// byte delta while the row ran a real tokenizer over each string. On the


### PR DESCRIPTION
The banner every hooked command writes into the agent's context said `-500tok this call`. That number is a byte count divided by 3.6, a constant calibrated against `cl100k_base`, which is GPT's encoding. It now reports the bytes OMNI counted.

```
before  [OMNI: -15774tok this call | -0tok session | 93% compression]
after   [OMNI: -27.2 KB this call | -27.2 KB session | 93% compression]
```

The percentage is unchanged and always was the defensible half of that line: the divisor cancels in a ratio, so `(raw/k - filtered/k) / (raw/k)` is `(raw - filtered) / raw` whatever `k` is.

## Two couplings, handled rather than left

**The bars were in the same estimated unit as the figure they gate.** Moving the figure to bytes and leaving `>= 500` would have fired the banner on a saving 3.6 times smaller, tripling how often OMNI writes into the agent's context. They moved with it, 500 and 1000 becoming 1800 and 3600 at the same 3.6. Not an exact translation, and review caught me claiming it was: the old bar subtracted two independently rounded estimates, so the two disagree over savings of 1,797 to 1,799 B. Measured, that disagreement is one-way, 54 cases where the old bar fired and this one is silent and none the other way, so the banner can only have got quieter. Nothing guarded any of this before; two tests do now.

**`omni stats` printed `Tokens Reduced` directly under `Data Distilled`.** Same quantity, one exact and one divided by 3.6. The derived line is deleted rather than converted, because it never said anything the line above it did not already say exactly.

## Verified by breaking it

| break | test | result |
| --- | --- | --- |
| report the token figure again | `the_banner_and_the_recorded_row_agree_about_the_same_call` | red, `got: -15.4 KB this call` |
| revert the bar to 500 without reverting the unit | `a_saving_under_the_converted_bar_writes_no_banner` | red, a 1.2 KB saving reached the context |
| lower the converted bar to 1700 | `the_converted_bar_is_never_noisier_than_the_one_it_replaced` | red, `fired where the old one did not, at 1700 B saved` |

`make fmt clippy test security binary-check` all green, 1,742 tests, smoke 46/46.

This makes #212's guard stricter rather than looser. That test exists because the banner and the `distillations` row described one call and disagreed, so "agrees with the row" used to mean "agrees after an estimator". The banner now prints that row's own two columns subtracted, with nothing in between.

## What this does not do

`omni stats` labels other figures in the same derived unit in nine more places, including the per-period summary (`10K → 10K tokens`), the token breakdown, and the share card. They are the same defect and this PR does not touch them, so #589 stays open for that half rather than being closed by this. Every one of them is derived: the `raw_tokens` column the DB holds is itself written by `estimate_tokens`, so reading it back does not make it measured.

Splitting there is deliberate. The banner is the copy that enters the agent's context and is acted on; `omni stats` is a report a person reads, and converting it touches the share card and the period rollups, which deserve their own diff.

Refs #589

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR replaces estimated token savings in the command banner with measured byte savings while preserving the compression percentage and converting the associated thresholds.
- Formats per-call and session savings as bytes.
- Removes the redundant estimated-token line from detailed stats.
- Adds regression coverage for threshold behavior and banner output.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/hooks/post_tool.rs | Converts banner savings and thresholds to bytes and adds regression tests establishing that the converted gate is never noisier. |
| src/cli/stats.rs | Removes the redundant estimated `Tokens Reduced` output beneath exact byte statistics. |
| changelog.d/589.fixed.md | Documents the unit correction, threshold conversion, and narrow one-way boundary difference. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(hooks): correct the claim that the c..."](https://github.com/fajarhide/omni/commit/a64999be981163cfd3839276ea0a1ef084b9a3c0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53874204)</sub>

<!-- /greptile_comment -->