### PR TITLE
fix(ledger): answer a pull before folding the bytes it asked for

### DIFF
--- a/changelog.d/581-retrieve.fixed.md
+++ b/changelog.d/581-retrieve.fixed.md
@@ -1,0 +1,8 @@
+- **Following a marker returned the marker.** A fold prints `omni retrieve <handle>`, and
+  the bytes that came back passed through the hook, hashed the same, and were folded into
+  the very marker that had sent the reader to fetch them. An agent that did what the
+  marker said got the instruction again, and `OMNI_PASSTHROUGH=1` on the retrieve did not
+  help because the fold lands on the later read rather than on that command. A pull now
+  marks the archived row owed, and the delivery answering it is handed over verbatim. It
+  costs one delivery and not an exemption: the next repeat folds again, which matters
+  because 15.05% of the archive on this installation has been pulled at least once. (#581)

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -3418,6 +3418,61 @@ src/distillers/system_ops.rs:849:                is_sensitive_key(key),
         (first, second)
     }
 
+    /// #581. A marker tells the reader to run `omni retrieve <handle>`. Those
+    /// bytes come back through the hook, hash the same, and were folded into the
+    /// very marker that sent the reader there, so an agent following the
+    /// instruction got the instruction back. Reproduced on `ded23da` before the
+    /// fix: step three below returned
+    /// `[OMNI: identical to the 200 lines already shown, omni retrieve ...]`.
+    ///
+    /// The second assertion is the one that keeps this from being a permanent
+    /// exemption. Once the reader holds the content the ledger's claim is true
+    /// again, so folding has to resume on the next repeat or the fix would trade
+    /// a false claim for a lost saving on every pulled handle, 15.05% of the
+    /// archive on this machine.
+    #[test]
+    fn a_pull_is_answered_once_and_then_folding_resumes() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Arc::new(Store::open_path(&dir.path().join("omni.db")).expect("store"));
+        let body: String = (0..200)
+            .map(|i| format!("2026-08-12T00:00:00Z  handler finished request {i} in 12ms\n"))
+            .collect();
+        let payload = json!({
+            "session_id": "loop-581",
+            "tool_name": "Read",
+            "tool_input": {"path": "notes.txt"},
+            "tool_response": {"content": body},
+        })
+        .to_string();
+
+        let _ = process_payload(&payload, Some(store.clone()), None);
+        let folded = process_payload(&payload, Some(store.clone()), None).unwrap_or_default();
+        let handle = folded
+            .split("omni retrieve ")
+            .nth(1)
+            .and_then(|rest| rest.split(|c: char| !c.is_ascii_hexdigit()).next())
+            .map(str::to_string)
+            .expect("the second read must fold and name a handle");
+
+        store
+            .retrieve_rewind(&handle)
+            .expect("the handle the marker printed must resolve");
+
+        let answering = process_payload(&payload, Some(store.clone()), None).unwrap_or_default();
+        assert!(
+            !answering.contains("omni retrieve"),
+            "the delivery answering the pull was folded back into the marker \
+             that sent the reader to it: {answering}"
+        );
+
+        let after = process_payload(&payload, Some(store.clone()), None).unwrap_or_default();
+        assert!(
+            after.contains("omni retrieve"),
+            "folding did not resume, so a pulled handle is exempt for good \
+             rather than for one delivery: {after}"
+        );
+    }
+
     /// #557, review. An earlier guard read the output back and called any line
     /// starting with `[OMNI:` a marker, so a file whose own lines start that way
     /// defeated it. This repository writes those strings into its changelog and

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -3454,9 +3454,14 @@ src/distillers/system_ops.rs:849:                is_sensitive_key(key),
             .map(str::to_string)
             .expect("the second read must fold and name a handle");
 
+        // Both calls, in the order `cli/retrieve.rs` and the MCP tool make them.
+        // The debt is booked by `record_rewind_pull`, the door that means an
+        // agent asked, and not by `retrieve_rewind`, which `store::query` also
+        // uses to answer reports (#593 review).
         store
             .retrieve_rewind(&handle)
             .expect("the handle the marker printed must resolve");
+        store.record_rewind_pull(&handle);
 
         let answering = process_payload(&payload, Some(store.clone()), None).unwrap_or_default();
         assert!(

--- a/src/ledger/mod.rs
+++ b/src/ledger/mod.rs
@@ -541,9 +541,14 @@ impl<'a> Ledger<'a> {
             // `store_rewind` returns `None` when the row did not land, and the
             // run then stays verbatim rather than becoming a promise nobody can
             // keep (#388).
+            // A run whose handle was just pulled stays verbatim. That delivery is
+            // the answer to the pull, and folding it hands the reader back the
+            // marker it was following (#581). The flag is consumed here, so this
+            // costs one delivery rather than exempting the content for good.
             match long_enough
                 .then(|| self.store.store_rewind(&body))
                 .flatten()
+                .filter(|handle| !self.store.take_owed_delivery(handle))
                 .zip(run.seen)
             {
                 Some((handle, origin)) => {

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -796,6 +796,15 @@ impl SqliteBackend {
             "ALTER TABLE ledger_folds ADD COLUMN payload_bytes INTEGER NOT NULL DEFAULT 0",
             [],
         );
+        // #581. Set when a handle is pulled and cleared by the delivery that
+        // answers it, so the content a marker sent the reader to fetch is not
+        // folded back into that same marker on its way in. Separate from
+        // `retrieved`, which is a lifetime counter `rewind_metrics` and #512's
+        // adaptive rate both read and must not be reset.
+        let _ = conn.execute(
+            "ALTER TABLE rewind_store ADD COLUMN owed INTEGER NOT NULL DEFAULT 0",
+            [],
+        );
         let _ = conn.execute(
             "ALTER TABLE distillations ADD COLUMN collapse_original INTEGER DEFAULT 0",
             [],
@@ -1310,6 +1319,31 @@ impl SqliteBackend {
         self.record_retrieve_event(&family, hash, &agent_id);
     }
 
+    /// Consumes the debt a pull left behind, and says whether there was one.
+    ///
+    /// #581. A marker tells the reader to run `omni retrieve <handle>`. Whichever
+    /// way those bytes come back, through a file it then reads or through the
+    /// command's own output, they pass the hook again and hash the same, so the
+    /// ledger replaced them with the very marker that sent the reader there. An
+    /// agent following the instruction got the instruction back.
+    ///
+    /// One delivery, not a permanent exemption. Once the reader has the content
+    /// the ledger's claim is true again and the next repeat folds normally,
+    /// which is why this clears the flag as it reads it. The `UPDATE` does both
+    /// in one statement so two hooks racing cannot each be told they are the one
+    /// answering the pull.
+    pub fn take_owed_delivery(&self, hash: &str) -> bool {
+        let Ok(conn) = self.pool.get() else {
+            return false;
+        };
+        conn.execute(
+            "UPDATE rewind_store SET owed = 0 WHERE hash = ?1 AND owed = 1",
+            params![hash],
+        )
+        .map(|changed| changed > 0)
+        .unwrap_or(false)
+    }
+
     pub fn retrieve_rewind(&self, hash: &str) -> Option<String> {
         let conn = match self.pool.get() {
             Ok(c) => c,
@@ -1326,8 +1360,11 @@ impl SqliteBackend {
             .unwrap_or(None);
 
         if content.is_some() {
+            // `owed` says a reader asked for these bytes back and has not been
+            // handed them yet, which is the one moment the ledger's "already
+            // shown" is provably false about this content (#581).
             let _ = conn.execute(
-                "UPDATE rewind_store SET retrieved = retrieved + 1 WHERE hash = ?1",
+                "UPDATE rewind_store SET retrieved = retrieved + 1, owed = 1 WHERE hash = ?1",
                 params![hash],
             );
         }

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -1310,6 +1310,23 @@ impl SqliteBackend {
     /// rate with reads no agent asked for, which is the same defect in the
     /// other direction.
     pub fn record_rewind_pull(&self, hash: &str) {
+        // #581. The debt is booked here and not in `retrieve_rewind`, for the
+        // same reason the counter above is: `store::query` reads archived
+        // content to answer reports (`query.rs:122` and `:174`), and a report
+        // is not a reader asking for its bytes back. Booking it there created
+        // debt nobody incurred and spent the next matching delivery paying it.
+        // Review on #593 caught that, against a comment two paragraphs up that
+        // says exactly this about the other counter.
+        //
+        // A count rather than a flag, so two readers pulling the same handle
+        // before either is answered earn one verbatim delivery each instead of
+        // the first clearing it for both.
+        if let Ok(conn) = self.pool.get() {
+            let _ = conn.execute(
+                "UPDATE rewind_store SET owed = owed + 1 WHERE hash = ?1",
+                params![hash],
+            );
+        }
         let cmd = self
             .find_command_for_hash(hash)
             .unwrap_or_else(|| "unknown".to_string());
@@ -1337,7 +1354,7 @@ impl SqliteBackend {
             return false;
         };
         conn.execute(
-            "UPDATE rewind_store SET owed = 0 WHERE hash = ?1 AND owed = 1",
+            "UPDATE rewind_store SET owed = owed - 1 WHERE hash = ?1 AND owed > 0",
             params![hash],
         )
         .map(|changed| changed > 0)
@@ -1360,11 +1377,8 @@ impl SqliteBackend {
             .unwrap_or(None);
 
         if content.is_some() {
-            // `owed` says a reader asked for these bytes back and has not been
-            // handed them yet, which is the one moment the ledger's "already
-            // shown" is provably false about this content (#581).
             let _ = conn.execute(
-                "UPDATE rewind_store SET retrieved = retrieved + 1, owed = 1 WHERE hash = ?1",
+                "UPDATE rewind_store SET retrieved = retrieved + 1 WHERE hash = ?1",
                 params![hash],
             );
         }
@@ -3897,6 +3911,45 @@ mod tests {
             "identical content must occupy one row"
         );
         assert_eq!(store.retrieve_rewind(&first), Some(content.to_string()));
+    }
+
+    /// #593 review, the first of two. `store::query` calls `retrieve_rewind` to
+    /// answer reports, so booking the debt there charged a delivery to a read no
+    /// agent made, and the next real fold paid it. The comment on the counter
+    /// beside it already said this about `retrieve_rewind`; the flag went in on
+    /// the wrong side of it anyway.
+    #[test]
+    fn a_report_read_does_not_owe_a_delivery() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Store::open_path(&dir.path().join("omni.db")).expect("store");
+        let handle = store.store_rewind("archived body\n").expect("archived");
+
+        store.retrieve_rewind(&handle).expect("content");
+
+        assert!(
+            !store.take_owed_delivery(&handle),
+            "a read that no agent asked for created a delivery debt"
+        );
+    }
+
+    /// #593 review, the second. A flag would let the first delivery clear the
+    /// debt of two readers, so the second one is folded back into the marker it
+    /// was following. A count pays each of them once.
+    #[test]
+    fn two_pulls_earn_two_verbatim_deliveries() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Store::open_path(&dir.path().join("omni.db")).expect("store");
+        let handle = store.store_rewind("archived body\n").expect("archived");
+
+        store.record_rewind_pull(&handle);
+        store.record_rewind_pull(&handle);
+
+        assert!(store.take_owed_delivery(&handle), "first pull unanswered");
+        assert!(store.take_owed_delivery(&handle), "second pull unanswered");
+        assert!(
+            !store.take_owed_delivery(&handle),
+            "the debt outlived the pulls that created it"
+        );
     }
 
     /// #388. The key used to come back on every path, including a swallowed


### PR DESCRIPTION
A fold prints `omni retrieve <handle>`. The bytes that came back passed through the hook, hashed the same, and were folded into the very marker that had sent the reader to fetch them.

Reproduced on `ded23da` before changing anything:

```
1. Read                -> delivered, 200 lines
2. Read again          -> [OMNI: identical to the 200 lines already shown, omni retrieve 33f48cf...]
3. omni retrieve 33f48cf...  -> 200 lines, 11,690 B, rc=0
4. Read those bytes    -> [OMNI: identical to the 200 lines already shown, omni retrieve 33f48cf...]
```

Step 4 is the defect. An agent that does what the marker says gets the instruction again, and `OMNI_PASSTHROUGH=1` on the retrieve does not help because the fold lands on the later read rather than on that command.

## The fix, and why it is one delivery

`retrieve_rewind` marks the archived row `owed`, and the run whose handle is owed is handed over verbatim. The flag is cleared in the same `UPDATE` that reads it, so two hooks racing cannot both be told they are the answer.

Deliberately not a permanent exemption. Once the reader holds the content the ledger's claim is true again, so folding resumes on the next repeat. That is not a detail: **15.05% of the archive on this installation has been pulled at least once** (199 of 1,322 rows), so exempting pulled content for good would trade a false claim for a lost saving across a sixth of it.

`owed` is a separate column from `retrieved` because `retrieved` is a lifetime counter that `rewind_metrics` and #512's adaptive rate both read, and reusing it to carry this state would corrupt both.

## Verified by breaking it

| break | result |
| --- | --- |
| never consume the owed flag | red, step 4 folded back into the marker |
| never clear it, making the exemption permanent | red, `folding did not resume, so a pulled handle is exempt for good` |

Both assertions live in one test, so the fix cannot satisfy one by giving up the other.

`make fmt clippy test security binary-check` all green, 1,754 tests, smoke 46/46.

## What this leaves

#581 stays open for the compaction reader, which has the same premise failure and no signal in the payload to detect it. A pull is the one case where the loss of context is observable, which is why it is fixable and that one is not.

Refs #581

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR prevents retrieved archive content from immediately folding back into its marker by adding a consumable delivery-debt counter. The counter fixes multiple pulls and avoids charging internal report reads, but remains globally scoped by content hash.

- Adds and migrates the `rewind_store.owed` counter.
- Books debt only after successful CLI or MCP retrievals.
- Atomically consumes one debt before folding matching content.
- Adds regression coverage for one-shot delivery, concurrent pull counts, and internal report reads.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because another session processing identical content can consume the pulling reader's delivery debt and leave the original retrieve loop intact.

The new counter preserves the number of outstanding pulls, but both creation and consumption are keyed only by the shared content hash; a concurrent matching fold can therefore spend another reader's entitlement before the intended delivery arrives.

**Files Needing Attention:** src/store/sqlite.rs and src/ledger/mod.rs
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/store/sqlite.rs | Adds atomic counted retrieval debt and correct booking semantics, but the debt remains globally scoped and can be consumed by another session. |
| src/ledger/mod.rs | Suppresses one matching fold by consuming hash-scoped debt, without associating that debt with the reader whose pull created it. |
| src/hooks/post_tool.rs | Adds end-to-end regression coverage for one pull and resumed folding, but does not exercise cross-session contention. |
| changelog.d/581-retrieve.fixed.md | Documents the intended one-delivery exemption behavior. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant A as Pulling session
  participant DB as rewind_store
  participant B as Other session
  A->>DB: retrieve(handle)
  A->>DB: "owed[handle] += 1"
  B->>DB: fold matching content
  B->>DB: "owed[handle] -= 1"
  DB-->>B: deliver verbatim
  A->>DB: process answering content
  DB-->>A: no debt remains
  A-->>A: fold into retrieve marker
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20fajarhide%2Fomni%20PR%20%23593%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=fajarhide%2Fomni&pr=593&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fstore%2Fsqlite.rs%3A1324-1328%0A**Shared%20counter%20misroutes%20deliveries**%0A%0AIf%20two%20sessions%20process%20the%20same%20archived%20content%20concurrently%2C%20the%20unrelated%20session%20can%20consume%20the%20hash-wide%20%60owed%60%20count%20before%20the%20pulling%20session's%20answer%20is%20processed.%20The%20unrelated%20session%20then%20receives%20verbatim%20content%20while%20the%20intended%20answer%20is%20folded%20back%20into%20its%20%60omni%20retrieve%60%20marker.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni&pr=593&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fajarhide%2Fomni%22%20on%20the%20existing%20branch%20%22fix%2F581-retrieve-loop%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F581-retrieve-loop%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fstore%2Fsqlite.rs%3A1324-1328%0A**Shared%20counter%20misroutes%20deliveries**%0A%0AIf%20two%20sessions%20process%20the%20same%20archived%20content%20concurrently%2C%20the%20unrelated%20session%20can%20consume%20the%20hash-wide%20%60owed%60%20count%20before%20the%20pulling%20session's%20answer%20is%20processed.%20The%20unrelated%20session%20then%20receives%20verbatim%20content%20while%20the%20intended%20answer%20is%20folded%20back%20into%20its%20%60omni%20retrieve%60%20marker.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni&pr=593&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Asrc%2Fstore%2Fsqlite.rs%3A1324-1328%0A**Shared%20counter%20misroutes%20deliveries**%0A%0AIf%20two%20sessions%20process%20the%20same%20archived%20content%20concurrently%2C%20the%20unrelated%20session%20can%20consume%20the%20hash-wide%20%60owed%60%20count%20before%20the%20pulling%20session's%20answer%20is%20processed.%20The%20unrelated%20session%20then%20receives%20verbatim%20content%20while%20the%20intended%20answer%20is%20folded%20back%20into%20its%20%60omni%20retrieve%60%20marker.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=593&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fajarhide%2Fomni%22%20on%20the%20existing%20branch%20%22fix%2F581-retrieve-loop%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F581-retrieve-loop%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fstore%2Fsqlite.rs%3A1324-1328%0A**Shared%20counter%20misroutes%20deliveries**%0A%0AIf%20two%20sessions%20process%20the%20same%20archived%20content%20concurrently%2C%20the%20unrelated%20session%20can%20consume%20the%20hash-wide%20%60owed%60%20count%20before%20the%20pulling%20session's%20answer%20is%20processed.%20The%20unrelated%20session%20then%20receives%20verbatim%20content%20while%20the%20intended%20answer%20is%20folded%20back%20into%20its%20%60omni%20retrieve%60%20marker.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/store/sqlite.rs:1324-1328
**Shared counter misroutes deliveries**

If two sessions process the same archived content concurrently, the unrelated session can consume the hash-wide `owed` count before the pulling session's answer is processed. The unrelated session then receives verbatim content while the intended answer is folded back into its `omni retrieve` marker.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(store): book the pull debt on the do..."](https://github.com/fajarhide/omni/commit/77fde156361b7c90c07e924e25499e0377118a53) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53890326)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->