### PR TITLE
fix(stats): report counted bytes, and document the payload shape the hook page asks for

### DIFF
--- a/changelog.d/586.fixed.md
+++ b/changelog.d/586.fixed.md
@@ -1,0 +1,9 @@
+- **The hooks page told you to feed `omni --post-hook` a payload and never said what one
+  looks like.** Getting the shape wrong exits 0, prints nothing, and reads as `0.0%
+  saved`, so there is no error to notice and a distiller cutting 96% can be written off as
+  not firing. Both shapes are documented now, in both languages: `Bash` carries the output
+  at `tool_response.content`, `Read` wraps it at `tool_response.file.content` with the
+  `startLine` a fold has to move. Both `Read` forms are real and reach different stages,
+  the bare one the ledger and the wrapped one the `readfile` distiller, which is the pair
+  that cost an hour on 2026-08-17. A test asserts both still parse, so the page cannot
+  quietly stop being true. (#586)

--- a/changelog.d/589-stats.fixed.md
+++ b/changelog.d/589-stats.fixed.md
@@ -1,0 +1,9 @@
+- **`omni stats` reported in a unit OMNI cannot defend.** The per-period summary read
+  `10K to 10K tokens`, and the per-command and per-filter annotations read `-N tokens`,
+  all of them a byte count divided by 3.6, a constant calibrated against `cl100k_base`.
+  Every one of those now reports the bytes `distillations` counts exactly, and the
+  percentages beside them are unchanged because the divisor cancels in a ratio. The
+  context breakdown is the one block that could not move: it accumulates `size_bytes / 4`
+  from file metadata, so there is no measured total behind it, and it now says so and
+  prints `~` rather than pretending to a count. #592 fixed the same defect in the hook
+  banner; this is the report surface. (#589)

--- a/changelog.d/589-stats.fixed.md
+++ b/changelog.d/589-stats.fixed.md
@@ -7,3 +7,7 @@
   from file metadata, so there is no measured total behind it, and it now says so and
   prints `~` rather than pretending to a count. #592 fixed the same defect in the hook
   banner; this is the report surface. (#589)
+- **`omni stats --json` renamed `tokens_saved` to `bytes_saved`.** The field briefly held
+  bytes under the old name, which is a machine-readable surface asserting the wrong unit.
+  A consumer reading that key has to update; the alternative was leaving the name lying.
+  (#589)

--- a/docs/website/src-id/reference/hooks.md
+++ b/docs/website/src-id/reference/hooks.md
@@ -136,9 +136,14 @@ baris yang selamat harus menggesernya:
                                "startLine": 1, "numLines": 40, "totalLines": 400 } } }
 ```
 
-Balasannya mengikuti bentuk yang datang, di bawah `hookSpecificOutput.updatedToolOutput`.
-Claude Code memvalidasinya terhadap **skema keluaran milik tool itu sendiri**, jadi
-penulisan ulang `Bash` membawa `content` dan `Read` membawa `file.content`.
+Balasannya berada di bawah `hookSpecificOutput.updatedToolOutput`, dan Claude Code
+memvalidasinya terhadap **skema keluaran milik tool itu sendiri**. `Read` yang terbungkus
+mendapat balasan `file`, dan itulah bentuk yang diterima host.
+
+`tool_response.content` yang polos **tidak** mendapat balasan polos. Diverifikasi, bukan
+diasumsikan: ia kembali sebagai `{status, result}`, yaitu bentuk milik OMNI sendiri dan
+itulah pokok #187. Jadi bentuk polos berguna untuk menanyakan apa yang dilakukan ledger,
+dan balasannya bukan yang akan diterima `Read` sungguhan.
 
 **Kedua bentuk `Read` itu sama-sama sah dan keduanya mencapai tahap yang berbeda.** Muatan
 `Read` dengan `tool_response.content` polos tetap diterima dan sampai ke ledger, sedangkan

--- a/docs/website/src-id/reference/hooks.md
+++ b/docs/website/src-id/reference/hooks.md
@@ -110,3 +110,38 @@ echo '<json muatan host>' | omni --post-hook
 
 `omni exec` dan post-hook memilih rute yang berbeda, jadi hasil dari yang satu
 bukan bukti tentang yang lain.
+
+### Bentuk muatannya, dan ia berbeda per tool
+
+Salah bentuk gagal secara diam-diam dan seragam: hook keluar 0, tidak mencetak apa pun,
+dan sebuah probe membacanya sebagai `0.0% saved`. Tidak ada error untuk disadari, jadi
+distiller yang sebenarnya memotong 96% bisa dianggap tidak berjalan.
+
+`Bash` menaruh keluarannya langsung di `tool_response`:
+
+```json
+{ "session_id": "s1", "tool_name": "Bash",
+  "tool_input":    { "command": "cat server.log" },
+  "tool_response": { "content": "baris satu\nbaris dua\n" } }
+```
+
+`Read` membungkusnya di dalam `file`, dan kunci tambahannya bukan hiasan. `startLine`
+adalah titik hitung penomoran `cat -n` di sisi host, jadi fold yang membuang baris di atas
+baris yang selamat harus menggesernya:
+
+```json
+{ "session_id": "s1", "tool_name": "Read",
+  "tool_input":    { "path": "notes.txt" },
+  "tool_response": { "file": { "filePath": "notes.txt", "content": "...",
+                               "startLine": 1, "numLines": 40, "totalLines": 400 } } }
+```
+
+Balasannya mengikuti bentuk yang datang, di bawah `hookSpecificOutput.updatedToolOutput`.
+Claude Code memvalidasinya terhadap **skema keluaran milik tool itu sendiri**, jadi
+penulisan ulang `Bash` membawa `content` dan `Read` membawa `file.content`.
+
+**Kedua bentuk `Read` itu sama-sama sah dan keduanya mencapai tahap yang berbeda.** Muatan
+`Read` dengan `tool_response.content` polos tetap diterima dan sampai ke ledger, sedangkan
+`tool_response.file.content` sampai ke distiller `readfile` dan ke penyesuaian `startLine`.
+Tidak ada yang salah; keduanya menjawab pertanyaan berbeda. Probe yang membidik satu tapi
+dibangun di atas yang lain mengembalikan nol bersih dan tampak seperti sebuah kesimpulan.

--- a/docs/website/src/reference/hooks.md
+++ b/docs/website/src/reference/hooks.md
@@ -102,3 +102,38 @@ echo '<host payload json>' | omni --post-hook
 
 `omni exec` and the post-hook route differently, so a result from one is not evidence
 about the other.
+
+### The payload shape, which differs per tool
+
+Getting this wrong fails silently and identically: the hook exits 0, prints nothing, and a
+probe reads that as `0.0% saved`. There is no error to notice, so a distiller that is in
+fact cutting 96% can be written off as not firing.
+
+`Bash` puts the output at the top of `tool_response`:
+
+```json
+{ "session_id": "s1", "tool_name": "Bash",
+  "tool_input":    { "command": "cat server.log" },
+  "tool_response": { "content": "line one\nline two\n" } }
+```
+
+`Read` wraps it in `file`, and the extra keys are not decoration. `startLine` is what the
+host counts `cat -n` numbering from, so a fold that removes lines above the survivors has
+to move it:
+
+```json
+{ "session_id": "s1", "tool_name": "Read",
+  "tool_input":    { "path": "notes.txt" },
+  "tool_response": { "file": { "filePath": "notes.txt", "content": "...",
+                               "startLine": 1, "numLines": 40, "totalLines": 400 } } }
+```
+
+The reply mirrors whichever shape arrived, under `hookSpecificOutput.updatedToolOutput`.
+Claude Code validates it against **the host tool's own output schema**, so a `Bash`
+rewrite carries `content` and a `Read` rewrite carries `file.content`.
+
+**Both `Read` shapes are real and they reach different stages.** A `Read` payload written
+with a bare `tool_response.content` is accepted and reaches the ledger, while
+`tool_response.file.content` reaches the `readfile` distiller and the `startLine`
+adjustment. Neither is wrong; they answer different questions. A probe aimed at one and
+built on the other returns a clean nothing and looks like a verdict.

--- a/docs/website/src/reference/hooks.md
+++ b/docs/website/src/reference/hooks.md
@@ -128,9 +128,14 @@ to move it:
                                "startLine": 1, "numLines": 40, "totalLines": 400 } } }
 ```
 
-The reply mirrors whichever shape arrived, under `hookSpecificOutput.updatedToolOutput`.
-Claude Code validates it against **the host tool's own output schema**, so a `Bash`
-rewrite carries `content` and a `Read` rewrite carries `file.content`.
+The reply goes under `hookSpecificOutput.updatedToolOutput`, and Claude Code validates it
+against **the host tool's own output schema**. A wrapped `Read` gets a `file` reply back,
+which is the shape the host accepts.
+
+A bare `tool_response.content` does **not** get a bare reply. Verified rather than assumed:
+it comes back as `{status, result}`, which is OMNI's own shape and is what #187 was about.
+So the bare form is fine for asking what the ledger did, and its reply is not what a real
+`Read` would accept.
 
 **Both `Read` shapes are real and they reach different stages.** A `Read` payload written
 with a bare `tool_response.content` is accepted and reaches the ledger, while

--- a/src/cli/stats.rs
+++ b/src/cli/stats.rs
@@ -1765,6 +1765,36 @@ mod tests {
         }
     }
 
+    /// #589. The alignment test beside this one does not guard the unit: it
+    /// stayed green with the byte formatter replaced by raw digits, which is how
+    /// this hole was found. The period summary used to print a byte count over
+    /// 3.6 and call it tokens, so what needs pinning is that the column carries
+    /// a counted unit and not a derived one.
+    #[test]
+    fn the_period_summary_reports_bytes_and_not_a_derived_unit() {
+        let rows = [PeriodRow {
+            label: "Today",
+            count: 118,
+            raw_bytes: 137_000,
+            filtered_bytes: 74_000,
+            reduction_pct: 46.0,
+        }];
+
+        let line = format_period_rows(&rows).join("\n");
+
+        // 137,000 B is 133.8 KB by `format_bytes`, written out by hand from its
+        // rules rather than by calling it.
+        assert!(
+            line.contains("133.8 KB") && line.contains("72.3 KB"),
+            "the summary must print the bytes it counted: {line}"
+        );
+        assert!(
+            !line.contains("tokens"),
+            "the summary went back to a unit calibrated against another vendor's \
+             tokenizer: {line}"
+        );
+    }
+
     #[test]
     fn aligns_period_columns_across_mixed_number_widths() {
         // Arrange: the widths that broke the old hardcoded layout, a 3-digit

--- a/src/cli/stats.rs
+++ b/src/cli/stats.rs
@@ -1192,7 +1192,7 @@ fn run_detail(args: &[String], store: &Store) -> Result<()> {
             "Agent".bright_black(),
             "Count".bright_black(),
             "Saved".bright_black(),
-            "Tokens".bright_black(),
+            "Saved".bright_black(),
             "Signal".bright_black(),
             w_cmd = CMD_KEY_WIDTH
         );
@@ -1444,7 +1444,10 @@ pub struct CommandStat {
     pub command: String,
     pub count: u64,
     pub savings_pct: f64,
-    pub tokens_saved: u64,
+    /// Bytes, and named for it since #589. It briefly held bytes under the old
+    /// name, which is a machine-readable surface asserting the wrong unit, and
+    /// that is the defect this issue is about rather than a cosmetic one.
+    pub bytes_saved: u64,
 }
 
 #[derive(serde::Serialize)]
@@ -1512,7 +1515,7 @@ fn run_json(store: &Store) -> Result<()> {
             command: cmd.clone(),
             count: *count,
             savings_pct: *pct,
-            tokens_saved: *bytes_saved,
+            bytes_saved: *bytes_saved,
         })
         .collect();
 

--- a/src/cli/stats.rs
+++ b/src/cli/stats.rs
@@ -63,8 +63,12 @@ fn format_number(n: u64) -> String {
 struct PeriodRow<'a> {
     label: &'a str,
     count: u64,
-    raw_tokens: u64,
-    filtered_tokens: u64,
+    /// Bytes, which `distillations` counts exactly. This column used to hold a
+    /// token figure that was these same bytes over 3.6, a constant calibrated
+    /// against `cl100k_base` (#589). The percentage beside it is unaffected
+    /// either way, since the divisor cancels in a ratio.
+    raw_bytes: u64,
+    filtered_bytes: u64,
     reduction_pct: f64,
 }
 
@@ -76,13 +80,10 @@ struct PeriodRow<'a> {
 fn format_period_rows(rows: &[PeriodRow<'_>]) -> Vec<String> {
     let labels: Vec<String> = rows.iter().map(|r| format!("{}:", r.label)).collect();
     let counts: Vec<String> = rows.iter().map(|r| format_number(r.count)).collect();
-    let inputs: Vec<String> = rows
-        .iter()
-        .map(|r| format_exact_tokens(r.raw_tokens))
-        .collect();
+    let inputs: Vec<String> = rows.iter().map(|r| format_bytes(r.raw_bytes)).collect();
     let outputs: Vec<String> = rows
         .iter()
-        .map(|r| format_exact_tokens(r.filtered_tokens))
+        .map(|r| format_bytes(r.filtered_bytes))
         .collect();
 
     let w_label = max_width(&labels).max(12);
@@ -102,7 +103,7 @@ fn format_period_rows(rows: &[PeriodRow<'_>]) -> Vec<String> {
                 pct.bright_red()
             };
             format!(
-                "  {:<w_label$} {:>w_count$} commands │ {:>w_in$} → {:<w_out$} tokens │  {}",
+                "  {:<w_label$} {:>w_count$} commands │ {:>w_in$} → {:<w_out$} │  {}",
                 labels[i].as_str().bright_white().bold(),
                 counts[i].as_str().cyan(),
                 inputs[i].as_str().red(),
@@ -162,23 +163,14 @@ pub(crate) fn group_and_calculate_stats(
                 0.0
             };
 
-            let tokens_saved = if raw_tok > 0 {
-                raw_tok.saturating_sub(filt_tok)
-            } else if input > 0 {
-                let r = crate::util::token_estimate::estimate_tokens(
-                    input as usize,
-                    crate::util::token_estimate::ContentHint::Mixed,
-                );
-                let f = crate::util::token_estimate::estimate_tokens(
-                    output as usize,
-                    crate::util::token_estimate::ContentHint::Mixed,
-                );
-                r.saturating_sub(f) as u64
-            } else {
-                0
-            };
+            // #589. Bytes, counted. This was the token columns when they were
+            // present and an `estimate_tokens` call over these same bytes when
+            // they were not, so both arms produced the same quantity over 3.6, a
+            // constant calibrated against `cl100k_base`. The subtraction is the
+            // whole of it now, and the fallback disappears with the estimator.
+            let bytes_saved = input.saturating_sub(output);
 
-            (cmd, calls, pct, tokens_saved)
+            (cmd, calls, pct, bytes_saved)
         })
         .collect();
 
@@ -310,7 +302,7 @@ fn has(args: &[String], names: &[&str]) -> bool {
 
 fn print_help() {
     println!(
-        "\n{} {}: Token savings analytics",
+        "\n{} {}: Savings analytics",
         "omni".bold().cyan(),
         "stats".bold().yellow()
     );
@@ -411,21 +403,31 @@ fn run_context_stats(store: &Store) -> Result<()> {
             "Commands (Turns):".bright_black(),
             format_number(session.command_count as u64).cyan()
         );
-        println!("\n  {}", "Token Breakdown:".bold().bright_white());
+        // #589. The rest of this report moved to counted bytes. This block
+        // cannot: `pre_tool.rs:188` accumulates `size_bytes / 4` from file
+        // metadata, so there is no measured byte total behind it and a fourth
+        // of a file's size is not a Claude token count. Labelled rather than
+        // converted, and the label is the whole fix here.
         println!(
-            "    {:<25} {} tokens",
+            "\n  {}",
+            "Token Breakdown (rough estimate, bytes over 4):"
+                .bold()
+                .bright_white()
+        );
+        println!(
+            "    {:<25} ~{} tokens",
             "File Reads:".bright_black(),
             format_exact_tokens(turn.file_read_tokens).yellow()
         );
         println!(
-            "    {:<25} {} tokens",
+            "    {:<25} ~{} tokens",
             "Tool Outputs:".bright_black(),
             format_exact_tokens(turn.tool_output_tokens).green()
         );
 
         let est_total = turn.file_read_tokens + turn.tool_output_tokens;
         println!(
-            "\n  {:<27} {} tokens",
+            "\n  {:<27} ~{} tokens",
             "Estimated Context Total:".bold().bright_white(),
             format_exact_tokens(est_total).bright_cyan()
         );
@@ -881,15 +883,12 @@ fn run_default(store: &Store) -> Result<()> {
         .iter()
         .filter(|(label, count, ..)| *count > 0 || label == "All Time")
         .map(
-            |(label, count, input, output, raw_tokens, filtered_tokens)| PeriodRow {
+            |(label, count, input, output, _raw_tokens, _filtered_tokens)| PeriodRow {
                 label,
                 count: *count,
-                raw_tokens: *raw_tokens,
-                filtered_tokens: *filtered_tokens,
-                reduction_pct: if *raw_tokens > 0 {
-                    100.0 * (1.0 - *filtered_tokens as f64 / *raw_tokens as f64)
-                } else if *input > 0 {
-                    // Fallback for legacy records that haven't been backfilled properly
+                raw_bytes: *input,
+                filtered_bytes: *output,
+                reduction_pct: if *input > 0 {
                     100.0 * (1.0 - *output as f64 / *input as f64)
                 } else {
                     0.0
@@ -939,7 +938,7 @@ fn run_default(store: &Store) -> Result<()> {
                 .iter()
                 .map(|(_, count, _, _)| count.to_string()),
         );
-        for (cmd, count, pct, tokens_saved) in &top_commands {
+        for (cmd, count, pct, bytes_saved) in &top_commands {
             let short_cmd = shorten_command(cmd, 18);
             let bar = format_bar_with_empty(*pct);
             let bar_colored = if *pct > 80.0 {
@@ -950,8 +949,8 @@ fn run_default(store: &Store) -> Result<()> {
                 bar.bright_red()
             };
 
-            let tokens_str = if *tokens_saved > 0 {
-                format!("(-{} tokens)", format_exact_tokens(*tokens_saved)).bright_black()
+            let tokens_str = if *bytes_saved > 0 {
+                format!("(-{})", format_bytes(*bytes_saved)).bright_black()
             } else {
                 "".bright_black()
             };
@@ -1202,7 +1201,7 @@ fn run_detail(args: &[String], store: &Store) -> Result<()> {
             super::column_rule(&[3, CMD_KEY_WIDTH, 11, 5, 6, 6, DETAIL_BAR]).bright_black()
         );
 
-        for (i, (name, cnt, pct, tokens_saved)) in display_filters.iter().enumerate() {
+        for (i, (name, cnt, pct, bytes_saved)) in display_filters.iter().enumerate() {
             let bar = format_bar(*pct, DETAIL_BAR);
             let bar_colored = if *pct > 80.0 {
                 bar.bright_green()
@@ -1229,8 +1228,8 @@ fn run_detail(args: &[String], store: &Store) -> Result<()> {
                 // already says why those two facts must not be folded (#471).
                 .unwrap_or("Unknown");
 
-            let tokens_str = if *tokens_saved > 0 {
-                format!("-{}", format_exact_tokens(*tokens_saved))
+            let tokens_str = if *bytes_saved > 0 {
+                format!("-{}", format_bytes(*bytes_saved))
             } else {
                 String::new()
             };
@@ -1509,11 +1508,11 @@ fn run_json(store: &Store) -> Result<()> {
 
     let commands_json: Vec<CommandStat> = top_commands
         .iter()
-        .map(|(cmd, count, pct, tokens_saved)| CommandStat {
+        .map(|(cmd, count, pct, bytes_saved)| CommandStat {
             command: cmd.clone(),
             count: *count,
             savings_pct: *pct,
-            tokens_saved: *tokens_saved,
+            tokens_saved: *bytes_saved,
         })
         .collect();
 
@@ -1774,22 +1773,22 @@ mod tests {
             PeriodRow {
                 label: "Today",
                 count: 118,
-                raw_tokens: 137_000,
-                filtered_tokens: 74_000,
+                raw_bytes: 137_000,
+                filtered_bytes: 74_000,
                 reduction_pct: 46.2,
             },
             PeriodRow {
                 label: "This Week",
                 count: 1_218,
-                raw_tokens: 10_200_000,
-                filtered_tokens: 647_000,
+                raw_bytes: 10_200_000,
+                filtered_bytes: 647_000,
                 reduction_pct: 93.6,
             },
             PeriodRow {
                 label: "All Time",
                 count: 5_047,
-                raw_tokens: 21_200_000,
-                filtered_tokens: 4_800_000,
+                raw_bytes: 21_200_000,
+                filtered_bytes: 4_800_000,
                 reduction_pct: 77.2,
             },
         ];
@@ -1798,7 +1797,8 @@ mod tests {
         let lines = format_period_rows(&rows);
 
         // Assert: every row starts its labels at the same offset.
-        for word in ["commands", "tokens", "saved"] {
+        // `tokens` left this line with #589; the columns it aligned are still here.
+        for word in ["commands", "saved"] {
             let offsets: Vec<_> = lines
                 .iter()
                 .map(|l| l.find(word).unwrap_or_else(|| panic!("{word} missing")))

--- a/src/hooks/normalize.rs
+++ b/src/hooks/normalize.rs
@@ -749,6 +749,39 @@ fn normalize_tool_name(name: &str) -> String {
 }
 
 #[cfg(test)]
+mod read_payload_shapes_586 {
+    use super::*;
+
+    /// #586. `reference/hooks.md` tells the reader that a `Read` payload has two
+    /// real shapes, a bare `tool_response.content` and a wrapped
+    /// `tool_response.file.content`, and that getting it wrong fails silently
+    /// with a clean `0.0% saved` rather than an error. That page is only worth
+    /// having while both shapes really do parse, so both are asserted here.
+    #[test]
+    fn both_documented_read_shapes_carry_their_content() {
+        let bare = r#"{"session_id":"s1","tool_name":"Read",
+            "tool_input":{"path":"notes.txt"},
+            "tool_response":{"content":"line one\nline two\n"}}"#;
+        let wrapped = r#"{"session_id":"s1","tool_name":"Read",
+            "tool_input":{"path":"notes.txt"},
+            "tool_response":{"file":{"filePath":"notes.txt",
+                "content":"line one\nline two\n","startLine":1,
+                "numLines":2,"totalLines":400}}}"#;
+
+        for (label, payload) in [("bare", bare), ("wrapped", wrapped)] {
+            let n = normalize(payload)
+                .unwrap_or_else(|| panic!("the {label} Read shape did not normalize at all"));
+            assert!(
+                n.content.contains("line one"),
+                "the {label} Read shape parsed but lost its content, which is the \
+                 failure the manual warns reads as 0.0% saved: {:?}",
+                n.content
+            );
+        }
+    }
+}
+
+#[cfg(test)]
 mod tests {
     /// A snake_case tool name has to reach the same arm as its PascalCase twin
     /// (#488).

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -3478,6 +3478,57 @@ src/distillers/system_ops.rs:849:                is_sensitive_key(key),
         );
     }
 
+    /// #586, review on #594. The hooks page first said the reply mirrors whatever
+    /// shape arrived. That is true for the wrapped `Read` and false for the bare
+    /// one, which comes back in OMNI's own `{status, result}` shape. I asserted
+    /// it after testing only the request side, which is the exact failure #187
+    /// is about: a contract crossed and checked on one side.
+    ///
+    /// Pinned here so the corrected sentence cannot drift from the code again.
+    #[test]
+    fn each_read_shape_gets_the_reply_the_manual_promises() {
+        let body: String = (0..200)
+            .map(|i| format!("2026-08-12T00:00:00Z  handler finished request {i} in 12ms\n"))
+            .collect();
+        let reply_keys = |wrapped: bool| {
+            let response = if wrapped {
+                json!({"file": {"filePath": "notes.txt", "content": body,
+                                "startLine": 1, "numLines": 200, "totalLines": 200}})
+            } else {
+                json!({"content": body})
+            };
+            let payload = json!({
+                "session_id": "shape-586",
+                "tool_name": "Read",
+                "tool_input": {"path": "notes.txt"},
+                "tool_response": response,
+            })
+            .to_string();
+
+            let dir = tempfile::tempdir().expect("tempdir");
+            let store = Arc::new(Store::open_path(&dir.path().join("omni.db")).expect("store"));
+            let _ = process_payload(&payload, Some(store.clone()), None);
+            let out = process_payload(&payload, Some(store.clone()), None).unwrap_or_default();
+            let v: serde_json::Value = serde_json::from_str(&out).unwrap_or(json!({}));
+            let updated = v["hookSpecificOutput"]["updatedToolOutput"].clone();
+            updated
+                .as_object()
+                .map(|o| o.keys().cloned().collect::<Vec<_>>())
+                .unwrap_or_default()
+        };
+
+        assert_eq!(
+            reply_keys(true),
+            vec!["file".to_string()],
+            "a wrapped Read must come back in the host's own shape"
+        );
+        let bare = reply_keys(false);
+        assert!(
+            bare.contains(&"result".to_string()) && !bare.contains(&"file".to_string()),
+            "the manual now says a bare Read replies in OMNI's shape, got {bare:?}"
+        );
+    }
+
     /// #557, review. An earlier guard read the output back and called any line
     /// starting with `[OMNI:` a marker, so a file whose own lines start that way
     /// defeated it. This repository writes those strings into its changelog and


### PR DESCRIPTION
Two issues in one branch, one CI cycle. They are the same defect on two surfaces: a figure presented as measured when it is derived, and a page that tells you to send something without saying what.

## #589, the report surface

`omni stats` reported in bytes over 3.6, a constant calibrated against `cl100k_base`. #592 fixed the hook banner; this is the report.

```
before   Today:   748 commands │  130K → 121K tokens │  7.0% saved
after    Today:   748 commands │ 533.7 KB → 496.5 KB │  7.0% saved
```

The per-command and per-filter annotations moved with it. `group_and_calculate_stats` feeds both paths, so one function carried the whole conversion and the two consumers only needed their bindings renamed to the unit they were already holding. Percentages are untouched: the divisor cancels in a ratio.

**One block did not move, and says so.** The context breakdown accumulates `size_bytes / 4` from file metadata at `pre_tool.rs:188`, a different and rougher estimator than the one this issue is about, and there is no measured byte total behind it. It is now titled `Token Breakdown (rough estimate, bytes over 4)` and prints `~`. Labelling was the honest option there rather than inventing a conversion.

## #586, the hooks page

The page told the reader to feed `omni --post-hook` a payload and never said what one looks like. Getting it wrong exits 0, prints nothing, and reads as `0.0% saved`, so there is no error to notice.

Both shapes are documented in both languages, including the pair that is genuinely surprising: **a `Read` payload has two real shapes that reach different stages.** A bare `tool_response.content` is accepted and reaches the ledger; `tool_response.file.content` reaches the `readfile` distiller and the `startLine` adjustment. Neither is wrong. That pair cost an hour on 2026-08-17 and briefly had the readfile distiller written off as not firing on Rust files.

A test asserts both shapes still carry their content, so the page cannot quietly stop being true.

## Verified by breaking it

| break | test | result |
| --- | --- | --- |
| make the bare `Read` shape stop parsing | `both_documented_read_shapes_carry_their_content` | red, `the bare Read shape did not normalize at all` |
| put a derived unit back in the summary | `the_period_summary_reports_bytes_and_not_a_derived_unit` | red, `34K → 72.3 KB`, the mixed-unit line it exists to prevent |

The second test exists **because** a break-test found it missing. Swapping `format_bytes` for raw digits left the existing alignment test green, which showed it guards column widths and not the unit, so the conversion had nothing holding it.

`make fmt clippy test security binary-check` all green, 1,756 tests, smoke 46/46.

## Also measured, on #585

`Glob` has zero calls across 120 host transcripts holding 17.86 MB of `tool_result`, verified against a raw grep that finds 132 `Grep` occurrences and 0 `Glob`. Widening the matcher would compress nothing anyone here produces, so that issue is a recommend-close with the number on it rather than a change in this branch.

Closes #586
Refs #589

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR replaces derived token figures on applicable stats surfaces with counted byte figures and documents the accepted hook payload and response shapes in both languages.
- Reports period and per-command savings using formatted byte counts.
- Renames the JSON command-savings field to `bytes_saved`.
- Clarifies bare and wrapped `Read` payload behavior and adds regression coverage for both request and response shapes.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/cli/stats.rs | Converts applicable human-readable command and period savings to counted bytes and exposes command JSON savings as `bytes_saved`; the previously reported unit defects are corrected. |
| docs/website/src/reference/hooks.md | Correctly distinguishes wrapped Read host replies from the OMNI-shaped reply produced for bare diagnostic payloads. |
| docs/website/src-id/reference/hooks.md | Mirrors the corrected Read payload and response-shape guidance in Indonesian. |
| src/hooks/normalize.rs | Adds coverage confirming that both documented Read request shapes preserve their content during normalization. |
| src/hooks/post_tool.rs | Adds coverage confirming wrapped and bare Read payloads receive the response shapes promised by the documentation. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Hook payload] --> B{Read response shape}
  B -->|tool_response.file.content| C[Read distiller and startLine adjustment]
  B -->|tool_response.content| D[Ledger path]
  C --> E[file-shaped updatedToolOutput]
  D --> F[status/result updatedToolOutput]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(stats): finish the unit rename, and ..."](https://github.com/fajarhide/omni/commit/9795c51a183788cff964f62e30caac54c532afc9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53900661)</sub>

<!-- /greptile_comment -->