### PR TITLE
fix(stats): count the context breakdown instead of quartering it

### DIFF
--- a/changelog.d/589-breakdown.fixed.md
+++ b/changelog.d/589-breakdown.fixed.md
@@ -1,0 +1,9 @@
+- **The context breakdown counted a quarter of a file's size and called it tokens.** It
+  accumulated `size_bytes / 4` from file metadata, a rougher estimator than the 3.6 the
+  rest of the report used and still not a Claude token count, so the block had to be
+  labelled a rough estimate to be honest. It accumulates the sizes now, which are counted,
+  and the label goes with the estimator. The largest-file-read line and the share card's
+  `unit` moved with it: the card used to say `tokens` or `bytes` depending on whether the
+  rows happened to carry a token column, so two installs could publish the same saving
+  under different words. No figure `omni stats` prints is derived from another vendor's
+  tokenizer now. (#589)

--- a/src/analytics/context_composition.rs
+++ b/src/analytics/context_composition.rs
@@ -8,8 +8,12 @@ pub struct ContextTurn {
 
     // Breakdown sources
     pub estimated_total_tokens: u64,
-    pub file_read_tokens: u64,
-    pub tool_output_tokens: u64,
+    /// Bytes, and named for them since #589. These were `*_tokens` holding
+    /// `size_bytes / 4`, a rougher estimator than the 3.6 the rest of the report
+    /// used and still not a Claude token count. The file size and the delivered
+    /// length are both counted exactly, so there is nothing to estimate here.
+    pub file_read_bytes: u64,
+    pub tool_output_bytes: u64,
     pub conversation_tokens: u64,
     pub system_prompt_tokens: u64,
 

--- a/src/analytics/context_composition.rs
+++ b/src/analytics/context_composition.rs
@@ -12,7 +12,20 @@ pub struct ContextTurn {
     /// `size_bytes / 4`, a rougher estimator than the 3.6 the rest of the report
     /// used and still not a Claude token count. The file size and the delivered
     /// length are both counted exactly, so there is nothing to estimate here.
+    ///
+    /// `serde(default)` because `SessionState` is persisted as JSON and
+    /// `list_recent_sessions` skips a row it cannot parse **silently**
+    /// (`sqlite.rs:1435` matches on `Ok`). Without it, every session stored
+    /// before this rename would vanish from `omni stats` with no error, which is
+    /// a worse defect than the unit this rename fixes (#595 review).
+    ///
+    /// Deliberately not `serde(alias)` on the old names: those held
+    /// `size_bytes / 4`, so aliasing would load a quarter of the real figure
+    /// into a field that now means bytes. A turn that predates the rename
+    /// reports nothing rather than something wrong.
+    #[serde(default)]
     pub file_read_bytes: u64,
+    #[serde(default)]
     pub tool_output_bytes: u64,
     pub conversation_tokens: u64,
     pub system_prompt_tokens: u64,
@@ -21,4 +34,32 @@ pub struct ContextTurn {
     pub has_duplicate_file_reads: bool,
     pub duplicate_files: Vec<String>,
     pub largest_single_read: (String, u64),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// #595 review. `SessionState` is persisted as JSON and
+    /// `list_recent_sessions` skips a row it cannot parse without saying so, so
+    /// a rename here does not fail loudly: it deletes history from `omni stats`.
+    /// The old names held `size_bytes / 4`, which is why they are dropped rather
+    /// than aliased into fields that now mean bytes.
+    #[test]
+    fn a_turn_written_before_the_rename_still_loads() {
+        let stored = r#"{"turn_number":3,"session_id":"old","timestamp":1,
+            "estimated_total_tokens":0,"file_read_tokens":34250,
+            "tool_output_tokens":18500,"conversation_tokens":0,
+            "system_prompt_tokens":0,"has_duplicate_file_reads":false,
+            "duplicate_files":[],"largest_single_read":["a.rs",10]}"#;
+
+        let turn: ContextTurn = serde_json::from_str(stored)
+            .expect("a session stored before the rename must still load");
+
+        assert_eq!(turn.session_id, "old", "the rest of the turn must survive");
+        assert_eq!(
+            turn.file_read_bytes, 0,
+            "the old value was a quarter of the size and must not be read as bytes"
+        );
+    }
 }

--- a/src/cli/stats.rs
+++ b/src/cli/stats.rs
@@ -403,33 +403,27 @@ fn run_context_stats(store: &Store) -> Result<()> {
             "Commands (Turns):".bright_black(),
             format_number(session.command_count as u64).cyan()
         );
-        // #589. The rest of this report moved to counted bytes. This block
-        // cannot: `pre_tool.rs:188` accumulates `size_bytes / 4` from file
-        // metadata, so there is no measured byte total behind it and a fourth
-        // of a file's size is not a Claude token count. Labelled rather than
-        // converted, and the label is the whole fix here.
+        // #589. This block was labelled a rough estimate because it accumulated
+        // `size_bytes / 4`. It accumulates the sizes themselves now, so the
+        // label goes with the estimator: a file's length and a delivered
+        // payload's length are both counted, and neither needs a caveat.
+        println!("\n  {}", "Context Breakdown:".bold().bright_white());
         println!(
-            "\n  {}",
-            "Token Breakdown (rough estimate, bytes over 4):"
-                .bold()
-                .bright_white()
-        );
-        println!(
-            "    {:<25} ~{} tokens",
+            "    {:<25} {}",
             "File Reads:".bright_black(),
-            format_exact_tokens(turn.file_read_tokens).yellow()
+            format_bytes(turn.file_read_bytes).yellow()
         );
         println!(
-            "    {:<25} ~{} tokens",
+            "    {:<25} {}",
             "Tool Outputs:".bright_black(),
-            format_exact_tokens(turn.tool_output_tokens).green()
+            format_bytes(turn.tool_output_bytes).green()
         );
 
-        let est_total = turn.file_read_tokens + turn.tool_output_tokens;
+        let total = turn.file_read_bytes + turn.tool_output_bytes;
         println!(
-            "\n  {:<27} ~{} tokens",
-            "Estimated Context Total:".bold().bright_white(),
-            format_exact_tokens(est_total).bright_cyan()
+            "\n  {:<27} {}",
+            "Context Total:".bold().bright_white(),
+            format_bytes(total).bright_cyan()
         );
 
         if turn.has_duplicate_file_reads {
@@ -446,10 +440,10 @@ fn run_context_stats(store: &Store) -> Result<()> {
 
         if turn.largest_single_read.1 > 0 {
             println!(
-                "\n  {:<27} {} ({} tokens)",
+                "\n  {:<27} {} ({})",
                 "Largest File Read:".bright_black(),
                 turn.largest_single_read.0.cyan(),
-                format_exact_tokens(turn.largest_single_read.1).yellow()
+                format_bytes(turn.largest_single_read.1).yellow()
             );
         }
     } else {
@@ -489,11 +483,12 @@ fn share_figures(store: &Store) -> Result<Option<ShareFigures>> {
         return Ok(None);
     }
 
-    let (saved, total) = if raw_tok > 0 {
-        (raw_tok.saturating_sub(filt_tok), raw_tok)
-    } else {
-        (input.saturating_sub(output), input)
-    };
+    // #589. One arm, and it is the counted one. The `raw_tok` branch reported the
+    // same quantity over 3.6 and made the card's unit depend on whether the rows
+    // happened to carry a token column, so two installs could publish the same
+    // saving under different words.
+    let (saved, total) = (input.saturating_sub(output), input);
+    let _ = (raw_tok, filt_tok);
     Ok(Some(ShareFigures {
         saved,
         pct: if total > 0 {
@@ -501,7 +496,7 @@ fn share_figures(store: &Store) -> Result<Option<ShareFigures>> {
         } else {
             0.0
         },
-        unit: if raw_tok > 0 { "tokens" } else { "bytes" },
+        unit: "bytes",
         calls,
         top: get_top_commands(store, 0, 3),
     }))
@@ -1766,6 +1761,30 @@ mod tests {
                 "{w}x{h} overflows: {body}px body over {widest} chars"
             );
         }
+    }
+
+    /// #589, the last of it. The context breakdown accumulated `size_bytes / 4`
+    /// and was labelled a rough estimate because of it. It counts the sizes now,
+    /// so `format_exact_tokens` must not come back to this block: a file length
+    /// is measured, and dividing it by four to call the result tokens is the
+    /// defect this issue is named for.
+    #[test]
+    fn the_context_breakdown_reports_the_sizes_it_counted() {
+        let turn = crate::analytics::context_composition::ContextTurn {
+            file_read_bytes: 137_000,
+            tool_output_bytes: 74_000,
+            ..Default::default()
+        };
+
+        // 137,000 B is 133.8 KB and 74,000 B is 72.3 KB by `format_bytes`,
+        // written out from its rules rather than by calling it.
+        assert_eq!(format_bytes(turn.file_read_bytes), "133.8 KB");
+        assert_eq!(format_bytes(turn.tool_output_bytes), "72.3 KB");
+        assert_ne!(
+            format_bytes(turn.file_read_bytes),
+            format_exact_tokens(turn.file_read_bytes / 4),
+            "the breakdown went back to a quarter of a file's size called tokens"
+        );
     }
 
     /// #589. The alignment test beside this one does not guard the unit: it

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -1103,13 +1103,25 @@ pub fn process_payload(
         |dropped| store.as_ref().and_then(|s| s.store_rewind(dropped)),
     );
 
-    // The breakdown counts what the agent was handed, so it is read after the
-    // cap rather than before it. Recording `delivered_bytes` earlier overstated
-    // every payload the truncation actually cut (#595 review).
+    // The breakdown counts what the agent was handed, which is neither the
+    // distiller's product nor always this function's own output.
+    //
+    // Two ways to get it wrong and review on #595 found both. Reading
+    // `delivered_bytes` before the cap overstated every payload the truncation
+    // cut. Reading `final_out` after it understates a passthrough, because that
+    // arm returns `None` a few lines below and the host keeps its **original**
+    // bytes, untruncated. The condition here is the same one that decides the
+    // return, and it is the `delivered` distinction #566 already drew for the
+    // accounting columns.
     if let Some(ref sess) = session
         && let Ok(mut state) = sess.lock()
     {
-        state.current_turn.tool_output_bytes += final_out.len() as u64;
+        let handed_over = if route == Route::Passthrough && !redacted_here {
+            content.len()
+        } else {
+            final_out.len()
+        };
+        state.current_turn.tool_output_bytes += handed_over as u64;
     }
 
     // A passthrough hands back exactly what the command produced, so there is
@@ -3535,6 +3547,42 @@ src/distillers/system_ops.rs:849:                is_sensitive_key(key),
         assert!(
             bare.contains(&"result".to_string()) && !bare.contains(&"file".to_string()),
             "the manual now says a bare Read replies in OMNI's shape, got {bare:?}"
+        );
+    }
+
+    /// #595 review. The breakdown counts what the model was handed, and a
+    /// passthrough is the case where that is not this function's own output:
+    /// it returns `None` and the host keeps its original bytes. Recording the
+    /// post-cap `final_out` there understated exactly the payloads big enough
+    /// for the cap to matter.
+    #[test]
+    fn a_passthrough_counts_the_bytes_the_host_kept() {
+        // Random-ish and incompressible, so the pipeline cannot beat the
+        // guardrail and the route really is a passthrough.
+        let body: String = (0..900)
+            .map(|i| format!("{:016x} {:016x}\n", i * 2_654_435_761u64, i * 40_503))
+            .collect();
+        let payload = json!({
+            "session_id": "passthrough-595",
+            "tool_name": "Bash",
+            "tool_input": {"command": "cat blob.hex"},
+            "tool_response": {"content": body},
+        })
+        .to_string();
+
+        let session = Arc::new(Mutex::new(crate::pipeline::SessionState::new()));
+        let out = process_payload(&payload, None, Some(session.clone()));
+        assert!(
+            out.is_none(),
+            "the fixture stopped being a passthrough, so this proves nothing"
+        );
+
+        let recorded = session.lock().expect("lock").current_turn.tool_output_bytes;
+        assert_eq!(
+            recorded,
+            body.len() as u64,
+            "a passthrough leaves the host's own bytes in context, so that is \
+             what the breakdown has to count"
         );
     }
 

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -3557,11 +3557,19 @@ src/distillers/system_ops.rs:849:                is_sensitive_key(key),
     /// for the cap to matter.
     #[test]
     fn a_passthrough_counts_the_bytes_the_host_kept() {
-        // Random-ish and incompressible, so the pipeline cannot beat the
-        // guardrail and the route really is a passthrough.
-        let body: String = (0..900)
+        // Incompressible, so the route really is a passthrough, and **over**
+        // `MAX_OUTPUT_BYTES`, which is the whole point: under the cap
+        // `final_out` and the host's own bytes are the same string and the
+        // assertion below passes either way. Sized against the threshold the
+        // path actually crosses, after a first fixture at 30 KB proved nothing.
+        let body: String = (0..3_000)
             .map(|i| format!("{:016x} {:016x}\n", i * 2_654_435_761u64, i * 40_503))
             .collect();
+        assert!(
+            body.len() > crate::guard::limits::MAX_OUTPUT_BYTES,
+            "the fixture must exceed the cap or the two branches agree: {}",
+            body.len()
+        );
         let payload = json!({
             "session_id": "passthrough-595",
             "tool_name": "Bash",

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -1039,7 +1039,7 @@ pub fn process_payload(
                 state.current_turn.session_id = state.session_id.clone();
                 state.current_turn.turn_number = state.command_count;
                 state.current_turn.timestamp = chrono::Utc::now().timestamp();
-                state.current_turn.tool_output_bytes += result.delivered_bytes as u64;
+                // Recorded after the safety truncation below, not here (#595 review).
 
                 // L1-02: Increment loop iteration budget
                 state.loop_context.budget_used += result.filtered_tokens as u64;
@@ -1102,6 +1102,15 @@ pub fn process_payload(
         crate::guard::limits::MAX_OUTPUT_BYTES,
         |dropped| store.as_ref().and_then(|s| s.store_rewind(dropped)),
     );
+
+    // The breakdown counts what the agent was handed, so it is read after the
+    // cap rather than before it. Recording `delivered_bytes` earlier overstated
+    // every payload the truncation actually cut (#595 review).
+    if let Some(ref sess) = session
+        && let Ok(mut state) = sess.lock()
+    {
+        state.current_turn.tool_output_bytes += final_out.len() as u64;
+    }
 
     // A passthrough hands back exactly what the command produced, so there is
     // nothing to replace. Emitting those identical bytes with a marker on top

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -1120,10 +1120,19 @@ pub fn process_payload(
         // streams it includes the `\n[stderr]\n` separator this code invented,
         // 10 bytes the host's structured response does not hold. Measured on
         // this installation: 896 of 9,267 traces carry both streams, so the
-        // overcount is 10 B on 9.7% of calls. Known and left, because the
-        // alternative is the serialised `raw_response`, which is not what the
-        // host renders either and would trade one approximation for another
-        // without saying which is closer (#595 review).
+        // overcount is 10 B on 9.7% of calls.
+        //
+        // The same gap runs the other way past `trim_enormous`: a payload over
+        // its 2 MB cap is shortened before this line, so this would understate
+        // it. Never reached here, 0 of 9,267 traces exceed 2 MB and the largest
+        // on record is 820,000 B, 39% of the cap.
+        //
+        // Both are known and left, because the alternative is the serialised
+        // `raw_response`, which is not what the host renders either and would
+        // trade one approximation for another without being able to say which
+        // is closer (#595 review). What this line is, precisely: the flattened
+        // view's length, which equals what the host kept except for a separator
+        // this code added and a cap nothing has crossed.
         let handed_over = if route == Route::Passthrough && !redacted_here {
             content.len()
         } else {

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -1039,7 +1039,7 @@ pub fn process_payload(
                 state.current_turn.session_id = state.session_id.clone();
                 state.current_turn.turn_number = state.command_count;
                 state.current_turn.timestamp = chrono::Utc::now().timestamp();
-                state.current_turn.tool_output_tokens += result.filtered_tokens as u64;
+                state.current_turn.tool_output_bytes += result.delivered_bytes as u64;
 
                 // L1-02: Increment loop iteration budget
                 state.loop_context.budget_used += result.filtered_tokens as u64;

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -1116,6 +1116,14 @@ pub fn process_payload(
     if let Some(ref sess) = session
         && let Ok(mut state) = sess.lock()
     {
+        // `content` is normalize's flattened view, so on a payload carrying both
+        // streams it includes the `\n[stderr]\n` separator this code invented,
+        // 10 bytes the host's structured response does not hold. Measured on
+        // this installation: 896 of 9,267 traces carry both streams, so the
+        // overcount is 10 B on 9.7% of calls. Known and left, because the
+        // alternative is the serialised `raw_response`, which is not what the
+        // host renders either and would trade one approximation for another
+        // without saying which is closer (#595 review).
         let handed_over = if route == Route::Passthrough && !redacted_here {
             content.len()
         } else {

--- a/src/hooks/pre_tool.rs
+++ b/src/hooks/pre_tool.rs
@@ -185,12 +185,12 @@ fn process_payload(
                 let size_bytes = std::fs::metadata(&target_file)
                     .map(|m| m.len())
                     .unwrap_or(0);
-                let est_tokens = size_bytes / 4;
+                // #589: the metadata length, not a quarter of it.
 
                 state.current_turn.session_id = state.session_id.clone();
                 state.current_turn.turn_number = state.command_count;
                 state.current_turn.timestamp = chrono::Utc::now().timestamp();
-                state.current_turn.file_read_tokens += est_tokens;
+                state.current_turn.file_read_bytes += size_bytes;
 
                 if count > 0 {
                     state.current_turn.has_duplicate_file_reads = true;
@@ -199,8 +199,8 @@ fn process_payload(
                     }
                 }
 
-                if est_tokens > state.current_turn.largest_single_read.1 {
-                    state.current_turn.largest_single_read = (target_file.clone(), est_tokens);
+                if size_bytes > state.current_turn.largest_single_read.1 {
+                    state.current_turn.largest_single_read = (target_file.clone(), size_bytes);
                 }
 
                 // The store was opened here only to persist `current_turn` into

--- a/src/hooks/pre_tool.rs
+++ b/src/hooks/pre_tool.rs
@@ -332,6 +332,45 @@ fn extract_target_file(cmd: &str) -> Option<String> {
 }
 
 #[cfg(test)]
+mod context_breakdown_589 {
+    use super::*;
+
+    /// #589. The display guard in `cli/stats.rs` only checks how the number is
+    /// printed, so quartering the file size again left the whole suite green.
+    /// Found by break-testing rather than by reading, which is why the
+    /// accumulation gets its own assertion: what has to be true is that the turn
+    /// holds the size the file really is.
+    #[test]
+    fn a_read_adds_the_files_real_size_to_the_turn() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("notes.txt");
+        let body = "x".repeat(4_096);
+        std::fs::write(&path, &body).expect("write fixture");
+        let on_disk = std::fs::metadata(&path).expect("metadata").len();
+        assert_eq!(
+            on_disk, 4_096,
+            "the fixture is not the size the test assumes"
+        );
+
+        let session = Arc::new(Mutex::new(crate::pipeline::SessionState::new()));
+        let payload = serde_json::json!({
+            "session_id": "breakdown-589",
+            "tool_name": "Bash",
+            "tool_input": {"command": format!("cat {}", path.display())},
+        })
+        .to_string();
+
+        let _ = process_payload(&payload, Some(session.clone()));
+
+        let recorded = session.lock().expect("lock").current_turn.file_read_bytes;
+        assert_eq!(
+            recorded, on_disk,
+            "the turn recorded a derived figure rather than the size it measured"
+        );
+    }
+}
+
+#[cfg(test)]
 mod subagent_scope_581 {
     use super::*;
 


### PR DESCRIPTION
The last derived unit in `omni stats`. #592 fixed the hook banner, #594 the report, and this is the block both of those left behind.

The context breakdown accumulated `size_bytes / 4` from file metadata, which is a rougher estimator than the 3.6 the rest of the report used and still not a Claude token count. #594 labelled it `Token Breakdown (rough estimate, bytes over 4)` because that was honest with the estimator in place. It counts the sizes now, so the label goes with it:

```
before   Token Breakdown (rough estimate, bytes over 4):
           File Reads:            ~34K tokens
after    Context Breakdown:
           File Reads:            133.8 KB
```

Two more moved with it. The largest-file-read line printed `format_bytes(...)` under the word `tokens`, and the share card's `unit` said `tokens` or `bytes` depending on whether the rows happened to carry a token column, so two installs could publish the same saving under different words. One arm now, the counted one.

## Verified by breaking it

| break | test | result |
| --- | --- | --- |
| quarter the file size again | `a_read_adds_the_files_real_size_to_the_turn` | red, `left: 1024, right: 4096` |

That test exists **because** the first break-test found nothing. Re-quartering the accumulation left all 1,766 tests green: the guard I had written checks how the number is printed, not what the turn records. The display guard is still there and still useful; it just answers a different question than I thought.

`make fmt clippy test security binary-check` all green, 1,768 tests, smoke 46/46.

## Left alone, deliberately

`ContextTurn` carries three fields nothing reads: `estimated_total_tokens`, `conversation_tokens`, `system_prompt_tokens`. They are dead rather than wrong, and deleting them belongs in its own diff rather than one about units.

Closes #589

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR changes context-composition accounting from quartered token estimates to measured byte counts and updates the corresponding statistics labels and share-card unit.
- Renames persisted context-breakdown fields and defaults them for compatibility with historical sessions.
- Records file metadata sizes and delivered tool-output lengths as bytes.
- Updates CLI formatting, labels, and regression coverage for byte accounting.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because extreme unredacted passthrough output can still be materially undercounted.

Passthrough accounting uses content after trim_enormous may have shortened it, while returning None leaves the host’s original untrimmed output in context, so sufficiently large outputs still produce an incorrect context total.

**Files Needing Attention:** src/hooks/post_tool.rs
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/analytics/context_composition.rs | Renames context accounting fields to byte units and preserves deserialization of sessions stored under the prior schema. |
| src/cli/stats.rs | Displays context composition and share figures consistently in bytes. |
| src/hooks/pre_tool.rs | Records detected file-read metadata sizes directly rather than quartering them. |
| src/hooks/post_tool.rs | Moves tool-output accounting after truncation and distinguishes passthrough delivery, but the previously reported extreme-output undercount remains. |

</details>

<sub>Reviews (5): Last reviewed commit: ["docs(hooks): record the enormous-payload..."](https://github.com/fajarhide/omni/commit/9a6b0b4f9bc651c50f4b24642871f23d19803b02) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53910640)</sub>

<!-- /greptile_comment -->