### PR TITLE
docs(site): lead with the measured payoff, and make five pages match 0.7.6

### DIFF
--- a/changelog.d/docs-landing-and-use-cases.changed.md
+++ b/changelog.d/docs-landing-and-use-cases.changed.md
@@ -1,0 +1,9 @@
+- **The landing page leads with what OMNI buys and the use-case page covers eleven
+  situations instead of six.** No figure changed. The three largest measured ones, 97.2%
+  off a repeated file read, 94% off `git log -15` and 92.9% off a `cargo test` run, were
+  each buried inside a page and are now on the first screen beside the 4,940 bytes the
+  lean MCP surface takes off every request. The aggregate and the 97.3% of calls that save
+  nothing keep their own section, because a tool that claims to help everywhere is one
+  nobody can predict. Five situations are new: reading one file in several passes,
+  dispatching a subagent, following a marker back, a context that gets compacted, and the
+  tool list every request carries. Both languages.

--- a/changelog.d/docs-landing-and-use-cases.changed.md
+++ b/changelog.d/docs-landing-and-use-cases.changed.md
@@ -25,3 +25,10 @@
   removed output byte was inserted in the middle. Sixteen of twenty-five advertised tools
   had never been called across 229 sessions, and they weighed 4,940 bytes against the
   4,942 the distillers remove from output in a busy session. Both languages throughout.
+- **`The ledger` names the three readers its premise fails for.** The page already rested
+  on one sentence, that the agent is still holding these bytes, and every rule is a
+  defence of the moment that stops being true. There are exactly three readers it fails
+  for and this release answered all three: a subagent carrying the parent's session id, a
+  context the host compacted, and a reader following a handle back. The pattern is stated
+  as the thing worth keeping, since it is what makes the next surprise diagnosable. Both
+  languages.

--- a/changelog.d/docs-landing-and-use-cases.changed.md
+++ b/changelog.d/docs-landing-and-use-cases.changed.md
@@ -7,3 +7,10 @@
   nobody can predict. Five situations are new: reading one file in several passes,
   dispatching a subagent, following a marker back, a context that gets compacted, and the
   tool list every request carries. Both languages.
+- **`Your first hour` teaches the two checks that make the rest worth trusting.** It now
+  opens with what the hour buys, checking OMNI rather than trusting it, and adds the two
+  commands that do it: pulling content back through a handle, and telling a real marker
+  apart from one that is only text. Both were verified against a built binary before being
+  written down, exit 1 with `the documentation example` for the reserved handle and exit 0
+  with the content for a real one. The `omni stats` section also says its absolute figures
+  are bytes now and why they used to be something else. Both languages.

--- a/changelog.d/docs-landing-and-use-cases.changed.md
+++ b/changelog.d/docs-landing-and-use-cases.changed.md
@@ -14,3 +14,14 @@
   written down, exit 1 with `the documentation example` for the reserved handle and exit 0
   with the content for a real one. The `omni stats` section also says its absolute figures
   are bytes now and why they used to be something else. Both languages.
+- **`Seeing what it saved` says what its numbers are counted in, and names a breaking
+  change.** Every absolute figure is bytes now, and the page explains why they used to be
+  something else and why the percentages never moved with them. It also documents that
+  `omni stats --json` renamed `commands[].tokens_saved` to `bytes_saved`: the field held
+  bytes under the old name for one release, and a machine-readable surface asserting the
+  wrong unit is the defect rather than a cosmetic slip.
+- **`What OMNI is` covers the second thing OMNI edits: itself.** Tool definitions sit in
+  the prefix of every request, so a prefix byte is carried from the first request while a
+  removed output byte was inserted in the middle. Sixteen of twenty-five advertised tools
+  had never been called across 229 sessions, and they weighed 4,940 bytes against the
+  4,942 the distillers remove from output in a busy session. Both languages throughout.

--- a/docs/website/src-id/concepts/the-ledger.md
+++ b/docs/website/src-id/concepts/the-ledger.md
@@ -85,6 +85,34 @@ salah, dan jawabannya biasanya ada di situ.
 Itu juga sebabnya ini persoalan pembatalan cache, bukan sistem ingatan. Ledger
 tidak menyimpan pengetahuan. Ia menyimpan tanda terima.
 
+## Tiga pembaca yang membuat premisnya gagal
+
+Setiap aturan yang layak diketahui di sini adalah pembelaan atas momen premisnya berhenti
+benar. Ada tepat tiga pembaca yang membuatnya gagal, dan ledger menjawab masing-masing
+dengan cara berbeda.
+
+**Sebuah subagent.** Claude Code menyerahkan session id milik induk kepada pembantunya,
+jadi ledger yang dikunci pada sesi saja akan menjawabnya dengan riwayat induk dan
+mengklaim 200 baris sudah ditampilkan kepada konteks yang tidak pernah menerimanya.
+Cakupannya adalah pembacanya, bukan sesinya, jadi pembantu itu mengumpulkan miliknya
+sendiri dan jatuh ke cakupan proyek untuk selebihnya, yang kata-katanya menyatakan terang
+bahwa tidak ada yang ditampilkan di sini.
+
+**Konteks yang dipadatkan.** Host memberitahukannya sebelum itu terjadi, dan ledger
+melupakan himpunan yang sudah ditampilkan milik sesi itu pada saat itu juga. Ia
+mengorbankan penghematan dengan sengaja. Tidak ada apa pun setelah compaction yang
+mengklaim Anda sudah memegang sesuatu yang tidak lagi Anda pegang.
+
+**Pembaca yang mengikuti sebuah handle.** Meminta byte kembali adalah bukti bahwa
+pembacanya tidak memilikinya, jadi pengiriman yang menjawab penarikan itu diserahkan utuh.
+Sebelumnya ia melewati pipeline, menghasilkan hash yang sama, dan kembali sebagai penanda
+yang tadi menyuruh pembacanya ke sana. Satu kali kirim, bukan pengecualian: pengulangan
+berikutnya melipat lagi.
+
+Polanya lebih berharga daripada ketiga kasusnya. Ketika ledger mengejutkan Anda, tanyakan
+pembaca mana yang sedang memegang byte-nya, dan apakah ada sesuatu yang memberi tahu OMNI
+bahwa pembacanya sudah berganti.
+
 ## Alurnya, satu perintah pada satu waktu
 
 ![Empat pertanyaan menentukan satu pelipatan: apakah barisnya menyatakan kegagalan, apakah ia sudah pernah ditampilkan, apakah deretannya menghemat lebih banyak daripada ongkos penandanya, dan apakah penulisan arsipnya berhasil. Satu saja "tidak" membuat baris-baris itu keluar apa adanya.](../media/the-ledger-decision.svg)

--- a/docs/website/src-id/concepts/use-cases.md
+++ b/docs/website/src-id/concepts/use-cases.md
@@ -1,6 +1,6 @@
 # Di mana OMNI membantu
 
-Enam situasi, masing-masing dengan angka terukurnya. Dua di antaranya kasus
+Sebelas situasi, masing-masing dengan angka terukurnya. Dua di antaranya kasus
 ketika OMNI tidak melakukan apa-apa, dan keduanya sengaja dimuat di sini:
 perkakas yang mengaku membantu di mana-mana adalah perkakas yang tidak bisa
 ditebak siapa pun.
@@ -106,6 +106,76 @@ perintah berikutnya tidak menghemat apa pun untuk Anda, ia merusak pipeline Anda
 
 **Angkanya: 0%**, memang dirancang begitu. Lihat
 [Yang tidak pernah disentuh](format-safety.md).
+
+## 7. Anda membaca satu berkas besar dalam beberapa bagian
+
+**Situasinya.** Sebuah berkas lebih panjang dari satu bacaan, jadi agent mengambilnya di
+sebuah offset, lalu berikutnya, lalu berikutnya lagi. Tiap jendela mengulang bagian kepala
+berkasnya, karena memang itu isi sebuah jendela pada offset.
+
+**Yang OMNI lakukan.** Ia melipat kepala yang berulang itu dan menggeser penomoran
+barisnya agar cocok, sehingga baris yang masih Anda lihat bernomor sesuai posisi
+sebenarnya di berkas. Paruh kedua itu penting: lipatan yang menomori ulang isi di bawahnya
+lebih buruk daripada tidak melipat sama sekali, dan itu sebabnya kasus ini ditolak selama
+satu rilis sampai penomorannya bisa dijaga benar.
+
+**Angkanya: 0,0% sebelumnya, 4,7% sesudahnya**, diukur pada empat jendela yang tumpang
+tindih dari satu berkas markdown. Berkas source tidak terpengaruh, karena distiller
+readfile menjangkaunya lebih dulu di 46,6% bagaimanapun.
+
+## 8. Anda mengirim subagent
+
+**Situasinya.** Agent Anda memunculkan pembantu untuk pekerjaan yang cakupannya sempit.
+Pembantu itu memulai dengan konteks kosong lalu membaca berkas yang sudah dibaca induknya.
+
+**Yang OMNI lakukan.** Ia memberi pembantu itu pandangannya sendiri. Claude Code
+menyerahkan session id milik induk kepada subagent, jadi ledger yang dikunci pada sesi
+saja akan menjawab pembantu itu dengan riwayat induknya dan memberitahunya 200 baris sudah
+ditampilkan, padahal konteks itu tidak pernah menerimanya. Sekarang pembantu itu melihat
+isinya, atau penanda yang menyatakan terang bahwa tidak ada yang ditampilkan di sini.
+
+**Angkanya: tidak ada rasio, dan justru itu intinya.** Ini kasus kebenaran. Penghematannya
+tidak pernah jadi masalah; klaimnya yang bermasalah.
+
+## 9. Anda mengikuti penanda untuk mengambil isinya kembali
+
+**Situasinya.** Sebuah penanda berbunyi `omni retrieve <handle>`. Anda menjalankannya,
+atau agent Anda yang menjalankannya, lalu membaca hasilnya.
+
+**Yang OMNI lakukan.** Ia menyerahkan byte itu utuh. Sebelumnya, byte itu kembali melewati
+pipeline, menghasilkan hash yang sama, dan terlipat menjadi penanda yang tadi menyuruh
+Anda ke sana, sehingga mengikuti instruksinya justru mengembalikan instruksinya.
+
+**Angkanya: satu kali kirim, bukan pengecualian.** Pengulangan berikutnya melipat lagi,
+dan itu penting karena 15,05% arsip di instalasi nyata pernah ditarik setidaknya sekali,
+sehingga mengecualikan semuanya berarti menukar klaim palsu dengan penghematan yang
+hilang.
+
+## 10. Konteks Anda dipadatkan di tengah sesi
+
+**Situasinya.** Sesinya panjang, host memadatkan percakapannya, dan separuh dari yang
+dipegang agent Anda hilang.
+
+**Yang OMNI lakukan.** Ia melupakan. Seluruh lisensi ledger adalah bahwa agent masih
+memegang byte yang digantikan sebuah handle, dan compaction adalah titik di mana itu
+berhenti benar, jadi himpunan yang sudah ditampilkan ikut pergi. Tidak ada apa pun setelah
+compaction yang mengklaim Anda sudah melihat sesuatu yang tidak lagi Anda pegang.
+
+**Angkanya: tidak ada rasio.** Ia mengorbankan penghematan dengan sengaja, dan itulah
+pertukaran yang menjaga penandanya tetap benar.
+
+## 11. Setiap request membawa daftar perkakas yang tidak pernah Anda panggil
+
+**Situasinya.** OMNI mendaftar sebagai server MCP, dan definisi perkakas berada di awal
+setiap request di setiap sesi. Berbeda dengan keluaran, byte di awal tidak dibayar sekali:
+ia dibaca ulang di setiap request sesudahnya.
+
+**Yang OMNI lakukan.** Ia hanya mengiklankan perkakas yang memang dipakai tier host Anda,
+sembilan alih-alih dua puluh lima, dengan `OMNI_MCP_TOOLS=all` untuk mengembalikan sisanya
+dan `omni doctor` yang menyebut set mana yang sedang berlaku.
+
+**Angkanya: 4.940 byte hilang dari setiap request.** Diukur di 229 sesi: enam belas dari
+dua puluh lima perkakas itu tidak pernah sekali pun dipanggil.
 
 ## Dan satu lagi yang juga tidak terjadi apa-apa
 

--- a/docs/website/src-id/concepts/what-it-is.md
+++ b/docs/website/src-id/concepts/what-it-is.md
@@ -82,6 +82,25 @@ Kalau Anda lebih suka melihat ini sebagai situasi ketimbang sebagai tahapan,
 [Di mana OMNI membantu](use-cases.md) memuat enam situasi lengkap dengan
 penghematan terukurnya.
 
+## Apa yang ia lakukan pada dirinya sendiri
+
+Semua di atas soal keluaran. Ada hal kedua yang disunting OMNI, dan lama sekali ia tidak
+menyuntingnya sama sekali: bobotnya sendiri.
+
+OMNI mendaftar sebagai server MCP, dan definisi perkakas berada di **awal** setiap request
+di setiap sesi tempat ia terpasang. Byte di awal tidak dibayar sekali. Ia dibawa sejak
+request pertama dan dibaca ulang di setiap request sesudahnya, sedangkan byte yang dibuang
+dari keluaran tool disisipkan di tengah dan dibaca lebih sedikit kali.
+
+Diukur di 229 sesi, enam belas dari dua puluh lima perkakas yang diiklankan OMNI tidak
+pernah sekali pun dipanggil, dan keenam belasnya berbobot 4.940 byte. Distiller-nya
+membuang median 4.942 byte dari keluaran tool pada sesi yang benar-benar padat. Dua byte
+bedanya, dan sisi awal itulah yang dibawa sejak permulaan.
+
+Jadi sekarang OMNI hanya memberi tahu host perkakas yang memang dipakai tier-nya. Alat
+yang menghabiskan konteks untuk menjelaskan dirinya sebanyak yang ia hemat bukanlah alat
+efisiensi token, dan menyadarinya menuntut pengukurannya sendiri diarahkan ke dirinya.
+
 ## Apa yang bukan dia
 
 **Bukan kompresor.** Ia tidak berusaha membuat keluaran menjadi kecil. Ia

--- a/docs/website/src-id/index.md
+++ b/docs/website/src-id/index.md
@@ -94,8 +94,8 @@ omni retrieve <handle>         # handle mana pun dari penanda mana pun, dicetak 
 ```
 
 Setiap angka di situs ini berasal dari korpus yang bisa Anda bangun ulang.
-[Benchmark](develop/benchmarks.md) memuat metodenya dan perintah persisnya untuk tiap
-baris, termasuk perbandingan yang kami kalah di dalamnya.
+[Benchmark](https://omni.weekndlabs.com/docs/develop/benchmarks) memuat metodenya dan
+perintah persisnya untuk tiap baris, termasuk perbandingan yang kami kalah di dalamnya.
 
 ## Yang Anda dapat
 

--- a/docs/website/src-id/index.md
+++ b/docs/website/src-id/index.md
@@ -18,6 +18,19 @@ Di dalam Claude Code cukup dua baris, sisanya diurus agent:
 /plugin install omni@omni
 ```
 
+## Apa yang dibelinya, terukur
+
+| | |
+|---|---:|
+| berkas yang dibaca agent dua kali | **97,2%** dari bacaan kedua |
+| `git log -15` | **94%** lebih kecil, semua commit tetap ada |
+| `cargo test`, 490 lulus dan 10 gagal | **92,9%** lebih kecil, kegagalannya tetap ada |
+| keluaran build dan test di seluruh korpus | **78,0%** |
+| definisi perkakas di setiap request | **4.940 byte** lebih ringan |
+
+Setiap angka itu bisa Anda putar ulang di riwayat Anda sendiri. Itulah inti dari sisa
+halaman ini.
+
 ## Masalahnya, dalam satu layar
 
 Agent Anda menjalankan test. Empat ratus baris kembali, yang penting satu.
@@ -69,6 +82,20 @@ keluar.
 
 Ini namanya ledger, dan pada riwayat perintah sungguhan ia bekerja lebih banyak
 daripada semua penyaring digabung.
+
+## Buktikan di mesin Anda sendiri
+
+Kebanyakan alat di ranah ini meminta Anda mempercayai angka dari laptop orang lain.
+Jalankan ini saja:
+
+```bash
+omni stats                     # apa yang OMNI lakukan di riwayat Anda, dalam byte terhitung
+omni retrieve <handle>         # handle mana pun dari penanda mana pun, dicetak utuh
+```
+
+Setiap angka di situs ini berasal dari korpus yang bisa Anda bangun ulang.
+[Benchmark](develop/benchmarks.md) memuat metodenya dan perintah persisnya untuk tiap
+baris, termasuk perbandingan yang kami kalah di dalamnya.
 
 ## Yang Anda dapat
 

--- a/docs/website/src-id/use/first-hour.md
+++ b/docs/website/src-id/use/first-hour.md
@@ -1,8 +1,12 @@
 # Satu jam pertama
 
-Diasumsikan `omni init` dan `omni doctor` sudah dijalankan. Tidak ada di sini
-yang mengubah konfigurasi; semuanya soal belajar membaca apa yang sedang
-dikerjakan OMNI supaya Anda bisa menilainya.
+Diasumsikan `omni init` dan `omni doctor` sudah dijalankan. Tidak ada di sini yang
+mengubah konfigurasi.
+
+Yang dibeli satu jam ini adalah kemampuan **memeriksa** OMNI alih-alih mempercayainya. Di
+ujungnya Anda bisa melihat potongan apa pun berdampingan dengan aslinya, menarik kembali
+apa pun yang ia buang, dan membedakan penanda miliknya dari baris yang sekadar mirip
+penanda. Keterampilan terakhir itulah yang membuat dua yang pertama ada gunanya.
 
 ## Lihat satu penyulingan terjadi
 
@@ -42,6 +46,12 @@ host menutupnya, karena itulah yang sebenarnya dibebankan jendela konteks kepada
 Anda. Persentase penyulingan di bawahnya adalah alat diagnosis untuk pipeline
 satu host.
 
+Setiap angka mutlak yang ia cetak berupa byte, dan byte itu dihitung. Dulu ia melaporkan
+token, dan token itu adalah hitungan byte yang sama dibagi konstanta yang dikalibrasi
+terhadap tokenizer vendor lain, jadi satuannya tidak bisa dipertahankan meski
+aritmetikanya benar. Persentasenya tidak pernah terpengaruh: pembaginya saling meniadakan
+di dalam rasio.
+
 ```sh
 omni stats --detail        # per perintah, per rute, per sesi, per agent
 omni stats --rerun         # distiller mana yang berongkos satu run ulang
@@ -51,6 +61,39 @@ omni dashboard             # angka yang sama di peramban, hanya di 127.0.0.1
 `--rerun` yang menarik. Persentase pengurangan tidak bisa memberi tahu apakah
 sebuah distiller membuang sesuatu yang lalu harus diambil ulang agent; yang ini
 bisa.
+
+## Tarik kembali sesuatu yang ia buang
+
+Setiap penanda menyebutkan sebuah handle. Jalankan:
+
+```sh
+omni retrieve 0000000000000000
+```
+
+Handle itu persisnya adalah contoh dokumentasi dan ditolak dengan menyebut namanya, dan
+justru itu inti bagian ini. Salin handle sungguhan dari penanda di keluaran Anda sendiri
+dan byte-nya kembali apa adanya, dan exit code-nya memberi tahu mana yang terjadi: 0 kalau
+handle-nya ketemu, 1 kalau tidak.
+
+Pasangan itu pemeriksaan kepercayaan tercepat yang ada. Alat yang membuang sesuatu tapi
+tidak bisa mengembalikannya adalah alat yang harus Anda percayai buta.
+
+## Bedakan penanda asli dari yang sekadar teks
+
+Halaman ini penuh penanda, begitu pula source OMNI sendiri, dan begitu pula laporan bug
+mana pun yang mengutipnya. Mencari bentuk penanda di transkrip Anda akan menemukan
+semuanya.
+
+Handle-nya yang membedakan. Semua contoh di manual ini memakai nilai cadangan
+`0000000000000000`, yang tidak akan pernah diberikan kepada lipatan sungguhan, jadi:
+
+```sh
+omni retrieve <handle-dari-keluaran-Anda>   # exit 0, beserta isinya
+omni retrieve 0000000000000000              # exit 1, "the documentation example"
+```
+
+Kalau Anda sedang mengukur apakah OMNI melakukan sesuatu sama sekali pada suatu run, exit
+code itulah jawabannya, bukan hasil grep terhadap `[OMNI`.
 
 ## Pancang apa yang sedang Anda kerjakan
 

--- a/docs/website/src-id/use/seeing-savings.md
+++ b/docs/website/src-id/use/seeing-savings.md
@@ -23,6 +23,27 @@ host menutupnya. Itu meteran yang benar-benar diperhatikan pengguna. Persentase
 penyulingan di bawahnya adalah alat diagnosis untuk pipeline satu host, bukan
 klaim produk.
 
+## Angkanya dihitung dalam satuan apa
+
+**Byte, dan byte itu dihitung, bukan diturunkan.** Setiap angka mutlak yang dicetak
+laporan ini adalah total byte dari `distillations`, dan setiap persentase adalah rasio
+dari dua di antaranya.
+
+Dulu satuannya token, yaitu hitungan byte yang sama dibagi 3,6, konstanta yang
+dikalibrasi terhadap `cl100k_base`. Itu encoding milik GPT, jadi satuannya tidak bisa
+dipertahankan meski aritmetikanya benar. Persentasenya tidak pernah terpengaruh:
+pembaginya saling meniadakan di dalam rasio, dan itu sebabnya angka reduksinya tidak
+bergeser ketika angka mutlaknya bergeser.
+
+Satu blok masih berupa taksiran dan ia menyatakannya. Context breakdown mengumpulkan
+ukuran berkas dari metadata, jadi `Context Breakdown` eksak untuk apa yang ia hitung dan
+bukan hitungan token yang menyamar.
+
+**Kalau Anda mem-parse `--json`, field `commands[].tokens_saved` sekarang bernama
+`bytes_saved`.** Selama satu rilis ia menyimpan byte dengan nama lama, dan itu permukaan
+yang dibaca mesin sambil menyatakan satuan yang keliru, jadi ia diganti nama alih-alih
+dibiarkan berbohong. Konsumennya harus ikut menyesuaikan.
+
 ## Membacanya tanpa membodohi diri sendiri
 
 **Pisahkan menurut `agent_id` sebelum mengutip apa pun.** Baris yang tercatat di

--- a/docs/website/src/concepts/the-ledger.md
+++ b/docs/website/src/concepts/the-ledger.md
@@ -76,6 +76,29 @@ for the premise to be false, and the answer is usually there.
 It is also why this is a cache invalidation problem and not a memory system. The
 ledger does not store knowledge. It stores receipts.
 
+## The three readers the premise fails for
+
+Every rule worth knowing here is a defence of the moment the premise stops being true.
+There are exactly three readers it fails for, and the ledger answers each differently.
+
+**A subagent.** Claude Code hands a helper the parent's session id, so a ledger keyed on
+the session alone would answer it with the parent's history and claim 200 lines were
+already shown to a context that had received none of them. The scope is the reader, not
+the session, so a helper accumulates its own and falls through to the project scope for
+anything else, where the wording says plainly that nothing was shown here.
+
+**A context that was compacted.** The host says so before it happens, and the ledger
+forgets that session's shown-set at that moment. It costs savings on purpose. Nothing
+after a compaction claims you already have something you no longer hold.
+
+**A reader following a handle.** Asking for bytes back is proof the reader does not have
+them, so the delivery answering a pull is handed over whole. Before, it went through the
+pipeline, hashed the same, and came back as the very marker that sent the reader there.
+One delivery, not an exemption: the next repeat folds again.
+
+The pattern is worth more than the three cases. When the ledger surprises you, ask which
+reader is holding the bytes, and whether anything told OMNI that reader had changed.
+
 ## The flow, one command at a time
 
 ![Four questions decide a fold: does the line state a failure, has it been shown before, does the run save more than its marker costs, and did the archive write succeed. Any no sends the lines out verbatim.](../media/the-ledger-decision.svg)

--- a/docs/website/src/concepts/use-cases.md
+++ b/docs/website/src/concepts/use-cases.md
@@ -1,7 +1,7 @@
 # Where OMNI helps
 
-Six situations, with the measured number attached to each. Two of them are cases where
-OMNI does nothing, and those are in here on purpose: a tool that claims to help
+Eleven situations, with the measured number attached to each. Two of them are cases
+where OMNI does nothing, and those are in here on purpose: a tool that claims to help
 everywhere is a tool nobody can predict.
 
 Every figure comes from the same replay of 6,656 real commands described in
@@ -96,6 +96,74 @@ byte. A compressor that reformats a payload the next command is about to parse h
 saved you anything, it has broken your pipeline.
 
 **The number: 0%**, by design. See [What it refuses to touch](format-safety.md).
+
+## 7. You read one big file in several passes
+
+**The situation.** A file is longer than one read, so the agent takes it at an offset,
+then another, then another. Each window repeats the head of the file, because that is
+what a window at an offset contains.
+
+**What OMNI does.** It folds the repeated head and moves the line numbering to match, so
+the lines you can still see are numbered where the file really has them. That second half
+matters: a fold that renumbers what is under it is worse than no fold, and it is why this
+case was refused for a release until the numbering could be kept true.
+
+**The number: 0.0% before, 4.7% after**, measured on four overlapping windows of one
+markdown file. Source files are unaffected, since the readfile distiller reaches those
+first at 46.6% either way.
+
+## 8. You dispatch a subagent
+
+**The situation.** Your agent spawns a helper to do a scoped job. The helper starts with
+an empty context and reads a file the parent already read.
+
+**What OMNI does.** It gives the helper its own view. Claude Code hands a subagent the
+parent's session id, so a ledger keyed on the session alone would answer the helper with
+the parent's history and tell it 200 lines were already shown, about bytes that context
+had never received. The helper now sees either the content or a marker that says plainly
+nothing was shown here.
+
+**The number: no ratio, and that is the point.** This is a correctness case. The saving
+was never the problem; the claim was.
+
+## 9. You follow a marker to get the content back
+
+**The situation.** A marker says `omni retrieve <handle>`. You run it, or your agent
+does, and reads the result.
+
+**What OMNI does.** It hands those bytes over whole. Before, they went back through the
+pipeline, hashed the same, and were folded into the very marker that sent you there, so
+following the instruction returned the instruction.
+
+**The number: one delivery, not an exemption.** The next repeat folds again, which
+matters because 15.05% of the archive on a real installation has been pulled at least
+once, and exempting all of it would trade a false claim for a lost saving.
+
+## 10. Your context gets compacted mid-session
+
+**The situation.** The session runs long, the host compacts the conversation, and half
+of what your agent was holding is gone.
+
+**What OMNI does.** It forgets. The ledger's whole licence is that the agent still holds
+the bytes a handle replaces, and compaction is where that stops being true, so the
+shown-set goes with it. Nothing after a compaction claims you have already seen something
+you no longer have.
+
+**The number: no ratio.** It costs savings on purpose, and it is the trade that keeps the
+markers true.
+
+## 11. Every request carries a tool list you never call
+
+**The situation.** OMNI registers as an MCP server, and tool definitions sit in the
+prefix of every request of every session. Unlike output, a prefix byte is not paid once:
+it is re-read on every request after the first.
+
+**What OMNI does.** It advertises the tools your host's tier actually uses, nine instead
+of twenty-five, with `OMNI_MCP_TOOLS=all` to restore the rest and `omni doctor` naming
+which set is in force.
+
+**The number: 4,940 bytes off every request.** Measured across 229 sessions: sixteen of
+the twenty-five had never been called once.
 
 ## And one more where nothing happens
 

--- a/docs/website/src/concepts/what-it-is.md
+++ b/docs/website/src/concepts/what-it-is.md
@@ -74,6 +74,25 @@ saying what happened.
 If you would rather see this as situations than as stages,
 [Where OMNI helps](use-cases.md) has six of them with the measured saving on each.
 
+## What it does to itself
+
+Everything above is about output. There is a second thing OMNI edits, and for a long time
+it did not edit it at all: its own weight.
+
+OMNI registers as an MCP server, and tool definitions sit in the **prefix** of every
+request of every session it is attached to. A prefix byte is not paid once. It is carried
+from the first request and re-read on every one after it, where a byte removed from tool
+output was inserted somewhere in the middle and is read fewer times.
+
+Measured across 229 sessions, sixteen of the twenty-five tools OMNI advertised had never
+been called once, and those sixteen were 4,940 bytes. The distillers remove a median of
+4,942 bytes from tool output in a session that pushes real volume through the hook. Two
+bytes apart, and the prefix side is the one carried from the start.
+
+So OMNI now tells a host about the tools its tier actually uses. A tool that spends as
+much context describing itself as it saves is not a token-efficiency tool, and noticing
+that required pointing its own measurement at itself.
+
 ## What it is not
 
 **Not a compressor.** It is not trying to make output small. It is trying to make

--- a/docs/website/src/index.md
+++ b/docs/website/src/index.md
@@ -2,8 +2,8 @@
 
 **Your AI agent pays to read the same output over and over. OMNI stops that.**
 
-It is one small program that sits between your terminal and your agent. It runs
-locally, it needs no API key, and once it is installed you never type its name again.
+One small program between your terminal and your agent. Local, no API key, no proxy.
+Install it and you never type its name again.
 
 ```bash
 brew install fajarhide/tap/omni && omni init
@@ -15,6 +15,19 @@ Inside Claude Code, two lines and the agent does the rest:
 /plugin marketplace add fajarhide/omni
 /plugin install omni@omni
 ```
+
+## What that buys, measured
+
+| | |
+|---|---:|
+| a file your agent reads twice | **97.2%** off the second read |
+| `git log -15` | **94%** smaller, every commit kept |
+| `cargo test`, 490 passed and 10 failed | **92.9%** smaller, the failures kept |
+| build and test output across the corpus | **78.0%** |
+| the tool definitions in every request | **4,940 bytes** lighter |
+
+Every one of those replays on your own history. That is the point of the rest of this
+page.
 
 ## The problem, in one screen
 
@@ -30,25 +43,16 @@ test pipeline::scorer::tests::scores_errors_critical ... ok
 test result: FAILED. 411 passed; 1 failed
 ```
 
-Here is what your agent reads instead:
-
-```
-cargo test: 411 passed, 1 failed
-  FAILED ledger::tests::renders_identical_bytes_for_identical_state
-  assertion `left == right` failed at src/ledger/mod.rs:601
-[OMNI: 406 lines omitted, omni retrieve 0000000000000000 for full output]
-```
-
-The failure survived. The 406 lines of `ok` did not. And that handle on the last line
-brings every one of them back, byte for byte, if anything ever needs them.
+The failure survives. The 406 lines of `ok` do not. A handle on the last line brings
+every one of them back, byte for byte, if anything ever needs them.
 
 ## The part nobody else does
 
-Filtering noise is the easy half, and several tools do it. Here is the half that is
-harder, and it is where most of OMNI's saving comes from.
+Filtering noise is the easy half, and several tools do it. Here is the harder half, and
+it is where most of OMNI's saving comes from.
 
-Your agent reads a file. Three turns later it reads the same file again, because
-nothing remembered the first read. You pay full price both times.
+Your agent reads a file. Three turns later it reads the same file again, because nothing
+remembered the first read. You pay full price both times.
 
 OMNI remembers. The second read comes back as one line:
 
@@ -56,13 +60,26 @@ OMNI remembers. The second read comes back as one line:
 [OMNI: 178 lines already shown, omni retrieve 0000000000000000]
 ```
 
-**A 7.6 KB file read twice costs 7.6 KB and then 214 bytes. That is 97.2% off the
-second read.** Nothing was deleted: those lines are already sitting in your agent's
-context from the first read, so sending them again buys nothing. The handle is there
-in case they scroll out of reach.
+**A 7.6 KB file read twice costs 7.6 KB and then 214 bytes.** Nothing was deleted: those
+lines are already in your agent's context from the first read, so sending them again buys
+nothing. The handle is there in case they scroll out of reach.
 
-This is called the ledger, and on real command histories it does more work than every
-filter combined.
+This is the ledger, and on real command histories it does more work than every filter
+combined.
+
+## Prove it on your own machine
+
+Most tools in this space ask you to trust a number from someone else's laptop. Run these
+instead:
+
+```bash
+omni stats                     # what OMNI did on your history, in counted bytes
+omni retrieve <handle>         # any handle from any marker, printed back byte for byte
+```
+
+Every figure on this site comes from a corpus you can rebuild.
+[Benchmarks](develop/benchmarks.md) has the method and the exact command for each row,
+including the comparison we lose.
 
 ## What you get
 
@@ -77,56 +94,51 @@ filter combined.
 
 ## Where it actually helps
 
-[Where OMNI helps](concepts/use-cases.md) walks through six situations with the real
-numbers attached, including the two where it does nothing and why that is correct.
+[Where OMNI helps](concepts/use-cases.md) walks through the situations with the real
+numbers attached, including the ones where it does nothing and why that is correct.
 
 ## Start here
 
 **Just want it working.** [Install](use/install.md) takes about five minutes. Then read
-[Reading the markers](use/markers.md), which is the one page worth your time, because
-the markers are how OMNI tells you what it did.
+[Reading the markers](use/markers.md), which is the one page worth your time, because the
+markers are how OMNI tells you what it did.
 
 **Want to understand it first.** [What OMNI is](concepts/what-it-is.md), then
-[The ledger](concepts/the-ledger.md).
-
-**Want to work on it.** [Architecture](develop/architecture.md) and
-[The pipeline, stage by stage](develop/pipeline.md) are the map.
-[Adding a distiller](develop/adding-a-distiller.md) is the most common change.
+[How it decides what to cut](concepts/how-it-decides.md), then [The ledger](concepts/the-ledger.md).
 
 ## Three things it will not do
 
-**It will not send anything anywhere.** Every stage runs on your machine and the
-archive is a SQLite file in your home directory.
+**It will not send anything anywhere.** Every stage runs on your machine and the archive
+is a SQLite file in your home directory.
 
-**It will not sit between you and your model.** There is no proxy and no API key handed
-to a local process. That was [decided against](develop/direction.md#non-goals) on
-purpose, and the reasoning is written down.
+**It will not sit between you and your model.** There is no proxy and no API key handed to
+a local process. That was [decided against](develop/direction.md#non-goals) on purpose,
+and the reasoning is written down.
 
-**It will not quietly guess.** A stage that failed to understand its input hands the
-input back unchanged. Structured data like JSON and YAML is never touched at all.
-Anything removed leaves a marker saying so. Those three rules outrank compression, in
-that order, every time they conflict.
+**It will not quietly guess.** A stage that failed to understand its input hands the input
+back unchanged. Structured data like JSON and YAML is never touched at all. Anything
+removed leaves a marker saying so. Those three rules outrank compression, in that order,
+every time they conflict.
 
 ## The honest version of the numbers
 
 Across 6,656 real commands, **97.3% of calls saved nothing at all**, because there was
-nothing to save. A two-line `git status` has no ceremony to drop and no repeats to
-fold, so OMNI hands it straight back rather than inventing a saving to report.
+nothing to save. A two-line `git status` has no ceremony to drop and no repeats to fold,
+so OMNI hands it straight back rather than inventing a saving to report.
 
-The 14.9% is what is left after counting all of those zeroes. It is a real average over
-a real mix, not a best case picked from a good day.
+The 14.9% is what is left after counting all of those zeroes. It is a real average over a
+real mix, not a best case picked from a good day.
 
-We publish the comparison we lose, too: on filtering alone, rtk gets 6.2% on that
-corpus and OMNI gets 2.7%. It is the ledger that puts OMNI ahead overall, and running
-rtk's filters with OMNI's ledger would beat both. [Benchmarks](develop/benchmarks.md)
-has the method and the command to reproduce every row on your own history.
+We publish the comparison we lose, too: on filtering alone, rtk gets 6.2% on that corpus
+and OMNI gets 2.7%. It is the ledger that puts OMNI ahead overall, and running rtk's
+filters with OMNI's ledger would beat both.
 
 If you want a number that describes your machine rather than someone else's, run
 `omni stats` after a few days.
 
 ## Where to ask
 
-[Discord](https://discord.gg/zHTuvZhF2M) for questions, and especially for the case
-this project cares about most: OMNI stating a result its input does not support. The
-[issue tracker](https://github.com/fajarhide/omni/issues) works too. A report with the
-raw and distilled output side by side gets fixed either way.
+[Discord](https://discord.gg/zHTuvZhF2M) for questions, and especially for the case this
+project cares about most: OMNI stating a result its input does not support. The
+[issue tracker](https://github.com/fajarhide/omni/issues) works too. A report with the raw
+and distilled output side by side gets fixed either way.

--- a/docs/website/src/use/first-hour.md
+++ b/docs/website/src/use/first-hour.md
@@ -1,7 +1,11 @@
 # Your first hour
 
-Assumes `omni init` and `omni doctor` are done. Nothing here changes configuration;
-it is all about learning to read what OMNI is doing so you can judge it.
+Assumes `omni init` and `omni doctor` are done. Nothing here changes configuration.
+
+What the hour buys is the ability to check OMNI instead of trusting it. By the end you
+will be able to see any cut side by side with the original, pull back anything it
+removed, and tell one of its markers apart from a line that merely looks like one. That
+last skill is the one that makes the other two worth having.
 
 ## See a distillation happen
 
@@ -36,8 +40,13 @@ omni stats
 ```
 
 It leads with session lifetime, how many commands a session carries before the host
-closes it, because that is what the context window actually costs you. The
-distillation percentage below it is a diagnostic for one host's pipeline.
+closes it, because that is what the context window actually costs you. The distillation
+percentage below it is a diagnostic for one host's pipeline.
+
+Every absolute figure it prints is in bytes, which are counted. It used to report tokens,
+and those were the same byte counts divided by a constant calibrated against another
+vendor's tokenizer, so the unit could not be defended even though the arithmetic was
+fine. Percentages were never affected: the divisor cancels in a ratio.
 
 ```sh
 omni stats --detail        # per command, per route, per session, per agent
@@ -47,6 +56,38 @@ omni dashboard             # the same numbers in a browser, on 127.0.0.1 only
 
 `--rerun` is the interesting one. Reduction percentage cannot tell you whether a
 distiller removed something the agent then had to go and fetch again; this can.
+
+## Pull back something it removed
+
+Every marker names a handle. Run it:
+
+```sh
+omni retrieve 0000000000000000
+```
+
+That exact handle is the documentation example and is refused by name, which is the
+point of this section. Copy a real one out of a marker in your own output and you get
+the bytes back verbatim, and the exit code tells you which happened: 0 when the handle
+resolved, 1 when it did not.
+
+That pair is the fastest trust check there is. A tool that removes things and cannot
+give them back is a tool you have to take on faith.
+
+## Tell a real marker from one that is just text
+
+This page is full of markers, so is OMNI's own source, and so is any bug report that
+quotes one. Searching your transcript for the marker shape will find all of them.
+
+The handle is what separates them. Worked examples everywhere in this manual use the
+reserved `0000000000000000`, which no real fold can ever be assigned, so:
+
+```sh
+omni retrieve <handle-from-your-output>   # exit 0, and the content
+omni retrieve 0000000000000000            # exit 1, "the documentation example"
+```
+
+If you are measuring whether OMNI did anything at all on a run, that exit code is the
+answer and grepping for `[OMNI` is not.
 
 ## Pin what you are working on
 

--- a/docs/website/src/use/seeing-savings.md
+++ b/docs/website/src/use/seeing-savings.md
@@ -22,6 +22,27 @@ It leads with **session lifetime**: how many commands a session carries before t
 host closes it. That is the meter a user actually watches. The distillation
 percentage below it is a diagnostic for one host's pipeline, not a product claim.
 
+## What the numbers are counted in
+
+**Bytes, and they are counted rather than derived.** Every absolute figure the report
+prints is a byte total out of `distillations`, and every percentage is a ratio of two of
+them.
+
+They used to be tokens, which were those same byte counts divided by 3.6, a constant
+calibrated against `cl100k_base`. That is GPT's encoding, so the unit could not be
+defended even though the arithmetic was sound. Percentages were never affected: the
+divisor cancels in a ratio, which is why the reduction figures did not move when the
+absolute ones did.
+
+One block is still an estimate and says so. The context breakdown accumulates file sizes
+from metadata, so `Context Breakdown` is exact for what it counts and is not a token
+count in disguise.
+
+**If you parse `--json`, the `commands[].tokens_saved` field is now `bytes_saved`.** It
+held bytes under the old name for one release, which is a machine-readable surface
+asserting the wrong unit, so it was renamed rather than left lying. Consumers have to
+follow.
+
 ## Reading it without fooling yourself
 
 **Split by `agent_id` before quoting anything.** Rows recorded under `terminal` are


### PR DESCRIPTION
The material was already on the site and buried. A reader met the pitch before the proof.

## What moved

The three largest measured numbers were each inside a page. They are on the first screen now, beside the one that is new this release:

| | |
|---|---:|
| a file read twice | 97.2% off the second read |
| `git log -15` | 94% smaller |
| `cargo test`, 490 passed and 10 failed | 92.9% smaller |
| build and test across the corpus | 78.0% |
| the tool definitions in every request | 4,940 B lighter |

A new section turns the differentiator into an invitation: `omni stats` and `omni retrieve <handle>` on your own history, rather than a number from someone else's laptop.

**No figure changed and none was added that is not measured.** The honest sections stay exactly where they were: 97.3% of calls save nothing, the aggregate is 14.9%, and the comparison we lose is still printed, rtk at 6.2% against OMNI at 2.7% on filtering alone.

That last part was a deliberate call rather than caution. Two competitors ship this pitch with 73.7k and 63k stars, so "we compress the most" is a fight on their ground with a number anyone can refute in one command. Replayable receipts and nothing-deleted are the parts they cannot copy, and burying them to make the hero louder would trade the only defensible ground for a claim that invites a rebuttal.

## Five new situations

Reading one file in several passes (0.0% to 4.7%), dispatching a subagent, following a marker back, a context that gets compacted, and the tool list every request carries (4,940 B). The last four are what 0.7.6 changed, so the page now explains the release rather than predating it.

Both languages, both books at thirteen sections. `docs_match_the_code` green.

Refs #252

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR refreshes the English and Indonesian documentation for OMNI 0.7.6 and moves measured benefits onto the landing pages.
- Expands the use-case documentation from six to eleven scenarios.
- Documents retrieval, compaction, subagent isolation, MCP tool trimming, and byte-based statistics.
- Adds reproducibility guidance and updates the first-hour workflow.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/website/src/index.md | Reworks the English landing page around measured benefits, reproducibility, and links to detailed documentation. |
| docs/website/src-id/index.md | Adds the corresponding Indonesian payoff table and local-verification guidance. |
| docs/website/src/concepts/use-cases.md | Expands the English use-case catalog with five scenarios introduced or addressed in 0.7.6. |
| docs/website/src-id/concepts/use-cases.md | Mirrors the expanded eleven-scenario catalog in Indonesian. |
| docs/website/src/use/first-hour.md | Adds practical verification steps for retrieving archived output and recognizing genuine markers. |
| docs/website/src/use/seeing-savings.md | Clarifies byte-based statistics and documents the JSON field rename. |

</details>

<sub>Reviews (5): Last reviewed commit: ["docs(site): link the Indonesian benchmar..."](https://github.com/fajarhide/omni/commit/5922de12d3d2baf5b5124dcdf8eeb00f2b7f6fa3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53928955)</sub>

<!-- /greptile_comment -->