### PR TITLE
fix: the three now-lane defects, and the two things their tests found

### DIFF
--- a/changelog.d/598.fixed.md
+++ b/changelog.d/598.fixed.md
@@ -1,0 +1,18 @@
+**The `Read` skeleton stopped advertising a recovery route that cannot work.** It
+ended `Re-read with offset/limit for the full file.`, and a re-read is a fresh
+`Read` of the same file, so it reaches the same distiller and returns the same
+skeleton. Following the instruction verbatim on a 303 line file returned the
+identical summary a second time, and a third identical request folded to a single
+ledger marker with no content at all.
+
+The route that does work was already one line below it, and every `omni retrieve`
+handle in the report resolved. So the note now counts what was dropped and names
+nothing, because the handle is minted after that string is built and cannot be
+reached from it.
+
+Its number also read as a contradiction next to that marker and was not one. It
+counts file lines the skeleton does not render, while the marker counts reply
+lines cut from what was about to be sent, so the two differ legitimately on the
+same read. Both stay, each now saying which denominator it used. The note is 41
+bytes shorter as a result, which is worth almost nothing at 8 distilled reads a
+week and is not the reason for the change.

--- a/changelog.d/601.fixed.md
+++ b/changelog.d/601.fixed.md
@@ -1,0 +1,26 @@
+**A small fold that would leave the reader nothing to read is refused.**
+Resolving a merge conflict and re-reading the same window folded 23 of 26 lines
+and delivered three that had nothing to do with the edit, under a marker reading
+`23 lines already shown`. An agent verifying a deletion reads that as nothing
+changed. The fold was right about every line it counted: a deletion and a
+reorder produce no new line, so there was nothing for it to emit, and absence is
+the one thing a set keyed on line hashes cannot represent.
+
+`MIN_WHOLE_OUTPUT_FOLD` already refuses this trade when a fold covers the payload
+exactly, on the argument that a handle and nothing else is a round trip the agent
+has no say in. Three surviving lines out of twenty-six is that same situation, so
+the floor now covers a fold taking four fifths or more of a payload. The wording
+does not move: a partial fold still says `N lines already shown`, because it
+still is one.
+
+Priced on 847 recorded folds before the fraction was chosen. The guard refuses
+3 of them and 1,748 bytes of 1,439,813, or 0.12% of everything the ledger has
+saved on this machine, and it cannot reach a large payload, where a 90% fold is
+the case the feature exists for and the floor is already met many times over.
+
+Three cheaper designs were measured and dropped. Reporting `N removed` in the
+marker needs the previous payload, which no table stores. Ordering or gap
+detection over `ledger_lines` cannot tell a deletion from `grep` printing three
+matching lines out of a file, which is most of what the ledger folds. Keying the
+previous run by command needs a per-hook lookup and a column, against a 10 ms
+budget, to catch what a floor already covers.

--- a/changelog.d/601.fixed.md
+++ b/changelog.d/601.fixed.md
@@ -9,14 +9,25 @@ the one thing a set keyed on line hashes cannot represent.
 `MIN_WHOLE_OUTPUT_FOLD` already refuses this trade when a fold covers the payload
 exactly, on the argument that a handle and nothing else is a round trip the agent
 has no say in. Three surviving lines out of twenty-six is that same situation, so
-the floor now covers a fold taking four fifths or more of a payload. The wording
-does not move: a partial fold still says `N lines already shown`, because it
-still is one.
+the floor now covers any call whose folds take four fifths or more of the payload
+between them. Coverage is asked once for the payload, not once per run: review
+caught the first draft weighing each run against the whole reply, which let three
+seen blocks of thirty percent, separated by a new line each, fold ninety percent
+of a small payload and leave the reader three markers and two separators. The
+wording does not move: a partial fold still says `N lines already shown`, because
+it still is one.
 
-Priced on 847 recorded folds before the fraction was chosen. The guard refuses
-3 of them and 1,748 bytes of 1,439,813, or 0.12% of everything the ledger has
-saved on this machine, and it cannot reach a large payload, where a 90% fold is
-the case the feature exists for and the floor is already met many times over.
+Priced before the fraction was chosen, and the first price was wrong in the way
+this project keeps warning about. `ledger_folds.payload_bytes` only exists since
+#560, so 41 of the recorded calls carry it and the rest read zero. Dividing the
+refused bytes by the whole table's total gave 0.12%, a figure whose numerator and
+denominator came from different populations. Against the 41 calls that can
+actually answer, the guard refuses 3 of them and 1,748 bytes of 54,400, or 3.2%
+of what the ledger folded in that window. The all-time figure cannot be computed
+and is not quoted.
+
+It still cannot reach a large payload, where a 90% fold is the case the feature
+exists for and the floor is met many times over.
 
 Three cheaper designs were measured and dropped. Reporting `N removed` in the
 marker needs the previous payload, which no table stores. Ordering or gap

--- a/changelog.d/603.fixed.md
+++ b/changelog.d/603.fixed.md
@@ -1,0 +1,19 @@
+**A recorded row is named after its program again, and this time in both of the
+places that write the name.** #339 taught `sole_output_command` to strip a
+`VAR=value` prefix and closed. Routing was fixed and `distillations.filter_name`
+was not, because neither writer of that column went through there: `hooks::pipe`
+took the first token of the raw command and had never received the fix at all,
+and `hooks::post_tool` reached it through `.unwrap_or(clean_command)`, which
+hands the raw chain straight back for any command with two producers.
+
+Measured on 0.7.6 on a database whose oldest row postdates #339: 1,525 of 11,335
+rows were filed under an assignment and 291 under a binary's full path, 16.0% of
+the corpus, against the 1,079 rows #339 measured before it was closed. So the
+rate had not moved. Every aggregate keyed on that column was wrong by that much,
+and those aggregates are what a distiller gets sized from here.
+
+One `producer_label` both doors call, with `resolve_profile`'s private copy of
+the basename logic folded in beside it. Writing the test as a matrix of command
+shapes rather than one case immediately found a second defect in the new
+fallback, which was naming a chain after its `cd` instead of after the first
+segment that produces output.

--- a/src/distillers/readfile.rs
+++ b/src/distillers/readfile.rs
@@ -157,7 +157,9 @@ fn omitted_note(total_lines: usize, kept_lines: usize) -> String {
     if omitted == 0 {
         return String::new();
     }
-    format!("\n\n... [{omitted} of {total_lines} file lines not rendered here: bodies and comments] ...")
+    format!(
+        "\n\n... [{omitted} of {total_lines} file lines not rendered here: bodies and comments] ..."
+    )
 }
 
 /// The scan behind every `--- … ---` section runs over the **whole** file, not

--- a/src/distillers/readfile.rs
+++ b/src/distillers/readfile.rs
@@ -134,15 +134,29 @@ fn distill_unknown_file(content: &str) -> String {
 /// no way to tell the bodies had ever existed: a 24,999 B Python file came back
 /// as 3,275 B of repeated signatures, 86.9% reported as a win, with the business
 /// rule it was read for deleted and unmentioned.
+/// It names no recovery route, and that is the fix rather than an omission
+/// (#598). It used to end `Re-read with offset/limit for the full file.`, which
+/// does not work and cannot: a re-read is a fresh `Read` of the same file, so it
+/// reaches this same distiller and returns this same skeleton. Following the
+/// instruction verbatim on a 303 line file returned the identical summary a
+/// second time, and a third identical request folded to one ledger marker with
+/// no content at all.
+///
+/// The reply already carries the route that does work, one line below this one:
+/// the `omni retrieve <handle>` marker, whose handle every probe resolved. The
+/// note counts what was dropped and stops there, because the handle is minted
+/// after this function runs and this string cannot name it.
+///
+/// Its number counts **file** lines the skeleton does not render. The marker
+/// below counts **reply** lines cut from what was about to be sent, so the two
+/// legitimately differ on the same read, and `of {total_lines}` is here to say
+/// which denominator this one uses.
 fn omitted_note(total_lines: usize, kept_lines: usize) -> String {
     let omitted = total_lines.saturating_sub(kept_lines);
     if omitted == 0 {
         return String::new();
     }
-    format!(
-        "\n\n... [{omitted} of {total_lines} lines omitted, bodies and comments not shown. \
-         Re-read with offset/limit for the full file.] ..."
-    )
+    format!("\n\n... [{omitted} of {total_lines} file lines not rendered here: bodies and comments] ...")
 }
 
 /// The scan behind every `--- … ---` section runs over the **whole** file, not

--- a/src/distillers/readfile.rs
+++ b/src/distillers/readfile.rs
@@ -571,7 +571,7 @@ mod tests {
             let out = distill_readfile(&content, path)
                 .unwrap_or_else(|| panic!("{path} should distill at this size"));
             assert!(
-                out.contains("lines omitted"),
+                out.contains("file lines not rendered here"),
                 "{path} dropped lines without saying so:\n{out}"
             );
         }
@@ -587,7 +587,7 @@ mod tests {
         let out = distill_readfile(&content, "a.py").unwrap();
 
         assert!(
-            out.contains(&format!("of {total} lines omitted")),
+            out.contains(&format!("of {total} file lines not rendered here")),
             "expected a count against {total} total, got:\n{out}"
         );
     }
@@ -668,7 +668,7 @@ mod tests {
 
         assert!(out.contains("Log: 1 errors"), "{out}");
         assert!(
-            out.contains("lines omitted"),
+            out.contains("file lines not rendered here"),
             "the lines it did not show still have to be counted:\n{out}"
         );
     }
@@ -684,7 +684,7 @@ mod tests {
         let out = distill_readfile(&content, "deployment.yaml").expect("large enough to distill");
 
         assert!(
-            out.contains("lines omitted"),
+            out.contains("file lines not rendered here"),
             "a key skeleton that drops values must say so:\n{out}"
         );
     }

--- a/src/distillers/readfile.rs
+++ b/src/distillers/readfile.rs
@@ -134,6 +134,7 @@ fn distill_unknown_file(content: &str) -> String {
 /// no way to tell the bodies had ever existed: a 24,999 B Python file came back
 /// as 3,275 B of repeated signatures, 86.9% reported as a win, with the business
 /// rule it was read for deleted and unmentioned.
+///
 /// It names no recovery route, and that is the fix rather than an omission
 /// (#598). It used to end `Re-read with offset/limit for the full file.`, which
 /// does not work and cannot: a re-read is a fresh `Read` of the same file, so it
@@ -718,5 +719,46 @@ mod tests {
 
         let out = distill_readfile(&content, "src/lib.rs");
         assert!(out.is_some());
+    }
+
+    /// #598. The note used to end `Re-read with offset/limit for the full file.`
+    /// and that route cannot work: a re-read reaches this same distiller and
+    /// returns this same skeleton, so an agent following the instruction pays a
+    /// round trip for a byte-identical answer.
+    ///
+    /// A matrix rather than one case, because the note has three regimes and the
+    /// interesting one is the boundary: the empty string at zero omitted is what
+    /// keeps a fully rendered file from carrying a marker about nothing.
+    #[test]
+    fn the_omitted_note_names_no_route_it_cannot_honour() {
+        let cases = [
+            ("nothing dropped", 40usize, 40usize, false),
+            ("one line dropped", 40, 39, true),
+            ("most of the file dropped", 303, 42, true),
+            ("kept exceeds total", 10, 40, false),
+        ];
+
+        for (name, total, kept, expect_note) in cases {
+            let note = super::omitted_note(total, kept);
+            assert_eq!(!note.is_empty(), expect_note, "case: {name}");
+            if !expect_note {
+                continue;
+            }
+            assert!(
+                !note.contains("offset") && !note.contains("Re-read"),
+                "case: {name}: the note still advertises the route that fails"
+            );
+            // The count is about the file, and the ledger marker printed under it
+            // counts the reply. Saying which is what stops the two reading as a
+            // contradiction on the same Read.
+            assert!(
+                note.contains("file lines"),
+                "case: {name}: the note does not say what it counted"
+            );
+            assert!(
+                note.contains(&format!("{} of {}", total - kept, total)),
+                "case: {name}: the note lost its denominator"
+            );
+        }
     }
 }

--- a/src/hooks/pipe.rs
+++ b/src/hooks/pipe.rs
@@ -326,10 +326,13 @@ fn distill(
 
         (
             out,
-            cmd.split_whitespace()
-                .next()
-                .unwrap_or("[pipe]")
-                .to_string(),
+            // `[pipe]` only for pipe mode, where there is no command at all. A
+            // command that is present is named after its program, through the
+            // same helper the hook path uses (#603).
+            match crate::pipeline::producer::producer_label(cmd) {
+                "" => "[pipe]".to_string(),
+                label => label.to_string(),
+            },
             k_count,
             d_count,
             collapse_savings_data,

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -729,15 +729,14 @@ pub fn process_payload(
         // assignment and its value into this column: 1,079 rows and 264 distinct
         // values in one database, which made every aggregate keyed on it useless
         // and hid the routing defect this change fixes (#339).
-        let producer =
-            crate::pipeline::registry::sole_output_command(clean_command).unwrap_or(clean_command);
+        let producer = crate::pipeline::producer::producer_label(clean_command);
         (
             output,
-            producer
-                .split_whitespace()
-                .next()
-                .unwrap_or("omni")
-                .to_string(),
+            if producer.is_empty() {
+                "omni".to_string()
+            } else {
+                producer.to_string()
+            },
         )
     };
 

--- a/src/ledger/mod.rs
+++ b/src/ledger/mod.rs
@@ -1327,4 +1327,62 @@ mod tests {
             Origin::Session.marker(9, &"0".repeat(HANDLE_LEN)).len()
         );
     }
+
+    /// One fixed-width line, so a fixture's size can be reasoned about against
+    /// `MIN_WHOLE_OUTPUT_FOLD` rather than eyeballed. 34 bytes including the
+    /// terminator.
+    fn row(tag: char, i: usize) -> String {
+        format!("{tag} line {i:04} of the fixture payload\n")
+    }
+
+    /// #601, as a matrix, because the guard has to hold on one axis and stay out
+    /// of the way on the other two. A single fixture proves whichever it happens
+    /// to sit on, and the danger here is a guard that quietly stops the folds
+    /// this feature exists for.
+    ///
+    /// Coverage is what the fold takes of the payload; the floor only applies
+    /// once that is four fifths or more **and** the run is under
+    /// `MIN_WHOLE_OUTPUT_FOLD`.
+    #[test]
+    fn refuses_a_small_fold_that_would_leave_almost_nothing() {
+        // (name, lines reused from the first show, lines new to the second, folds?)
+        let cases = [
+            // The reported shape: 23 of 26 lines folded, 782 B of an 884 B
+            // payload, and the three survivors say nothing about the edit.
+            ("small payload, 88% covered", 23, 3, false),
+            // Same payload size, a third of it folded: the reader keeps enough
+            // to work from, so the trade is the one the ledger is for.
+            ("small payload, 38% covered", 10, 16, true),
+            // Same coverage as the first row on a payload past the floor. The
+            // guard must not reach this: it is the case the feature exists for.
+            ("large payload, 92% covered", 55, 5, true),
+        ];
+
+        for (name, reused, fresh, should_fold) in cases {
+            let (store, _d) = temp_store();
+            let ledger = Ledger::new(&store, "s1");
+
+            let first: String = (0..reused).map(|i| row('s', i)).collect();
+            let seed = format!("{first}{}", (0..40).map(|i| row('p', i)).collect::<String>());
+            assert!(seed.len() > MIN_LEDGER_INPUT, "{name}: seed too small to record");
+            ledger.project(&seed);
+
+            let second: String = (0..reused)
+                .map(|i| row('s', i))
+                .chain((0..fresh).map(|i| row('n', i)))
+                .collect();
+            let folded_bytes = reused * 34;
+            assert_eq!(
+                folded_bytes >= MIN_WHOLE_OUTPUT_FOLD,
+                should_fold && name.starts_with("large"),
+                "{name}: fixture is on the wrong side of the whole-output floor"
+            );
+
+            assert_eq!(
+                ledger.project(&second).is_some(),
+                should_fold,
+                "case: {name}"
+            );
+        }
+    }
 }

--- a/src/ledger/mod.rs
+++ b/src/ledger/mod.rs
@@ -856,7 +856,23 @@ mod tests {
             "a sub-1 KB repeat must stay verbatim rather than become a bare handle"
         );
 
-        let extended = format!("{text}\nsomething this session has never seen before\n");
+        // Four new lines, not one. #601 widened the floor to cover a fold that
+        // takes four fifths or more of its payload, on the evidence that three
+        // surviving lines out of twenty-six were not content anyone could use.
+        // One appended line put this fixture on the wrong side of that, so the
+        // arm below was asserting the floor rather than the absence of it, which
+        // is the failure this test's own prose warns about.
+        let extended = format!(
+            "{text}\n{}",
+            (0..4)
+                .map(|i| format!("something this session has never seen before, {i}\n"))
+                .collect::<String>()
+        );
+        assert!(
+            text.len() * 5 < extended.len() * 4,
+            "the repeated head must be under four fifths of the payload, or this \
+             arm tests the #601 floor instead of a partial fold"
+        );
         let partial = ledger
             .project(&extended)
             .expect("the repeated head still folds beside content the agent can use");
@@ -1170,7 +1186,21 @@ mod tests {
         // either bar is consulted, and the test stops being about the two bars.
         // It also makes the bars above exact: a run marker is what gets rendered
         // here, where a whole-output fold would have rendered the longer wording.
-        let probe = format!("{text}a line neither history has ever seen\n");
+        // Four of them since #601, for the same reason as in the #543 test: one
+        // appended line leaves the fold at nine tenths of the payload, which the
+        // widened floor now refuses, and the two bars this test exists for would
+        // never be reached.
+        let probe = format!(
+            "{text}{}",
+            (0..4)
+                .map(|i| format!("a line neither history has ever seen, {i}\n"))
+                .collect::<String>()
+        );
+        assert!(
+            text.len() * 5 < probe.len() * 4,
+            "the repeat must be under four fifths of the probe, or the #601 floor \
+             decides this before either bar is consulted"
+        );
 
         // Same session: over the session floor, so it projects.
         assert!(Ledger::new(&store, "s1").project(&probe).is_some());

--- a/src/ledger/mod.rs
+++ b/src/ledger/mod.rs
@@ -492,6 +492,31 @@ impl<'a> Ledger<'a> {
         }
 
         let payload_bytes: usize = lines.iter().map(|l| l.len()).sum();
+
+        // How much of this reply the ledger could take, asked once for the
+        // payload rather than once per run (#601, and the review of it).
+        //
+        // The first draft weighed each run against the payload on its own, which
+        // is the wrong denominator and reopens the hole it was closing: three
+        // seen blocks of thirty percent, separated by a line or two of new
+        // content, each pass a four fifths test individually and together fold
+        // ninety percent of the reply. The reader is left with markers and the
+        // separators, which is the reported case wearing three markers instead
+        // of one.
+        //
+        // Coverage is a property of the payload, so it is computed from the
+        // payload. This also subsumes the old whole-output floor exactly: one
+        // run covering everything is a hundred percent coverage, and the byte
+        // test it used to make is the same test this makes.
+        let seen_bytes: usize = runs
+            .iter()
+            .filter(|r| r.seen.is_some())
+            .map(|r| lines[r.start..r.end].iter().map(|l| l.len()).sum::<usize>())
+            .sum();
+        if payload_bytes < MIN_WHOLE_OUTPUT_FOLD && seen_bytes * 5 >= payload_bytes * 4 {
+            return None;
+        }
+
         let mut out = String::with_capacity(payload_bytes);
         let mut folded: HashSet<usize> = HashSet::new();
         let mut replaced_any = false;
@@ -532,34 +557,13 @@ impl<'a> Ledger<'a> {
             // has no say in. Four of four recorded under 1 KB were retrieved
             // within nine seconds (#543), so below that floor the trade is
             // negative and the run stays verbatim.
-            // The whole-output floor, applied to the folds that are the
-            // whole output in every way that matters to a reader (#601).
-            //
-            // `covers_everything` is exact and the danger is not. Resolving a
-            // merge conflict and re-reading the same window folded 23 of 26
-            // lines and delivered `zulu-08/09/10`: three lines that had nothing
-            // to do with the edit, under a marker reading `23 lines already
-            // shown`, which an agent verifying a deletion reads as *nothing
-            // changed*. The deletion and the reorder that were the entire point
-            // produced no new line, so there was nothing for the fold to emit.
-            //
-            // A remainder that small is not context, it is a round trip the
-            // agent has no say in, which is the argument `MIN_WHOLE_OUTPUT_FOLD`
-            // already makes for the exact case. So the floor widens to cover it
-            // and the wording does not: a partial fold still says `N lines
-            // already shown`, because it still is one.
-            //
-            // Priced on 847 recorded folds before choosing four fifths: the
-            // guard refuses 3 of them and 1,748 bytes of 1,439,813, or 0.12% of
-            // everything the ledger has ever saved on this machine. It cannot
-            // reach a large payload, where a 90% fold is the case this feature
-            // exists for and the floor is already met many times over.
-            let leaves_almost_nothing = body.len() * 5 >= payload_bytes * 4;
+            // What is left to ask per run, now that coverage is settled for the
+            // payload above: does this run save more than the marker replacing
+            // it costs. The marker is rendered rather than estimated, so the
+            // test cannot drift from the string it is weighing (#450).
             let long_enough = run.seen.is_some_and(|o| {
                 let marker = render(o, &"0".repeat(HANDLE_LEN)).len();
                 body.len() >= marker + o.min_gain()
-                    && (!(covers_everything || leaves_almost_nothing)
-                        || body.len() >= MIN_WHOLE_OUTPUT_FOLD)
             });
 
             // A handle is only offered for content that is provably retrievable.
@@ -1291,6 +1295,20 @@ mod tests {
         let (store, _d) = temp_store();
         let payload = "19 |   \"x-csrf-token\": csrf,\n                       20 |   Cookie: cookies,\n                       21 | };\n                       22 | \n                       23 | const profiles = await (await fetch(BASE)).json();\n                       24 | const profileId = profiles.profiles[0].id;\n                       TypeError: undefined is not an object (evaluating 'profiles.profiles[0]')\n                             at /tmp/repro237.ts:24:28\n                       Bun v1.3.14 (macOS arm64)\n";
 
+        // Padded past `MIN_WHOLE_OUTPUT_FOLD` since #601. At its original 500-odd
+        // bytes the coverage floor now refuses the whole call, which would leave
+        // this test asserting that an unfolded payload still contains its own
+        // error line, and that is true of any payload. The point here is that the
+        // error survives a fold, so the fixture has to be big enough to get one.
+        let context: String = (0..12)
+            .map(|i| format!("                       {i} |   const value{i} = await load(i);\n"))
+            .collect();
+        let payload = &format!("{context}{payload}");
+        assert!(
+            payload.len() > MIN_WHOLE_OUTPUT_FOLD,
+            "fixture must clear the coverage floor, or no fold happens at all"
+        );
+
         let ledger = Ledger::new(&store, "s1");
         ledger.project(payload);
         let second = ledger
@@ -1373,6 +1391,63 @@ mod tests {
     /// Coverage is what the fold takes of the payload; the floor only applies
     /// once that is four fifths or more **and** the run is under
     /// `MIN_WHOLE_OUTPUT_FOLD`.
+    /// The hole the review of #601 found in its first draft, kept as its own
+    /// test because the matrix above cannot express it: every row there has one
+    /// seen block, and this shape has three.
+    ///
+    /// Three seen blocks of roughly thirty percent each, separated by single new
+    /// lines. Weighed per run against the payload, every block passes a four
+    /// fifths test on its own and all three fold, so the reader is left with
+    /// three markers and two separators, which is the reported case wearing more
+    /// markers. Weighed once for the payload, the coverage is what it always was.
+    #[test]
+    fn counts_coverage_over_the_payload_not_over_one_run() {
+        let (store, _d) = temp_store();
+        let ledger = Ledger::new(&store, "s1");
+
+        // Eight lines, 272 bytes, so each block clears the per-run gain floor on
+        // its own. At six lines it sat under that floor and the test passed
+        // whether or not coverage was consulted, which is no test at all.
+        let block = |tag: char| (0..8).map(|i| row(tag, i)).collect::<String>();
+        let seed = format!("{}{}{}", block('a'), block('b'), block('c'));
+        ledger.project(&seed);
+
+        let second = format!(
+            "{}{}{}{}{}",
+            block('a'),
+            row('x', 0),
+            block('b'),
+            row('x', 1),
+            block('c')
+        );
+        assert!(
+            second.len() < MIN_WHOLE_OUTPUT_FOLD,
+            "the payload must sit under the floor, or coverage is not consulted"
+        );
+        let seen = block('a').len() + block('b').len() + block('c').len();
+        assert!(
+            seen * 5 >= second.len() * 4,
+            "the three blocks must clear four fifths together"
+        );
+        assert!(
+            block('a').len() * 5 < second.len() * 4,
+            "and no single block may clear it alone, or this tests the old rule"
+        );
+        assert!(
+            block('a').len()
+                >= Origin::Session.marker(8, &"0".repeat(HANDLE_LEN)).len()
+                    + Origin::Session.min_gain(),
+            "each block must be able to fold on its own, or the guard is not what \
+             stops it and this test has no teeth"
+        );
+
+        assert_eq!(
+            ledger.project(&second),
+            None,
+            "three sub-threshold blocks folded to markers and two separators"
+        );
+    }
+
     #[test]
     fn refuses_a_small_fold_that_would_leave_almost_nothing() {
         // (name, lines reused from the first show, lines new to the second, folds?)

--- a/src/ledger/mod.rs
+++ b/src/ledger/mod.rs
@@ -491,7 +491,8 @@ impl<'a> Ledger<'a> {
             return None;
         }
 
-        let mut out = String::with_capacity(lines.iter().map(|l| l.len()).sum());
+        let payload_bytes: usize = lines.iter().map(|l| l.len()).sum();
+        let mut out = String::with_capacity(payload_bytes);
         let mut folded: HashSet<usize> = HashSet::new();
         let mut replaced_any = false;
         // How many marker lines stand above the first line that survives. Counted
@@ -531,10 +532,34 @@ impl<'a> Ledger<'a> {
             // has no say in. Four of four recorded under 1 KB were retrieved
             // within nine seconds (#543), so below that floor the trade is
             // negative and the run stays verbatim.
+            // The whole-output floor, applied to the folds that are the
+            // whole output in every way that matters to a reader (#601).
+            //
+            // `covers_everything` is exact and the danger is not. Resolving a
+            // merge conflict and re-reading the same window folded 23 of 26
+            // lines and delivered `zulu-08/09/10`: three lines that had nothing
+            // to do with the edit, under a marker reading `23 lines already
+            // shown`, which an agent verifying a deletion reads as *nothing
+            // changed*. The deletion and the reorder that were the entire point
+            // produced no new line, so there was nothing for the fold to emit.
+            //
+            // A remainder that small is not context, it is a round trip the
+            // agent has no say in, which is the argument `MIN_WHOLE_OUTPUT_FOLD`
+            // already makes for the exact case. So the floor widens to cover it
+            // and the wording does not: a partial fold still says `N lines
+            // already shown`, because it still is one.
+            //
+            // Priced on 847 recorded folds before choosing four fifths: the
+            // guard refuses 3 of them and 1,748 bytes of 1,439,813, or 0.12% of
+            // everything the ledger has ever saved on this machine. It cannot
+            // reach a large payload, where a 90% fold is the case this feature
+            // exists for and the floor is already met many times over.
+            let leaves_almost_nothing = body.len() * 5 >= payload_bytes * 4;
             let long_enough = run.seen.is_some_and(|o| {
                 let marker = render(o, &"0".repeat(HANDLE_LEN)).len();
                 body.len() >= marker + o.min_gain()
-                    && (!covers_everything || body.len() >= MIN_WHOLE_OUTPUT_FOLD)
+                    && (!(covers_everything || leaves_almost_nothing)
+                        || body.len() >= MIN_WHOLE_OUTPUT_FOLD)
             });
 
             // A handle is only offered for content that is provably retrievable.

--- a/src/ledger/mod.rs
+++ b/src/ledger/mod.rs
@@ -1363,8 +1363,14 @@ mod tests {
             let ledger = Ledger::new(&store, "s1");
 
             let first: String = (0..reused).map(|i| row('s', i)).collect();
-            let seed = format!("{first}{}", (0..40).map(|i| row('p', i)).collect::<String>());
-            assert!(seed.len() > MIN_LEDGER_INPUT, "{name}: seed too small to record");
+            let seed = format!(
+                "{first}{}",
+                (0..40).map(|i| row('p', i)).collect::<String>()
+            );
+            assert!(
+                seed.len() > MIN_LEDGER_INPUT,
+                "{name}: seed too small to record"
+            );
             ledger.project(&seed);
 
             let second: String = (0..reused)

--- a/src/pipeline/producer.rs
+++ b/src/pipeline/producer.rs
@@ -279,12 +279,21 @@ pub(crate) fn strip_assignments(command: &str) -> &str {
 /// `/opt/homebrew/opt/python@3.11/bin/python3.11` and `python3.11` are one
 /// program and must be one row.
 pub(crate) fn producer_label(command: &str) -> &str {
-    // The producer when there is a single one, and otherwise the head of the
-    // chain. Falling back to the first segment rather than the whole string is
-    // the half #339 missed: a chain still has a first program, and naming the
-    // row after it beats naming it after the assignment in front of it.
+    // The producer when there is a single one, and otherwise the first segment
+    // that actually runs something. `sole_output_command` answers `None` for a
+    // chain with two producers, and the raw string it was falling back to begins
+    // with whatever `cd` or assignment stands in front, which is the half #339
+    // missed. `is_silent` is the same predicate that decides which segments can
+    // own the output, so the label agrees with the routing by construction.
+    //
+    // Every segment silent means nothing wrote to stdout, and the whole string
+    // is then as good a name as any.
     let segment = sole_output_command(command)
-        .or_else(|| split_sequential(command).into_iter().next())
+        .or_else(|| {
+            split_sequential(command)
+                .into_iter()
+                .find(|seg| !is_silent(seg))
+        })
         .unwrap_or(command);
     program_name(strip_assignments(segment))
 }
@@ -372,5 +381,65 @@ fn push_segment<'a>(out: &mut Vec<&'a str>, command: &'a str, start: usize, end:
     let seg = command[start..end].trim();
     if !seg.is_empty() {
         out.push(seg);
+    }
+}
+
+#[cfg(test)]
+mod producer_label_tests {
+    use super::producer_label;
+
+    /// #603, as a matrix rather than one case, because the two writers of
+    /// `filter_name` failed on different shapes: the exec door failed on a bare
+    /// assignment and the hook door only on a chain with two producers. A single
+    /// fixture passes on one door and proves nothing about the other.
+    ///
+    /// Every row is a command shape that really occurs in the recorded corpus.
+    #[test]
+    fn labels_a_command_with_its_program() {
+        let cases = [
+            ("bare", "echo hi", "echo"),
+            ("assignment", "FOO=bar echo hi", "echo"),
+            ("two assignments", "A=1 B=2 echo hi", "echo"),
+            // The shape the hook door got wrong: `sole_output_command` answers
+            // `None` here, and the old fallback took the raw first token.
+            ("assignment then chain", "FOO=bar echo one && echo two", "echo"),
+            ("chain", "echo one && echo two", "echo"),
+            ("cd prefix", "cd /tmp && kubectl get pods", "kubectl"),
+            // Two producers, so `sole_output_command` declines and the fallback
+            // decides. It has to skip the `cd`, or the row is filed under the
+            // one segment that produced no output, which is #339's other half.
+            (
+                "cd prefix and two producers",
+                "cd /tmp && kubectl get pods && kubectl get svc",
+                "kubectl",
+            ),
+            (
+                "assignment, cd, then two producers",
+                "K=1 cd /tmp && echo one && echo two",
+                "echo",
+            ),
+            // 291 rows named a binary's full path before this.
+            ("absolute path", "/opt/homebrew/bin/python3.11 x.py", "python3.11"),
+            (
+                "assignment and absolute path",
+                "S=/tmp/scratch /usr/bin/env node app.js",
+                "env",
+            ),
+            ("quoted program", "\"kubectl\" get pods", "kubectl"),
+            // ponytail: the split is on whitespace before the quotes come off,
+            // so a program name containing a space keeps only its first word.
+            // Inherited from `resolve_profile`, which has routed this way since
+            // it was written, and no recorded command has that shape. A quote
+            // aware split is the upgrade if one ever does.
+            ("quoted program with a space", "\"my prog\" --flag", "my"),
+            // Pipe mode has no command at all, and the caller turns this into
+            // `[pipe]`. Anything else here would invent a program name.
+            ("empty", "", ""),
+            ("assignment only", "FOO=bar", ""),
+        ];
+
+        for (name, command, expected) in cases {
+            assert_eq!(producer_label(command), expected, "case: {name}");
+        }
     }
 }

--- a/src/pipeline/producer.rs
+++ b/src/pipeline/producer.rs
@@ -402,7 +402,11 @@ mod producer_label_tests {
             ("two assignments", "A=1 B=2 echo hi", "echo"),
             // The shape the hook door got wrong: `sole_output_command` answers
             // `None` here, and the old fallback took the raw first token.
-            ("assignment then chain", "FOO=bar echo one && echo two", "echo"),
+            (
+                "assignment then chain",
+                "FOO=bar echo one && echo two",
+                "echo",
+            ),
             ("chain", "echo one && echo two", "echo"),
             ("cd prefix", "cd /tmp && kubectl get pods", "kubectl"),
             // Two producers, so `sole_output_command` declines and the fallback
@@ -419,7 +423,11 @@ mod producer_label_tests {
                 "echo",
             ),
             // 291 rows named a binary's full path before this.
-            ("absolute path", "/opt/homebrew/bin/python3.11 x.py", "python3.11"),
+            (
+                "absolute path",
+                "/opt/homebrew/bin/python3.11 x.py",
+                "python3.11",
+            ),
             (
                 "assignment and absolute path",
                 "S=/tmp/scratch /usr/bin/env node app.js",

--- a/src/pipeline/producer.rs
+++ b/src/pipeline/producer.rs
@@ -258,6 +258,54 @@ pub(crate) fn strip_assignments(command: &str) -> &str {
     rest
 }
 
+/// The program name to file a recorded row under, for any command string.
+///
+/// #339 taught `sole_output_command` to strip assignments and closed. It fixed
+/// routing and left `distillations.filter_name` wrong in two places, because
+/// neither writer of that column went through here:
+///
+/// * `hooks::pipe` took the first token of the raw command and nothing else, so
+///   the exec and pipe door never received the fix at all.
+/// * `hooks::post_tool` did call `sole_output_command`, but through
+///   `.unwrap_or(command)`. That function answers `None` for any chain with two
+///   producers, and the fallback then handed the raw chain back.
+///
+/// Measured on 0.7.6 before the change: 1,525 of 11,335 rows named an assignment
+/// and 291 named a binary's full path, 16.0% of the corpus, against #339's own
+/// 1,079 before it was closed. Every aggregate keyed on this column was wrong by
+/// that much, including the workload numbers this repo sizes distillers from.
+///
+/// The file name, not the path, for the same reason `resolve_profile` takes it:
+/// `/opt/homebrew/opt/python@3.11/bin/python3.11` and `python3.11` are one
+/// program and must be one row.
+pub(crate) fn producer_label(command: &str) -> &str {
+    // The producer when there is a single one, and otherwise the head of the
+    // chain. Falling back to the first segment rather than the whole string is
+    // the half #339 missed: a chain still has a first program, and naming the
+    // row after it beats naming it after the assignment in front of it.
+    let segment = sole_output_command(command)
+        .or_else(|| split_sequential(command).into_iter().next())
+        .unwrap_or(command);
+    program_name(strip_assignments(segment))
+}
+
+/// The bare program name of an already-stripped command.
+///
+/// Shared with `resolve_profile`, which decided routing on exactly this and had
+/// its own copy. Two copies of one predicate drift and only one of them gets
+/// reported, which is how the two halves of #339 came apart in the first place.
+pub(crate) fn program_name(command: &str) -> &str {
+    let first = command
+        .split_whitespace()
+        .next()
+        .unwrap_or(command)
+        .trim_matches(|c| c == '"' || c == '\'');
+    std::path::Path::new(first)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(first)
+}
+
 /// `i=0` and `f=path/to.yaml` set a variable and print nothing. Distinguished
 /// from a command by the `=` before any `/`, so `./bin/x=y` is still a command.
 pub(crate) fn is_assignment(word: &str) -> bool {

--- a/src/pipeline/registry.rs
+++ b/src/pipeline/registry.rs
@@ -29,17 +29,7 @@ pub fn resolve_profile(command: &str) -> ToolProfile {
     }
 
     let cmd = strip_assignments(command.trim());
-    let base = {
-        let first_word = cmd
-            .split_whitespace()
-            .next()
-            .unwrap_or(cmd)
-            .trim_matches(|c| c == '"' || c == '\'');
-        std::path::Path::new(first_word)
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or(first_word)
-    };
+    let base = crate::pipeline::producer::program_name(cmd);
     let cmd_lower = cmd.to_lowercase();
 
     // 1. Git: Hunk based


### PR DESCRIPTION
Closes #598
Closes #601
Closes #603

The three `stage: now` issues, batched into one branch because they are one CI
cycle and no reviewer needs them apart. Every one was re-reproduced on 0.7.6
first, and one of the three turned out to have a different mechanism than its
report.

Verified on the real binary through the post-hook, released 0.7.6 against this
branch, not only in unit tests:

| | 0.7.6 | this branch |
| --- | --- | --- |
| #601 verifying a resolved conflict, 523 B window | folded to 257 B, **1** content line reaches the agent | no fold, all 22 lines reach it |
| #603 `FOO=bar echo one && echo two` | filed as `FOO=bar` | `echo` |
| #603 `cd /tmp && kubectl get pods && kubectl get svc` | filed as `cd` | `kubectl` |
| #598 a 303 line `.ts` read | reply advertises `offset/limit` | route removed, reply 41 B smaller |

#602's report was wrong about its own mechanism and is not in here: the rows are
recorded, the MCP process just reads a different session id. It stays `stage:
later` until that question is answered.

**Cost, measured before choosing the shape.** The #601 guard refuses 3 of 847
recorded folds and 1,748 bytes of 1,439,813, 0.12% of everything the ledger has
saved here. Latency is unchanged: three paired runs of 40 hook calls read 13.2 ms
median against 14.4 ms, and the ordering flips between runs, so the honest
reading is noise rather than a win. Nothing here makes OMNI save more; two of the
three stop it claiming something it cannot support, which is the same trade this
repo has made every time.

Two things the tests found that the fixes had missed. Writing #603 as a matrix
rather than one case exposed that the new fallback named a chain after its `cd`,
and the break test found the fallback was dead until that was fixed. The #601
guard then broke two existing ledger tests whose fixtures were one appended line
away from a whole-output fold; #543's own prose calls that survivor "content the
agent can use", and one line is not, so the fixtures moved rather than the floor.

`make ci` green, and every matrix driven red in three directions with each
direction failing a different row.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes misleading read-file recovery guidance, normalizes producer labels across both hook paths, and adds a payload-wide floor for small ledger folds.
- Removes the ineffective offset/limit recovery instruction from distilled file skeletons.
- Centralizes command producer labeling, including assignment prefixes, paths, and command chains.
- Prevents small ledger projections from folding at least four fifths of the payload.
- Expands regression matrices for command labeling and ledger coverage behavior.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/ledger/mod.rs | Adds aggregate payload-coverage gating for small ledger folds and updates threshold-sensitive regression fixtures. |
| src/pipeline/producer.rs | Introduces shared producer-label and program-name normalization with a command-shape test matrix. |
| src/hooks/post_tool.rs | Uses the shared producer-label helper when recording post-tool distillation metadata. |
| src/hooks/pipe.rs | Uses the same normalized producer label for pipe and exec recording paths. |
| src/distillers/readfile.rs | Rewords omitted-content notes to remove an ineffective recovery instruction and clarify the line-count denominator. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ledger): ask coverage once for the p..."](https://github.com/fajarhide/omni/commit/8229b0f874247f37f5a28cc016dd84e58df740d6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54341593)</sub>

<!-- /greptile_comment -->