### PR TITLE
docs: an average over one mix is not a floor under yours

### DIFF
--- a/docs/website/src-id/index.md
+++ b/docs/website/src-id/index.md
@@ -161,9 +161,10 @@ untuk dilaporkan.
 
 Angka **14,9%** di tabel atas sengaja dari korpus yang berbeda: harness yang sama
 pada satu minggu kerja biasa, dengan setiap pengembalian tadi ikut dihitung bersama
-kemenangannya. Baca keduanya berpasangan. Baris per kelas itulah yang memprediksi
-beban kerja Anda, sementara angka gabungan adalah lantainya, bukan
-langit-langitnya. Itu rata-rata
+kemenangannya. Itu rata-rata atas campuran tersebut, bukan janji untuk campuran Anda.
+Baris per kelas itulah yang memprediksi beban kerja Anda sendiri, dan rentangnya dari
+**4,3%** pada pencarian sampai **89,6%** pada pembacaan ulang file, jadi cari kelas
+yang benar-benar Anda jalankan. Itu rata-rata
 nyata atas campuran perintah yang nyata, bukan kasus terbaik yang dipetik dari
 hari yang bagus.
 

--- a/docs/website/src/index.md
+++ b/docs/website/src/index.md
@@ -135,10 +135,10 @@ report.
 
 The **14.9%** in the table above is a different corpus on purpose: the same harness over
 a week of ordinary work, with every one of those hands-back counted in alongside the
-wins. Read the two together. The per-class row is what predicts your workload, and the
-aggregate is the floor of what the tool does rather than the ceiling. Both corpora, the
-method, and every unflattering figure we have are on
-[Benchmarks](develop/benchmarks.md).
+wins. It is an average over that mix, not a promise for yours. The per-class rows are
+what predict your own workload and they run from **4.3%** on search to **89.6%** on file
+re-reads, so find the classes you actually run. Both corpora, the method, and every
+unflattering figure we have are on [Benchmarks](develop/benchmarks.md).
 
 Against the closest comparable tools on identical bytes, the ledger is what puts OMNI
 ahead overall. The full head-to-head, including the arm where another tool's filters


### PR DESCRIPTION
Follow-up to #606, from Greptile's review on it. Valid, and it is the copy doctrine's
own failure mode running the other way.

#606 fixed an understatement: the pages led with "97.3% of calls saved nothing at
all", which averages the payloads OMNI declines on purpose into the calls that win.
The replacement called the 14.9% aggregate "the floor of what the tool does rather
than the ceiling". That is an overstatement. The same pages record search at 4.3%,
`git` at 7.0%, infra at 6.8% and a `kubectl get pods` case at 0%, so 14.9% is a lower
bound for nothing.

It now says what it is, an average over that mix and not a promise for yours, and
quotes the per-class range so a reader can find their own workload rather than taking
the mean: 4.3% on search to 89.6% on file re-reads. Still leads with the win, without
inventing a guarantee to do it.

English and Indonesian. The matching change on omni-pages is in its own PR.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This documentation-only PR replaces a misleading “floor” characterization of the 14.9% aggregate in the English and Indonesian landing pages.
- Reframes 14.9% as an average over a particular workload mix rather than a guarantee.
- Adds per-class endpoint figures intended to help readers identify representative workloads.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until the newly quoted per-class range is drawn from the 14.9% ordinary-work corpus or the different corpus is clearly disclosed.

The revised copy removes the floor claim but still misleads readers by pairing an ordinary-work aggregate with per-class figures from a separate corpus that the benchmark documentation explicitly characterizes as unusual and inflated.

**Files Needing Attention:** docs/website/src/index.md and docs/website/src-id/index.md
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/website/src/index.md | Corrects the aggregate wording but associates it with endpoint figures from a different, explicitly inflated corpus. |
| docs/website/src-id/index.md | Faithfully mirrors the English correction and therefore carries over the same corpus mismatch. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20fajarhide%2Fomni%20PR%20%23607%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=fajarhide%2Fomni&pr=607&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Adocs%2Fwebsite%2Fsrc%2Findex.md%3A138-140%0A**Per-class%20range%20mixes%20corpora**%0A%0AWhen%20readers%20use%20this%20range%20to%20interpret%20the%20preceding%2014.9%25%20ordinary-work%20average%2C%20the%20copy%20substitutes%20class%20endpoints%20from%20the%20separate%205%2C984-call%20corpus%20that%20the%20benchmark%20page%20describes%20as%20unusual%20and%20inflated.%20The%206%2C656-command%20corpus%20behind%2014.9%25%20actually%20ranges%20from%206.9%25%20to%2078.0%25%2C%20so%20this%20pairing%20gives%20readers%20a%20misleading%20workload%20estimate.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni&pr=607&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fajarhide%2Fomni%22%20on%20the%20existing%20branch%20%22docs%2Faggregate-is-not-a-floor%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2Faggregate-is-not-a-floor%22.%0A%0A%23%23%23%20Issue%201%0Adocs%2Fwebsite%2Fsrc%2Findex.md%3A138-140%0A**Per-class%20range%20mixes%20corpora**%0A%0AWhen%20readers%20use%20this%20range%20to%20interpret%20the%20preceding%2014.9%25%20ordinary-work%20average%2C%20the%20copy%20substitutes%20class%20endpoints%20from%20the%20separate%205%2C984-call%20corpus%20that%20the%20benchmark%20page%20describes%20as%20unusual%20and%20inflated.%20The%206%2C656-command%20corpus%20behind%2014.9%25%20actually%20ranges%20from%206.9%25%20to%2078.0%25%2C%20so%20this%20pairing%20gives%20readers%20a%20misleading%20workload%20estimate.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni&pr=607&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Adocs%2Fwebsite%2Fsrc%2Findex.md%3A138-140%0A**Per-class%20range%20mixes%20corpora**%0A%0AWhen%20readers%20use%20this%20range%20to%20interpret%20the%20preceding%2014.9%25%20ordinary-work%20average%2C%20the%20copy%20substitutes%20class%20endpoints%20from%20the%20separate%205%2C984-call%20corpus%20that%20the%20benchmark%20page%20describes%20as%20unusual%20and%20inflated.%20The%206%2C656-command%20corpus%20behind%2014.9%25%20actually%20ranges%20from%206.9%25%20to%2078.0%25%2C%20so%20this%20pairing%20gives%20readers%20a%20misleading%20workload%20estimate.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=607&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fajarhide%2Fomni%22%20on%20the%20existing%20branch%20%22docs%2Faggregate-is-not-a-floor%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2Faggregate-is-not-a-floor%22.%0A%0A%23%23%23%20Issue%201%0Adocs%2Fwebsite%2Fsrc%2Findex.md%3A138-140%0A**Per-class%20range%20mixes%20corpora**%0A%0AWhen%20readers%20use%20this%20range%20to%20interpret%20the%20preceding%2014.9%25%20ordinary-work%20average%2C%20the%20copy%20substitutes%20class%20endpoints%20from%20the%20separate%205%2C984-call%20corpus%20that%20the%20benchmark%20page%20describes%20as%20unusual%20and%20inflated.%20The%206%2C656-command%20corpus%20behind%2014.9%25%20actually%20ranges%20from%206.9%25%20to%2078.0%25%2C%20so%20this%20pairing%20gives%20readers%20a%20misleading%20workload%20estimate.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
docs/website/src/index.md:138-140
**Per-class range mixes corpora**

When readers use this range to interpret the preceding 14.9% ordinary-work average, the copy substitutes class endpoints from the separate 5,984-call corpus that the benchmark page describes as unusual and inflated. The 6,656-command corpus behind 14.9% actually ranges from 6.9% to 78.0%, so this pairing gives readers a misleading workload estimate.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: an average over one mix is not a f..."](https://github.com/fajarhide/omni/commit/480f6f14a4cabc11410d70f27c66e55e49834ff9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54367347)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->