### PR TITLE
fix: a diffstat that counts the diff, and a release gate that builds what it tests

### DIFF
--- a/changelog.d/597.fixed.md
+++ b/changelog.d/597.fixed.md
@@ -1,0 +1,15 @@
+**The release script builds the binary it smoke-tests.** `scripts/omni-release.sh`
+ran `tests/smoke_test.sh ./target/release/omni` and never built that file, so the
+last gate before a tag validated whatever binary happened to be on disk. Cutting
+0.7.6 stopped at `Results: 44/46 passed, 2 failed` against a `target/release/omni`
+two days old, minutes after `make binary-check` passed 46/46 against a freshly
+built `target/ci/omni`. The two gates disagreed because they test different files
+and only one of them built what it tested.
+
+Failing loudly was the lucky direction. The same staleness passes silently
+whenever the old binary still satisfies the checks, and it does today: the
+two-day-old 0.7.6 binary in this tree passes 46 of 46. A gate that can go green on
+a build nobody made is not a gate. `smoke_test.sh` also falls back to
+`./target/debug/omni` when the release path is missing, so a machine that has
+never built release validated a debug binary and said nothing about it; building
+first removes that fallback's ability to fire during a release.

--- a/changelog.d/616.fixed.md
+++ b/changelog.d/616.fixed.md
@@ -12,9 +12,17 @@ diff adding one line and removing five came back as
 `git diff: 1 files changed, 0+, 0-` with no hunk under it. A reader concludes the
 commit changed nothing.
 
-The counts now come from the payload, the same lines `git show --numstat` counts,
-and the tier may only drop a segment that carries no diff. The per-line filter
-below it already decided what a hunk contributes.
+The counts now come from the payload, and position decides what counts rather
+than the leading character: `+` and `-` lines inside a hunk, nothing outside one.
+That was the other half of the same defect. `git show --format=%B -p` prints the
+commit body unindented, so a body line opening with `-` read as a removal and a
+60+/60- diff came out as `61+, 62-`. Position also settles a case a prefix test
+gets wrong in the opposite direction: a removed line whose own text starts with
+`--` renders as `--- …`, so excluding `---` dropped a real removal from the
+output while the summary still counted it. Shown and counted now follow one rule.
+
+A tier may only drop a segment that carries no hunk. The per-line filter below it
+already decided what a hunk contributes.
 
 Worth saying because the report that found this described a different mechanism:
 its own `git show … | sed … | head -40` had cut the removal hunk before OMNI saw

--- a/changelog.d/616.fixed.md
+++ b/changelog.d/616.fixed.md
@@ -1,0 +1,22 @@
+**The `git diff` summary is measured from the diff, and a decorative hunk no
+longer disappears under it.** The `git diff: N files changed, X+, Y-` line counted
+the `+` and `-` lines that survived the scorer rather than the ones in the payload
+it replaces, so it reported a diffstat for the filtered output while reading as a
+diffstat for the commit.
+
+One tier turns that into a false claim on its own. `is_blank_or_decorative` tiers
+a block whose lines carry only `-`, `=`, `*` or `_` as Noise, and a hunk removing
+a rule of `=====` characters is exactly that once each line carries its `-`
+marker. The whole segment was skipped before the emit and before the count, so a
+diff adding one line and removing five came back as
+`git diff: 1 files changed, 0+, 0-` with no hunk under it. A reader concludes the
+commit changed nothing.
+
+The counts now come from the payload, the same lines `git show --numstat` counts,
+and the tier may only drop a segment that carries no diff. The per-line filter
+below it already decided what a hunk contributes.
+
+Worth saying because the report that found this described a different mechanism:
+its own `git show … | sed … | head -40` had cut the removal hunk before OMNI saw
+it, and the `1+, 0-` in that transcript was true about every byte OMNI received.
+The defect above was found while failing to reproduce that one.

--- a/scripts/omni-release.sh
+++ b/scripts/omni-release.sh
@@ -83,6 +83,14 @@ ok "cargo clippy: no warnings"
 
 # 8. Smoke test
 if [ -x tests/smoke_test.sh ]; then
+    # Build what we are about to validate. Without this the gate tests whichever
+    # binary happens to sit in target/release, which on 0.7.6 was two days old and
+    # failed 2 of 46 checks that `make binary-check` had just passed against a
+    # freshly built target/ci/omni. A gate that can go green on a stale build is
+    # not a gate, and smoke_test.sh silently falls back to target/debug/omni when
+    # the release path is missing (#597).
+    echo "   Building release binary..."
+    cargo build --release > /tmp/omni-build 2>&1 || { cat /tmp/omni-build && fail "release build failed"; }
     echo "   Running smoke tests..."
     bash tests/smoke_test.sh ./target/release/omni > /tmp/omni-smoke 2>&1 || { cat /tmp/omni-smoke && fail "smoke test failed"; }
     ok "Smoke test: all pass"

--- a/scripts/omni-release.sh
+++ b/scripts/omni-release.sh
@@ -91,8 +91,17 @@ if [ -x tests/smoke_test.sh ]; then
     # the release path is missing (#597).
     echo "   Building release binary..."
     cargo build --release > /tmp/omni-build 2>&1 || { cat /tmp/omni-build && fail "release build failed"; }
+    # Ask cargo where it put the binary rather than assuming ./target. With
+    # CARGO_TARGET_DIR or a build.target-dir in .cargo/config.toml, the build
+    # lands elsewhere and a hard-coded path re-opens exactly the divergence this
+    # step closes: the smoke test would read a stale ./target/release/omni, or
+    # fall through to ./target/debug/omni and say nothing about it.
+    TARGET_DIR=$(cargo metadata --format-version 1 --no-deps --offline 2>/dev/null \
+        | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p')
+    [ -n "$TARGET_DIR" ] || TARGET_DIR="${CARGO_TARGET_DIR:-target}"
+    [ -x "$TARGET_DIR/release/omni" ] || fail "release binary not at $TARGET_DIR/release/omni after build"
     echo "   Running smoke tests..."
-    bash tests/smoke_test.sh ./target/release/omni > /tmp/omni-smoke 2>&1 || { cat /tmp/omni-smoke && fail "smoke test failed"; }
+    bash tests/smoke_test.sh "$TARGET_DIR/release/omni" > /tmp/omni-smoke 2>&1 || { cat /tmp/omni-smoke && fail "smoke test failed"; }
     ok "Smoke test: all pass"
 fi
 

--- a/src/distillers/git.rs
+++ b/src/distillers/git.rs
@@ -95,11 +95,39 @@ fn distill_status(input: &str) -> String {
     out
 }
 
-/// Whether a line is diff payload rather than prose around it.
-fn is_diff_line(line: &str) -> bool {
-    line.starts_with("@@ ")
-        || (line.starts_with('+') && !line.starts_with("+++"))
-        || (line.starts_with('-') && !line.starts_with("---"))
+/// The diffstat, counted the way `git show --numstat` counts it: `+` and `-`
+/// lines inside a hunk, and nothing outside one.
+///
+/// Position is what separates a diff line from prose, not the leading character.
+/// `git show --format=%B -p` prints the commit body unindented, so a body line
+/// opening with `-` reads as a removal, and counting those turned a 60+/60- diff
+/// into `61+, 62-` (review of #618). Being inside a hunk also excludes the
+/// `---`/`+++` file headers by position, which matters: a removed line whose own
+/// text starts with `--` renders as `--- …`, so testing the prefix would have
+/// dropped a real removal.
+fn count_hunk_lines(input: &str) -> (usize, usize) {
+    let mut in_hunk = false;
+    let (mut added, mut removed) = (0, 0);
+    for line in input.lines() {
+        if line.starts_with("diff --git") {
+            in_hunk = false;
+        } else if line.starts_with("@@ ") {
+            in_hunk = true;
+        } else if in_hunk {
+            if line.starts_with('+') {
+                added += 1;
+            } else if line.starts_with('-') {
+                removed += 1;
+            }
+        }
+    }
+    (added, removed)
+}
+
+/// Whether a segment carries a hunk, which is what makes it diff rather than the
+/// prose around one.
+fn holds_a_hunk(content: &str) -> bool {
+    content.lines().any(|l| l.starts_with("@@ "))
 }
 
 fn distill_diff(segments: &[OutputSegment], input: &str) -> String {
@@ -109,16 +137,8 @@ fn distill_diff(segments: &[OutputSegment], input: &str) -> String {
     // Counted over the payload, never over what survived the filter below. The
     // summary labels the diff it replaces, so a line the scorer dropped is still
     // a line the diff changed, and reporting the surviving count as the diffstat
-    // is a measurement the output cannot support (#616). `git show --numstat`
-    // counts the same lines: body only, both file headers excluded.
-    let added = input
-        .lines()
-        .filter(|l| l.starts_with('+') && !l.starts_with("+++"))
-        .count();
-    let removed = input
-        .lines()
-        .filter(|l| l.starts_with('-') && !l.starts_with("---"))
-        .count();
+    // is a measurement the output cannot support (#616).
+    let (added, removed) = count_hunk_lines(input);
 
     for seg in segments {
         if seg.content.starts_with("diff --git") {
@@ -142,7 +162,7 @@ fn distill_diff(segments: &[OutputSegment], input: &str) -> String {
         // `git diff: 1 files changed, 0+, 0-` with no hunk at all (#616). The
         // per-line filter further down already decides what a segment
         // contributes; the tier only gets to drop a segment carrying no diff.
-        if seg.tier == SignalTier::Noise && !seg.content.lines().any(is_diff_line) {
+        if seg.tier == SignalTier::Noise && !holds_a_hunk(&seg.content) {
             continue;
         }
 
@@ -154,8 +174,17 @@ fn distill_diff(segments: &[OutputSegment], input: &str) -> String {
         // Noise, which is the assumption #616 was built on.
         let keep_context = seg.context_score > 0.0 || seg.tier == SignalTier::Critical;
 
+        // Same position rule the counts use, so what is shown and what is counted
+        // cannot disagree. A removed line whose own text starts with `--` renders
+        // as `--- …`, and the prefix test that used to stand here dropped it from
+        // the output while the summary still counted it (review of #618).
+        let mut in_hunk = false;
         for line in seg.content.lines() {
-            let keep = is_diff_line(line)
+            if line.starts_with("@@ ") {
+                in_hunk = true;
+            }
+            let keep = line.starts_with("@@ ")
+                || (in_hunk && (line.starts_with('+') || line.starts_with('-')))
                 || (keep_context
                     && !line.starts_with("+++")
                     && !line.starts_with("---")
@@ -432,6 +461,50 @@ index 1111111..2222222 100644
             out.lines().filter(|l| *l == "-=====").count(),
             5,
             "the removed hunk did not survive: {out:?}"
+        );
+    }
+
+    /// Review of #618. Position decides whether a line is diff payload, not its
+    /// leading character. `git show --format=%B -p` prints the commit body
+    /// unindented, so a body line opening with `-` reads as a removal; counting
+    /// those turned a 60+/60- diff into `61+, 62-`.
+    ///
+    /// The hunk here also removes a line whose own text starts with `--`, which
+    /// git renders as `--- comment`. Excluding it by prefix, the obvious way to
+    /// keep the file headers out, would drop a real removal instead.
+    #[test]
+    fn diffstat_counts_hunk_lines_and_not_the_prose_around_them() {
+        let input = "\
+fix: rewrite the table
+
+- dropped the legacy branch
+- dropped the second legacy branch
++ added nothing, this is prose
+
+diff --git a/src/table.rs b/src/table.rs
+index 1111111..2222222 100644
+--- a/src/table.rs
++++ b/src/table.rs
+@@ -1,3 +1,2 @@
+ use std::fmt;
+--- comment
+-let x = 1;
++let x = 2;
+";
+        let cmd = "git show --format=%B -p abc1234 -- src/table.rs";
+        let profile = crate::pipeline::registry::resolve_profile(cmd);
+        let segments =
+            crate::pipeline::scorer::score_segments(input, profile.segmentation, None, cmd);
+        let out = distill_diff(&segments, input);
+
+        assert!(
+            out.contains("1 files changed, 1+, 2-"),
+            "prose leaked into the diffstat: {out:?}"
+        );
+        assert!(
+            out.contains("--- comment"),
+            "a removal whose text starts with `--` was dropped from the output \
+             while the summary counted it: {out:?}"
         );
     }
 }

--- a/src/distillers/git.rs
+++ b/src/distillers/git.rs
@@ -95,11 +95,30 @@ fn distill_status(input: &str) -> String {
     out
 }
 
-fn distill_diff(segments: &[OutputSegment], _input: &str) -> String {
+/// Whether a line is diff payload rather than prose around it.
+fn is_diff_line(line: &str) -> bool {
+    line.starts_with("@@ ")
+        || (line.starts_with('+') && !line.starts_with("+++"))
+        || (line.starts_with('-') && !line.starts_with("---"))
+}
+
+fn distill_diff(segments: &[OutputSegment], input: &str) -> String {
     let mut out = String::new();
-    let mut added = 0;
-    let mut removed = 0;
     let mut files = std::collections::HashSet::new();
+
+    // Counted over the payload, never over what survived the filter below. The
+    // summary labels the diff it replaces, so a line the scorer dropped is still
+    // a line the diff changed, and reporting the surviving count as the diffstat
+    // is a measurement the output cannot support (#616). `git show --numstat`
+    // counts the same lines: body only, both file headers excluded.
+    let added = input
+        .lines()
+        .filter(|l| l.starts_with('+') && !l.starts_with("+++"))
+        .count();
+    let removed = input
+        .lines()
+        .filter(|l| l.starts_with('-') && !l.starts_with("---"))
+        .count();
 
     for seg in segments {
         if seg.content.starts_with("diff --git") {
@@ -115,32 +134,33 @@ fn distill_diff(segments: &[OutputSegment], _input: &str) -> String {
             continue;
         }
 
-        if seg.tier == SignalTier::Noise {
+        // A hunk is never noise. `is_blank_or_decorative` tiers a block whose
+        // lines hold only `-`, `=`, `*` or `_` as Noise, which is exactly what a
+        // diff removing a rule of `=====` looks like once each line carries its
+        // `-` marker. Skipping the segment dropped the hunk from the output and
+        // from the counts below, so a 1+/5- diff came out as
+        // `git diff: 1 files changed, 0+, 0-` with no hunk at all (#616). The
+        // per-line filter further down already decides what a segment
+        // contributes; the tier only gets to drop a segment carrying no diff.
+        if seg.tier == SignalTier::Noise && !seg.content.lines().any(is_diff_line) {
             continue;
         }
 
         let mut hunk_out = String::new();
-        // Since all hunks contain "@@ -", their tier is Important (0.7).
-        // To achieve >60% reduction, we only keep context lines if specifically boosted by session context (context_score > 0).
+        // Context lines are kept only when session context boosted the segment,
+        // which is what buys the >60% reduction. The old note here claimed a hunk
+        // is always Important because it contains "@@ -"; the tier is assigned by
+        // `classify_block` over the whole block and a decorative one comes back
+        // Noise, which is the assumption #616 was built on.
         let keep_context = seg.context_score > 0.0 || seg.tier == SignalTier::Critical;
 
         for line in seg.content.lines() {
-            if line.starts_with("@@ ") {
-                hunk_out.push_str(line);
-                hunk_out.push('\n');
-            } else if line.starts_with('+') && !line.starts_with("+++") {
-                added += 1;
-                hunk_out.push_str(line);
-                hunk_out.push('\n');
-            } else if line.starts_with('-') && !line.starts_with("---") {
-                removed += 1;
-                hunk_out.push_str(line);
-                hunk_out.push('\n');
-            } else if keep_context
-                && !line.starts_with("+++")
-                && !line.starts_with("---")
-                && !line.starts_with("index")
-            {
+            let keep = is_diff_line(line)
+                || (keep_context
+                    && !line.starts_with("+++")
+                    && !line.starts_with("---")
+                    && !line.starts_with("index"));
+            if keep {
                 hunk_out.push_str(line);
                 hunk_out.push('\n');
             }
@@ -362,6 +382,56 @@ Date:   Mon Mar 20 10:00:00 2026 +0700
         assert!(
             !out.contains("this body line must not survive"),
             "body leaked as subject: {out:?}"
+        );
+    }
+
+    /// #616. The summary is a claim about the diff, so it has to be measured
+    /// from the diff. It used to count the `+`/`-` lines that survived the
+    /// filter, and a hunk whose removed lines hold only rule characters is
+    /// tiered `Noise` by `is_blank_or_decorative` and was skipped before either
+    /// the emit or the count. A 1+/5- diff came back as
+    /// `git diff: 1 files changed, 0+, 0-` with no hunk under it, which reads as
+    /// a commit that changed nothing.
+    ///
+    /// Scored through the real scorer on purpose: with a hand-built `Important`
+    /// segment the tier that causes this never occurs and the test passes either
+    /// way.
+    #[test]
+    fn diffstat_counts_the_diff_and_a_decorative_hunk_survives() {
+        let input = "\
+diff --git a/docs/banner.txt b/docs/banner.txt
+index 1111111..2222222 100644
+--- a/docs/banner.txt
++++ b/docs/banner.txt
+@@ -1,7 +1,2 @@
+ title
+-=====
+-=====
+-=====
+-=====
+-=====
++short
+";
+        let cmd = "git show abc1234 -- docs/banner.txt";
+        let profile = crate::pipeline::registry::resolve_profile(cmd);
+        let segments =
+            crate::pipeline::scorer::score_segments(input, profile.segmentation, None, cmd);
+        assert!(
+            segments.iter().any(|s| s.tier == SignalTier::Noise),
+            "fixture no longer produces the Noise tier this guards: {:?}",
+            segments.iter().map(|s| &s.tier).collect::<Vec<_>>()
+        );
+
+        let out = distill_diff(&segments, input);
+
+        assert!(
+            out.contains("1 files changed, 1+, 5-"),
+            "diffstat does not match the payload: {out:?}"
+        );
+        assert_eq!(
+            out.lines().filter(|l| *l == "-=====").count(),
+            5,
+            "the removed hunk did not survive: {out:?}"
         );
     }
 }

--- a/src/distillers/git.rs
+++ b/src/distillers/git.rs
@@ -95,29 +95,92 @@ fn distill_status(input: &str) -> String {
     out
 }
 
-/// The diffstat, counted the way `git show --numstat` counts it: `+` and `-`
-/// lines inside a hunk, and nothing outside one.
+/// The old and new line counts a hunk header declares, from `@@ -a,b +c,d @@`.
+/// A missing count means one line, which is how git writes a single-line hunk.
+fn parse_hunk_header(line: &str) -> Option<(usize, usize)> {
+    let body = line.strip_prefix("@@ ")?;
+    let (ranges, _) = body.split_once(" @@")?;
+    let (old, new) = ranges.split_once(' ')?;
+    let count = |r: &str| -> Option<usize> {
+        match r.get(1..)?.split_once(',') {
+            Some((_, n)) => n.parse().ok(),
+            None => Some(1),
+        }
+    };
+    Some((count(old)?, count(new)?))
+}
+
+/// Walks a payload line by line and says which lines are hunk body.
 ///
-/// Position is what separates a diff line from prose, not the leading character.
-/// `git show --format=%B -p` prints the commit body unindented, so a body line
-/// opening with `-` reads as a removal, and counting those turned a 60+/60- diff
-/// into `61+, 62-` (review of #618). Being inside a hunk also excludes the
-/// `---`/`+++` file headers by position, which matters: a removed line whose own
-/// text starts with `--` renders as `--- …`, so testing the prefix would have
-/// dropped a real removal.
+/// Position is what separates diff payload from the prose around it, not the
+/// leading character, and the hunk header is the only thing that says where the
+/// body ends. Two review findings on #618 are the same mistake at different
+/// distances: `git show --format=%B -p` prints the commit body unindented, so a
+/// bullet opening with `-` read as a removal; and running to the next
+/// `diff --git` instead let a *later* commit's message in `git log -p` be read as
+/// patch content, which is what the declared counts fix.
+///
+/// Deciding by position also settles a case the obvious prefix test gets wrong in
+/// the other direction: a removed line whose own text starts with `--` renders as
+/// `--- …`, so excluding `---` would drop a real removal.
+#[derive(Default)]
+struct HunkWalk {
+    old_left: usize,
+    new_left: usize,
+}
+
+impl HunkWalk {
+    /// Feeds one line, returning whether it is inside a hunk body. A header is
+    /// not body, so it returns false for one.
+    fn step(&mut self, line: &str) -> bool {
+        if let Some((old, new)) = parse_hunk_header(line) {
+            self.old_left = old;
+            self.new_left = new;
+            return false;
+        }
+        if self.old_left == 0 && self.new_left == 0 {
+            return false;
+        }
+        match line.as_bytes().first() {
+            Some(b'+') => {
+                self.new_left = self.new_left.saturating_sub(1);
+                true
+            }
+            Some(b'-') => {
+                self.old_left = self.old_left.saturating_sub(1);
+                true
+            }
+            // `\ No newline at end of file` annotates the line above it and is
+            // not itself a line of either side, so it spends no budget.
+            Some(b'\\') => true,
+            // A context line, and an empty one counts too: git writes it as a
+            // lone space, which anything that strips trailing whitespace turns
+            // into "". Treating that as the end of the hunk would undercount the
+            // rest of it, which is the failure this whole function exists to stop.
+            Some(b' ') | None => {
+                self.old_left = self.old_left.saturating_sub(1);
+                self.new_left = self.new_left.saturating_sub(1);
+                true
+            }
+            _ => {
+                self.old_left = 0;
+                self.new_left = 0;
+                false
+            }
+        }
+    }
+}
+
+/// The diffstat, counted the way `git show --numstat` counts it.
 fn count_hunk_lines(input: &str) -> (usize, usize) {
-    let mut in_hunk = false;
+    let mut walk = HunkWalk::default();
     let (mut added, mut removed) = (0, 0);
     for line in input.lines() {
-        if line.starts_with("diff --git") {
-            in_hunk = false;
-        } else if line.starts_with("@@ ") {
-            in_hunk = true;
-        } else if in_hunk {
-            if line.starts_with('+') {
-                added += 1;
-            } else if line.starts_with('-') {
-                removed += 1;
+        if walk.step(line) {
+            match line.as_bytes().first() {
+                Some(b'+') => added += 1,
+                Some(b'-') => removed += 1,
+                _ => {}
             }
         }
     }
@@ -174,17 +237,13 @@ fn distill_diff(segments: &[OutputSegment], input: &str) -> String {
         // Noise, which is the assumption #616 was built on.
         let keep_context = seg.context_score > 0.0 || seg.tier == SignalTier::Critical;
 
-        // Same position rule the counts use, so what is shown and what is counted
-        // cannot disagree. A removed line whose own text starts with `--` renders
-        // as `--- …`, and the prefix test that used to stand here dropped it from
-        // the output while the summary still counted it (review of #618).
-        let mut in_hunk = false;
+        // The same walk the counts use, so what is shown and what is counted
+        // cannot disagree.
+        let mut walk = HunkWalk::default();
         for line in seg.content.lines() {
-            if line.starts_with("@@ ") {
-                in_hunk = true;
-            }
+            let in_body = walk.step(line);
             let keep = line.starts_with("@@ ")
-                || (in_hunk && (line.starts_with('+') || line.starts_with('-')))
+                || (in_body && (line.starts_with('+') || line.starts_with('-')))
                 || (keep_context
                     && !line.starts_with("+++")
                     && !line.starts_with("---")
@@ -506,5 +565,56 @@ index 1111111..2222222 100644
             "a removal whose text starts with `--` was dropped from the output \
              while the summary counted it: {out:?}"
         );
+    }
+
+    /// Second review pass on #618. A hunk ends where its own header says it does,
+    /// not at the next `diff --git`. `git log --format=%B -p` puts the next
+    /// commit's message straight after the previous commit's last hunk, so
+    /// running to the next file header read that message as patch content: two
+    /// 1+/1- commits came out as `2+, 3-` because of three prose bullets.
+    #[test]
+    fn a_later_commit_message_is_not_counted_as_patch() {
+        let input = "\
+chore: plain message, no bullets
+
+diff --git a/big.txt b/big.txt
+index 1111111..2222222 100644
+--- a/big.txt
++++ b/big.txt
+@@ -1 +1 @@
+-one
++two
+fix: rewrite the table
+
+- dropped the legacy branch
+- dropped the second legacy branch
++ added nothing, this is prose
+
+diff --git a/big.txt b/big.txt
+index 3333333..1111111 100644
+--- a/big.txt
++++ b/big.txt
+@@ -1 +1 @@
+-zero
++one
+";
+        let cmd = "git log --format=%B -p -2 -- big.txt";
+        let profile = crate::pipeline::registry::resolve_profile(cmd);
+        let segments =
+            crate::pipeline::scorer::score_segments(input, profile.segmentation, None, cmd);
+        let out = distill_diff(&segments, input);
+
+        assert!(
+            out.contains("2+, 2-"),
+            "a later commit's message was counted as patch content: {out:?}"
+        );
+    }
+
+    #[test]
+    fn hunk_header_counts_default_to_one_line() {
+        assert_eq!(parse_hunk_header("@@ -1,3 +1,2 @@"), Some((3, 2)));
+        assert_eq!(parse_hunk_header("@@ -1 +1 @@"), Some((1, 1)));
+        assert_eq!(parse_hunk_header("@@ -27,6 +27,7 @@ image:"), Some((6, 7)));
+        assert_eq!(parse_hunk_header("-not a header"), None);
     }
 }


### PR DESCRIPTION
Two unrelated fixes, batched into one branch and one CI cycle.

**#616, the `git diff` summary.** `git diff: N files changed, X+, Y-` counted the
`+` and `-` lines that survived the scorer and printed that as the stat for the
diff it replaces. One tier makes it a false claim on its own:
`is_blank_or_decorative` tiers a block whose lines carry only `-`, `=`, `*` or `_`
as Noise, and a hunk removing a rule of `=====` characters is exactly that once
every line carries its `-` marker. The segment was skipped before the emit and
before the count. On the released 0.7.6 binary, for a diff that adds one line and
removes five:

```
$ git show --numstat HEAD -- docs/banner.txt
1	5	docs/banner.txt

$ omni exec git show HEAD -- docs/banner.txt
git diff: 1 files changed, 0+, 0-
b/docs/banner.txt
[OMNI: 16 lines omitted, omni retrieve a358852b56ff25a0 for full output]
```

The counts now come from the payload, the same lines `git show --numstat` counts,
and the tier may only drop a segment carrying no diff. The per-line filter below
already decided what a hunk contributes, so the skip was buying nothing there.

**The report's own mechanism does not reproduce, and that is in the issue.** Its
`git show … | sed … | head -40` cut the removal hunk before OMNI saw it: the one
hunk header in that transcript, `@@ -27,6 +27,7 @@`, declares six old lines
against seven new, which is the `1+, 0-` it printed. Rebuilt the commit
synthetically at the reported 6+/14- and ran the same pipeline through 0.7.6; it
returns `6+, 14-` with all fourteen removed lines intact. The defect above was
found while failing to reproduce that one.

**#597, the release gate.** `scripts/omni-release.sh` ran
`tests/smoke_test.sh ./target/release/omni` with no `cargo build --release`
anywhere, so the last gate before a tag validated whatever binary was on disk.
Planting `/bin/echo` at `target/release/omni` makes `smoke_test.sh` exit 137;
with the added build it exits 0 at 46/46. The two-day-old 0.7.6 binary in this
tree passes 46 of 46 today, which is the silent direction of the same failure.

**Verification.** `make ci` green. The new test is scored through the real scorer,
because a hand-built `Important` segment never produces the tier this guards.
Driven red twice: restoring the unconditional Noise skip fails the hunk assertion
while the stat stays correct (so the counting change carries the stat on its own),
and restoring the original code fails the stat assertion at
`git diff: 1 files changed, 0+, 0-`.

Closes #616
Closes #597

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR makes release smoke tests build and resolve the release artifact before testing it, and changes Git diff summaries to count raw hunk payload rather than filtered segments. The new payload-wide hunk detection still permits diff-shaped commit prose to enter the count.

- Builds the release binary and resolves Cargo's configured target directory before smoke testing.
- Counts additions and removals using hunk-header budgets.
- Preserves decorative hunks and adds regression coverage for prose and hunk-boundary cases.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because diff-shaped commit-message prose can still corrupt the Git diffstat produced by the attempted prose-counting fix.

The counter scans the entire command payload and accepts any syntactically valid hunk header without first entering a real diff section, allowing subsequent prefixed prose to be reported as additions or removals.

**Files Needing Attention:** src/distillers/git.rs
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/distillers/git.rs | Reworks diffstat parsing and filtering, but hunk-looking commit prose can still initiate counting outside an actual patch section. |
| scripts/omni-release.sh | Builds the release binary, resolves Cargo's target directory, verifies the artifact, and smoke-tests that exact path. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20fajarhide%2Fomni%20PR%20%23618%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=fajarhide%2Fomni&pr=618&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fdistillers%2Fgit.rs%3A181-182%0A**Diff-shaped%20prose%20inflates%20counts**%0A%0AWhen%20%60git%20show%20--format%3D%25B%20-p%60%20emits%20a%20commit-message%20line%20shaped%20like%20%60%40%40%20-1%20%2B1%20%40%40%60%2C%20the%20payload-wide%20%60HunkWalk%60%20accepts%20it%20without%20first%20entering%20a%20%60diff%20--git%60%20section%20and%20counts%20following%20%60%2B%60%20or%20%60-%60%20prose%20as%20patch%20content%2C%20causing%20the%20displayed%20diffstat%20to%20overreport%20additions%20or%20removals.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni&pr=618&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fajarhide%2Fomni%22%20on%20the%20existing%20branch%20%22fix%2F616-597-diffstat-and-release-build%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F616-597-diffstat-and-release-build%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fdistillers%2Fgit.rs%3A181-182%0A**Diff-shaped%20prose%20inflates%20counts**%0A%0AWhen%20%60git%20show%20--format%3D%25B%20-p%60%20emits%20a%20commit-message%20line%20shaped%20like%20%60%40%40%20-1%20%2B1%20%40%40%60%2C%20the%20payload-wide%20%60HunkWalk%60%20accepts%20it%20without%20first%20entering%20a%20%60diff%20--git%60%20section%20and%20counts%20following%20%60%2B%60%20or%20%60-%60%20prose%20as%20patch%20content%2C%20causing%20the%20displayed%20diffstat%20to%20overreport%20additions%20or%20removals.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni&pr=618&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Asrc%2Fdistillers%2Fgit.rs%3A181-182%0A**Diff-shaped%20prose%20inflates%20counts**%0A%0AWhen%20%60git%20show%20--format%3D%25B%20-p%60%20emits%20a%20commit-message%20line%20shaped%20like%20%60%40%40%20-1%20%2B1%20%40%40%60%2C%20the%20payload-wide%20%60HunkWalk%60%20accepts%20it%20without%20first%20entering%20a%20%60diff%20--git%60%20section%20and%20counts%20following%20%60%2B%60%20or%20%60-%60%20prose%20as%20patch%20content%2C%20causing%20the%20displayed%20diffstat%20to%20overreport%20additions%20or%20removals.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=618&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fajarhide%2Fomni%22%20on%20the%20existing%20branch%20%22fix%2F616-597-diffstat-and-release-build%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F616-597-diffstat-and-release-build%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fdistillers%2Fgit.rs%3A181-182%0A**Diff-shaped%20prose%20inflates%20counts**%0A%0AWhen%20%60git%20show%20--format%3D%25B%20-p%60%20emits%20a%20commit-message%20line%20shaped%20like%20%60%40%40%20-1%20%2B1%20%40%40%60%2C%20the%20payload-wide%20%60HunkWalk%60%20accepts%20it%20without%20first%20entering%20a%20%60diff%20--git%60%20section%20and%20counts%20following%20%60%2B%60%20or%20%60-%60%20prose%20as%20patch%20content%2C%20causing%20the%20displayed%20diffstat%20to%20overreport%20additions%20or%20removals.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/distillers/git.rs:181-182
**Diff-shaped prose inflates counts**

When `git show --format=%B -p` emits a commit-message line shaped like `@@ -1 +1 @@`, the payload-wide `HunkWalk` accepts it without first entering a `diff --git` section and counts following `+` or `-` prose as patch content, causing the displayed diffstat to overreport additions or removals.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(git): end a hunk where its header sa..."](https://github.com/fajarhide/omni/commit/b140f21215de8bca16fa3dca51f72996967261a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54693478)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->