### PR TITLE
fix: byte-index cuts that panic on non-ASCII text, and the deny that was switched off

### DIFF
--- a/changelog.d/619.fixed.md
+++ b/changelog.d/619.fixed.md
@@ -1,0 +1,21 @@
+**Cuts at a byte index no longer panic on non-ASCII text.** `String::truncate` and
+a `&s[..n]` slice both panic when the index lands inside a multi-byte character,
+and twenty-three cuts took a fixed or length-clamped index on text OMNI does not
+control: error messages, recorded commands, session payloads, task and goal
+strings. Two sat in the MCP server, where the panic takes down a tool call, and
+`CONTRIBUTING.md` requires a hook never to crash its host.
+
+They now go through the `util::text` helpers that were already in the tree and
+already doing this correctly, so an accented path or a CJK identifier costs a
+character off a preview rather than the process.
+
+One of them was reachable rather than theoretical. `infer_domain` walks byte
+indices to find the common prefix of two directories and sliced at every one of
+them, so two hot files under a directory whose name carries any multi-byte
+character panicked outright.
+
+`src/lib.rs` has denied `clippy::string_slice` all along, and thirteen files
+switched it off wholesale with a module-level allow, which is where every one of
+these lived. Six of those files no longer need the exemption. `infer_domain` keeps
+a function-scoped one that says which three slices are proven safe and why,
+because a blanket allow is what hid the wrong one.

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -1,6 +1,5 @@
 // Safety: String indexing uses session IDs (hex/ASCII) and ASCII delimiter
 // positions from find()/rfind() which are always valid char boundaries.
-#![allow(clippy::string_slice)]
 
 use crate::store::sqlite::Store;
 use crate::store::transcript;
@@ -118,7 +117,7 @@ pub fn run_session(args: &[String], store: Arc<Store>) -> anyhow::Result<()> {
             };
             let task = s.inferred_task.as_deref().unwrap_or("not detected");
             let sid = if s.session_id.len() > 8 {
-                &s.session_id[..8]
+                crate::util::text::safe_slice(&s.session_id, 8)
             } else {
                 &s.session_id
             };
@@ -191,7 +190,7 @@ pub fn run_session(args: &[String], store: Arc<Store>) -> anyhow::Result<()> {
             .unwrap_or_else(|| "unknown time".to_string());
 
         let sid = if state.session_id.len() > 8 {
-            &state.session_id[..8]
+            crate::util::text::safe_slice(&state.session_id, 8)
         } else {
             &state.session_id
         };
@@ -257,7 +256,7 @@ pub fn run_session(args: &[String], store: Arc<Store>) -> anyhow::Result<()> {
             for err in state.active_errors.iter().take(3) {
                 let e = err.replace('\n', " ");
                 let clean = if e.len() > 80 {
-                    format!("{}...", &e[..77])
+                    format!("{}...", crate::util::text::safe_slice(&e, 77))
                 } else {
                     e
                 };
@@ -283,7 +282,7 @@ fn run_resume() -> anyhow::Result<()> {
             super::print_rule();
 
             let sid = if t.session_id.len() > 8 {
-                &t.session_id[..8]
+                crate::util::text::safe_slice(&t.session_id, 8)
             } else {
                 &t.session_id
             };
@@ -317,7 +316,7 @@ fn run_resume() -> anyhow::Result<()> {
             for entry in t.entries.iter().filter(|e| e.is_pending()) {
                 let kind = format!("{:?}", entry.kind);
                 let payload_preview = if entry.payload.len() > 60 {
-                    format!("{}...", &entry.payload[..57])
+                    format!("{}...", crate::util::text::safe_slice(&entry.payload, 57))
                 } else {
                     entry.payload.clone()
                 };
@@ -367,7 +366,7 @@ fn run_transcript() -> anyhow::Result<()> {
 
     let t = &recent[0];
     let sid = if t.session_id.len() > 8 {
-        &t.session_id[..8]
+        crate::util::text::safe_slice(&t.session_id, 8)
     } else {
         &t.session_id
     };
@@ -413,7 +412,7 @@ fn run_transcript() -> anyhow::Result<()> {
             .unwrap_or_else(|| "??".to_string());
 
         let payload_preview = if entry.payload.len() > 50 {
-            format!("{}...", &entry.payload[..47])
+            format!("{}...", crate::util::text::safe_slice(&entry.payload, 47))
         } else {
             entry.payload.clone()
         }
@@ -578,7 +577,7 @@ fn run_health(store: &Store) -> anyhow::Result<()> {
     } else {
         for cmd in state.last_commands.iter().take(5) {
             let display = if cmd.len() > 60 {
-                format!("{}...", &cmd[..57])
+                format!("{}...", crate::util::text::safe_slice(cmd, 57))
             } else {
                 cmd.clone()
             };
@@ -1027,10 +1026,13 @@ mod tests {
             ctx.push_str(&format!(" Hot: {}.", hot_str));
         }
         if err != "none" {
-            ctx.push_str(&format!(" Error: {}", &err[..err.len().min(80)]));
+            ctx.push_str(&format!(
+                " Error: {}",
+                crate::util::text::safe_slice(err, 80)
+            ));
         }
         if ctx.len() > 200 {
-            ctx.truncate(197);
+            crate::util::text::safe_truncate(&mut ctx, 197);
             ctx.push_str("...");
         }
 

--- a/src/cli/stats.rs
+++ b/src/cli/stats.rs
@@ -1,5 +1,4 @@
 // Safety: String slicing uses ASCII delimiter positions or boundary-checked safe utilities.
-#![allow(clippy::string_slice)]
 
 use crate::store::sqlite::Store;
 use anyhow::{Context, Result};
@@ -199,7 +198,10 @@ fn shorten_command(cmd: &str, max_len: usize) -> String {
     if short.len() <= max_len {
         short
     } else {
-        format!("{}...", &short[..max_len.saturating_sub(3)])
+        format!(
+            "{}...",
+            crate::util::text::safe_slice(&short, max_len.saturating_sub(3))
+        )
     }
 }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1,5 +1,4 @@
 // Safety: String slicing uses ASCII delimiter positions or boundary-checked safe utilities.
-#![allow(clippy::string_slice)]
 
 use crate::pipeline::scorer::score_segments;
 use crate::pipeline::{SessionState, SignalTier};
@@ -304,7 +303,7 @@ impl OmniServer {
         let goal_hash = {
             let mut hasher = Sha256::new();
             hasher.update(params.0.goal.as_bytes());
-            hex::encode(hasher.finalize())[..16].to_string()
+            crate::util::text::safe_slice(&hex::encode(hasher.finalize()), 16).to_string()
         };
 
         match params.0.action.as_str() {
@@ -587,7 +586,7 @@ impl OmniServer {
                     s.active_errors.len(),
                     s.active_errors
                         .first()
-                        .map(|e| e[..e.len().min(80)].to_string())
+                        .map(|e| crate::util::text::safe_slice(e, 80).to_string())
                         .unwrap_or_default()
                 ));
             }
@@ -610,7 +609,7 @@ impl OmniServer {
                 ));
                 let mut pattern_preview = p.pattern_text.replace('\n', " ");
                 if pattern_preview.len() > 100 {
-                    pattern_preview.truncate(97);
+                    crate::util::text::safe_truncate(&mut pattern_preview, 97);
                     pattern_preview.push_str("...");
                 }
                 report.push_str(&format!("  Pattern: {}\n\n", pattern_preview));
@@ -792,7 +791,7 @@ impl OmniServer {
                     goal_str, last_session_str, task, hot_str, err
                 );
                 if msg.len() > 400 {
-                    msg.truncate(397);
+                    crate::util::text::safe_truncate(&mut msg, 397);
                     msg.push_str("...");
                 }
                 msg
@@ -881,7 +880,7 @@ impl OmniServer {
             out.push_str(&format!(
                 "  {:2}. {:<40} {} → {} bytes  {:.0}%  {}\n",
                 i + 1,
-                &row.command[..row.command.len().min(40)],
+                crate::util::text::safe_slice(&row.command, 40),
                 row.input_bytes,
                 row.output_bytes,
                 savings_pct,
@@ -1267,7 +1266,10 @@ impl OmniServer {
         } else {
             for err in &session.active_errors {
                 let clean = err.replace('\n', " ");
-                out.push_str(&format!("- {}\n", &clean[..clean.len().min(120)]));
+                out.push_str(&format!(
+                    "- {}\n",
+                    crate::util::text::safe_slice(&clean, 120)
+                ));
             }
         }
 
@@ -1304,7 +1306,7 @@ impl OmniServer {
         // Recent Commands
         out.push_str("\n## Recent Commands\n");
         for cmd in session.last_commands.iter().take(10) {
-            out.push_str(&format!("- `{}`\n", &cmd[..cmd.len().min(80)]));
+            out.push_str(&format!("- `{}`\n", crate::util::text::safe_slice(cmd, 80)));
         }
 
         // Context Pressure

--- a/src/session/tracker.rs
+++ b/src/session/tracker.rs
@@ -1,5 +1,4 @@
 // Safety: String slicing uses ASCII delimiter positions or boundary-checked safe utilities.
-#![allow(clippy::string_slice)]
 
 use crate::pipeline::{DistillResult, SessionState};
 use crate::store::sqlite::Store;
@@ -330,13 +329,19 @@ pub fn infer_task(session: &SessionState) -> Option<String> {
 
     task.map(|t| {
         if t.len() > 50 {
-            t[..47].to_string() + "..."
+            crate::util::text::safe_slice(&t, 47).to_string() + "..."
         } else {
             t
         }
     })
 }
 
+// Three slices here, each proven to sit on a char boundary rather than assumed
+// to: `rfind` returns one by definition, and the prefix loop below skips every
+// index that is not one, which is also what `prefix_len` inherits. A blanket
+// file-level allow used to cover these and hid the one that was genuinely wrong
+// (#619), so the exemption is per-function and says why.
+#[allow(clippy::string_slice)]
 pub fn infer_domain(session: &SessionState) -> Option<String> {
     let paths: Vec<String> = session.hot_files.keys().cloned().collect();
     if paths.is_empty() {
@@ -357,6 +362,15 @@ pub fn infer_domain(session: &SessionState) -> Option<String> {
 
         let first = dirs[0].as_str();
         for r in 0..=min_len {
+            // `r` walks bytes, so most values of it land inside a multi-byte
+            // character and slicing there panics. Any path with an accent or a
+            // CJK segment took the process down here, and two such paths are
+            // enough to reach this loop (#619). Skipping the non-boundaries also
+            // leaves `prefix_len` on one, which is what makes the slice below
+            // safe.
+            if !first.is_char_boundary(r) {
+                continue;
+            }
             let prefix = &first[..r];
             if dirs.iter().all(|p| p.starts_with(prefix)) {
                 prefix_len = r;
@@ -528,6 +542,24 @@ mod tests {
         // prefix -> "src/auth/"
         // split -> ["src", "auth"] -> last is "auth"
         assert_eq!(domain.unwrap(), "auth");
+    }
+
+    /// #619. The common-prefix loop walked byte indices and sliced at each one,
+    /// so any path with a multi-byte character in it panicked here. Two hot files
+    /// under a directory are all it takes to reach the loop, and an accented or
+    /// CJK directory name is ordinary rather than adversarial.
+    #[test]
+    fn infers_domain_from_paths_with_multi_byte_characters() {
+        let mut state = SessionState::new();
+        state.add_hot_file("src/café/handler.rs");
+        state.add_hot_file("src/café/router.rs");
+
+        // Panicked before the boundary skip; the assertion is that it returns.
+        let domain = infer_domain(&state);
+        assert!(
+            domain.is_some_and(|d| !d.is_empty()),
+            "a multi-byte path should still infer a domain"
+        );
     }
 
     #[test]

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -1,5 +1,4 @@
 // Safety: String slicing uses ASCII delimiter positions or boundary-checked safe utilities.
-#![allow(clippy::string_slice)]
 
 use anyhow::{Context, Result};
 use r2d2::Pool;
@@ -2495,7 +2494,7 @@ impl SqliteBackend {
                was_resolved = 0,
                resolution_hint = '',
                tool_family = CASE WHEN tool_family = '' THEN ?3 ELSE tool_family END",
-            params![hash, &pattern_text[..pattern_text.len().min(500)], tool_family, now],
+            params![hash, crate::util::text::safe_slice(pattern_text, 500), tool_family, now],
         );
     }
 
@@ -2511,7 +2510,7 @@ impl SqliteBackend {
             "UPDATE pattern_memory SET was_resolved = 1, resolution_hint = ?1
              WHERE tool_family = ?2 AND was_resolved = 0 AND last_seen > ?3",
             params![
-                &resolution_hint[..resolution_hint.len().min(500)],
+                crate::util::text::safe_slice(resolution_hint, 500),
                 tool_family,
                 now - 3600
             ],

--- a/src/store/transcript.rs
+++ b/src/store/transcript.rs
@@ -1,5 +1,4 @@
 // Safety: String slicing uses ASCII delimiter positions or boundary-checked safe utilities.
-#![allow(clippy::string_slice)]
 
 use anyhow::{Context, Result};
 use chrono::Utc;
@@ -189,7 +188,7 @@ impl Transcript {
             .find(|e| matches!(e.kind, EntryKind::PipeInput | EntryKind::UserInput))
             .map(|e| {
                 if e.payload.len() > 60 {
-                    format!("{}...", &e.payload[..57])
+                    format!("{}...", crate::util::text::safe_slice(&e.payload, 57))
                 } else {
                     e.payload.clone()
                 }
@@ -205,7 +204,7 @@ impl Transcript {
 
         format!(
             "Session {} ({}, {} pending): last input: {}",
-            &self.session_id[..self.session_id.len().min(12)],
+            crate::util::text::safe_slice(&self.session_id, 12),
             age_str,
             pending,
             last_input,
@@ -367,7 +366,7 @@ fn truncate_payload(payload: &str, max_bytes: usize) -> String {
     } else {
         format!(
             "{}... [truncated, {} total bytes]",
-            &payload[..max_bytes],
+            crate::util::text::safe_slice(payload, max_bytes),
             payload.len()
         )
     }


### PR DESCRIPTION
`String::truncate` and a `&s[..n]` slice both panic when the index lands inside a
multi-byte character. Twenty-three cuts took a fixed or length-clamped byte index
on text OMNI does not control: error messages, recorded commands, session
payloads, task and goal strings. Two are in the MCP server, where a panic takes
down a tool call, and `CONTRIBUTING.md` requires a hook never to crash its host.

`src/util/text.rs` already had `safe_slice`, `safe_truncate` and
`safe_truncate_with_ellipsis`, and several of these files already called them
elsewhere, so this is the helper applied where it was skipped. No behaviour change
beyond not panicking.

**One site was reachable, not latent.** `infer_domain` finds the common prefix of
two directory paths by walking byte indices `0..=min_len` and slicing at each, so
two hot files under a directory carrying any multi-byte character panicked. With
the boundary skip removed, the new test reproduces it:

```
panicked at src/session/tracker.rs:371:32:
end byte index 8 is not a char boundary; it is inside 'é' (bytes 7..9 of string)
```

**The guard existed and was switched off.** `src/lib.rs:3` denies
`clippy::string_slice`; thirteen files disable it with a module-level allow, which
is where all of these lived. Six of those no longer need it, so the deny is now
live in them. `infer_domain` keeps a function-scoped allow naming the three slices
that are proven safe and why, since a blanket allow is what hid the wrong one.

Left out on purpose: the blanket allows in `jsts`, `system_ops`, `pipe`,
`collapse`, `engram` and `query`. Their slices take indices from `find`/`rfind`
and are safe by construction, so converting them to targeted allows is mechanical
and unrelated to any panic.

Two corrections to the issue, both posted there: `cli/stats.rs:179` is
`Vec::truncate` and never belonged in the class, and the body's count of four was
low.

`make ci` green, smoke 46/46.

Closes #619

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR replaces unsafe byte-index string cuts with existing UTF-8-boundary-aware helpers and fixes Unicode path handling in domain inference.
- Uses `safe_slice` and `safe_truncate` for CLI, MCP, persistence, and transcript previews.
- Skips non-character boundaries while computing common path prefixes.
- Narrows broad Clippy lint exemptions and adds a Unicode regression test.
- Documents the fix in the changelog.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable regressions identified in the changed paths.

The new helpers preserve the requested byte ceilings while returning valid UTF-8 prefixes, the common-prefix loop records only verified character boundaries, and the narrowed lint exemptions still cover the remaining intentional slices.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/session/tracker.rs | Fixes the reachable Unicode panic in common-prefix inference, narrows the lint exemption, and adds a focused regression test. |
| src/mcp/server.rs | Replaces externally influenced byte-index cuts with boundary-safe preview and truncation helpers. |
| src/cli/session.rs | Makes session identifiers, errors, payloads, commands, and generated context safe to truncate when they contain non-ASCII text. |
| src/cli/stats.rs | Makes command shortening UTF-8 safe while preserving its maximum-byte behavior. |
| src/store/sqlite.rs | Safely caps persisted pattern and resolution text at 500 bytes without violating storage constraints. |
| src/store/transcript.rs | Makes transcript summaries and payload truncation safe at Unicode character boundaries. |
| changelog.d/619.fixed.md | Accurately documents the panic class, affected surfaces, and narrowed lint exemptions. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(utf8): route byte-index cuts through..."](https://github.com/fajarhide/omni/commit/6e6940e142b739b0561c648af585413bb64cf1c1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54708062)</sub>

<!-- /greptile_comment -->