### PR TITLE
perf(mcp): 23% off the tool surface by dropping two schema keys nothing reads

### DIFF
--- a/changelog.d/609.changed.md
+++ b/changelog.d/609.changed.md
@@ -1,0 +1,19 @@
+**OMNI's MCP surface is 23.1% smaller, with every tool still advertised.** The
+tool definitions sit in the prefix of every request for the life of a session, so
+each byte is re-read once per request rather than once. `schemars` was stamping
+every parameter struct with two keys a caller never uses: `$schema`, a 56 byte URL
+naming the JSON Schema draft, and `title`, which is the Rust struct name
+(`OmniRunParams`). Over the nine tools that is 686 B of 2,972 B, now 2,286 B.
+
+Nothing was removed to get it. No tool dropped, no description shortened, no
+parameter changed, and `omni_retrieve` still parses its argument from the trimmed
+schema. `title` was also leaking an internal type name onto the wire, which is not
+something a caller should be reading.
+
+Two tests hold it: one asserts neither key is advertised on either policy arm, the
+other ratchets the total byte size so a schema growing back fails rather than
+being noticed later.
+
+This is the cheap half of #609. The expensive half stands: 37 of 260 sessions in
+the measured corpus ever call an omni tool, so 86% still carry a surface they never
+use, and `omni_context` has never been called once.

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1480,11 +1480,36 @@ impl OmniServer {
     /// `policy::FULL`. That default is deliberate: the cost of a tool is paid
     /// by every user on every request, and the benefit is paid by whoever calls
     /// it (#577).
+    /// Drop the two schema keys that cost bytes and tell a caller nothing.
+    ///
+    /// `schemars` stamps every parameter struct with `$schema`, a 56 byte URL
+    /// naming the JSON Schema draft, and `title`, which is the Rust struct name
+    /// (`OmniRunParams`). Neither changes how a tool is called, and both sit in
+    /// the prefix of every request for the life of a session, which is the unit
+    /// #609 measured the surface in. Over the nine advertised tools: 2,972 B to
+    /// 2,286 B, 23.1%, with no tool removed and no description shortened.
+    ///
+    /// `title` also leaked an internal type name onto the wire, which is not
+    /// something a caller should be reading.
+    fn strip_schema_boilerplate(
+        router: &mut rmcp::handler::server::router::tool::ToolRouter<Self>,
+    ) {
+        for route in router.map.values_mut() {
+            let mut schema = (*route.attr.input_schema).clone();
+            let dropped_url = schema.remove("$schema").is_some();
+            let dropped_title = schema.remove("title").is_some();
+            if dropped_url || dropped_title {
+                route.attr.input_schema = std::sync::Arc::new(schema);
+            }
+        }
+    }
+
     fn router_from(
         agent_id: &str,
         keep_everything: bool,
     ) -> rmcp::handler::server::router::tool::ToolRouter<Self> {
         let mut router = Self::tool_router();
+        Self::strip_schema_boilerplate(&mut router);
         if keep_everything {
             return router;
         }
@@ -1773,6 +1798,11 @@ mod tests {
     /// The gate from the design: the advertised surface on a Full-tier host is
     /// under 3,000 bytes. It was 7,912 before this, and the 4,940 that came off
     /// is the half that had never been called.
+    ///
+    /// Ratcheted to 2,500 for #609, which took another 686 B off by dropping the
+    /// `$schema` and `title` keys `schemars` stamps on every parameter struct.
+    /// The old 3,000 gate stayed green through that whole regression, which is
+    /// what a bound set far above the measurement buys you.
     #[test]
     fn the_advertised_surface_is_smaller_than_it_was() {
         let router = OmniServer::router_from("claude_code", false);
@@ -1789,8 +1819,8 @@ mod tests {
             listed.len()
         );
         assert!(
-            bytes < 3_000,
-            "advertised surface is {bytes} B, gate is 3000"
+            bytes <= 2_500,
+            "advertised surface is {bytes} B, gate is 2500 (it measured 2,286 on #609)"
         );
     }
 
@@ -1808,6 +1838,31 @@ mod tests {
             names.iter().any(|n| n == "omni_run"),
             "advertised: {names:?}"
         );
+    }
+
+    /// #609. The surface sits in the prefix of every request for the life of a
+    /// session, so bytes that tell a caller nothing are paid over and over.
+    /// `schemars` stamps each parameter struct with `$schema`, a URL naming the
+    /// draft, and `title`, the Rust struct name. Neither affects how a tool is
+    /// called; together they were 686 B of 2,972 B.
+    ///
+    /// Asserted on `router_from` rather than `tool_router`, because the raw
+    /// router is the source the strip runs on and still carries both keys.
+    /// Checked on both arms: the override restores every *tool*, not the
+    /// boilerplate.
+    #[test]
+    fn the_advertised_schemas_carry_no_boilerplate() {
+        for keep_everything in [false, true] {
+            for tool in OmniServer::router_from("claude_code", keep_everything).list_all() {
+                for key in ["$schema", "title"] {
+                    assert!(
+                        !tool.input_schema.contains_key(key),
+                        "{} still advertises {key} (keep_everything={keep_everything})",
+                        tool.name
+                    );
+                }
+            }
+        }
     }
 
     /// The escape hatch, because a cut nobody can undo is a cut that gets


### PR DESCRIPTION
The MCP tool definitions sit in the prefix of every request for the life of a
session, so a byte there is re-read once per request rather than once. That is the
unit #609 measured the surface in, and it is what makes 686 B worth a commit.

`schemars` stamps every parameter struct with two keys nothing reads: `$schema`, a
56 byte URL naming the JSON Schema draft, and `title`, which is the Rust struct
name. Eight of the nine tools carry both.

```json
{"$schema":"https://json-schema.org/draft/2020-12/schema","title":"OmniRunParams",...}
```

Measured through the real server over stdio, not modelled: **2,972 B to 2,286 B,
23.1%**. Nothing was removed to get it. No tool dropped, no description shortened,
no parameter changed, and `title` stops putting an internal type name on the wire.

Verified over a live stdio session that invocation is unaffected: `omni_retrieve`
still parses `hash` from the trimmed schema and returns `Not found: deadbeef…`
rather than a parameter error, and `omni_context_breakdown` still answers.

**Why this rather than the two levers in the issue.** The composition is not what
the body assumed: schemas are 1,611 B of the surface (54%) and descriptions only
848 B (28%), so the obvious lever touches a quarter of it. This is 2.5x what
dropping `omni_context` would save, and unlike that it does not change the tool
list, so it needs no minor version.

**Tests.** One asserts neither key is advertised, on both policy arms. The byte
gate from #580 was already measuring this exact quantity at `< 3_000`, so it is
ratcheted to `<= 2_500` rather than joined by a second test measuring the same
thing. Worth saying that the old bound stayed green through the whole 686 B
regression, which is what a gate set far above the measurement buys you. Both
driven red by removing the strip: `omni_context still advertises $schema` and
`advertised surface is 2972 B, gate is 2500`.

`make ci` green, smoke 46/46.

Half of #609, so the issue stays open. 37 of 260 sessions in the corpus ever call
an omni tool, and the deferred or opt-in surface is worth 2,286 B rather than 686.
The re-measurement and the composition table are on the issue.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR reduces the MCP tool-definition surface by removing unused root-level `$schema` and `title` metadata from advertised input schemas.

- Applies the transformation centrally before tool-policy filtering.
- Ratchets the serialized surface-size gate to 2,500 bytes.
- Tests both filtered and all-tools advertisement paths for removal of the metadata.
- Documents the measured reduction in the changelog.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete behavioral, compatibility, or security defects identified.

The removed fields are optional schema metadata, the production advertisement path applies the transformation before every policy branch, and the added tests cover both filtered and complete tool sets.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/mcp/server.rs | Centrally strips optional JSON Schema metadata from advertised tool inputs and adds coverage for schema contents and serialized size. |
| changelog.d/609.changed.md | Documents the MCP surface reduction, retained tool behavior, and remaining optimization opportunity. |

</details>

<sub>Reviews (1): Last reviewed commit: ["perf(mcp): stop advertising schema keys ..."](https://github.com/fajarhide/omni/commit/9f92a9c908b0168f5c32784d753dbe5d4a834359) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54719622)</sub>

<!-- /greptile_comment -->