### PR TITLE
docs: fix the broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,11 +319,11 @@ A passion project for the era of agentic AI. Contributions welcome.
 [Apache License 2.0](LICENSE).
 
 <p align="center">
-  <a href="https://star-history.com/#fajarhide/omni&Date">
+  <a href="https://star-history.dera.page/#fajarhide/omni&Date">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=fajarhide/omni&type=Date&theme=dark" />
-      <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=fajarhide/omni&type=Date" />
-      <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=fajarhide/omni&type=Date" width="600" />
+      <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=fajarhide/omni&type=Date&theme=dark" />
+      <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=fajarhide/omni&type=Date" />
+      <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=fajarhide/omni&type=Date" width="600" />
     </picture>
   </a>
 </p>

--- a/i18n/README-ar.md
+++ b/i18n/README-ar.md
@@ -326,11 +326,11 @@ brew install fajarhide/tap/omni && omni init
 
 <!-- Star History -->
 <p align="center">
-  <a href="https://star-history.com/#fajarhide/omni&Date">
+  <a href="https://star-history.dera.page/#fajarhide/omni&Date">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=fajarhide/omni&type=Date&theme=dark" />
-      <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=fajarhide/omni&type=Date" />
-      <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=fajarhide/omni&type=Date" width="600" />
+      <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=fajarhide/omni&type=Date&theme=dark" />
+      <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=fajarhide/omni&type=Date" />
+      <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=fajarhide/omni&type=Date" width="600" />
     </picture>
   </a>
 </p>

--- a/i18n/README-id.md
+++ b/i18n/README-id.md
@@ -281,11 +281,11 @@ Ini proyek yang lahir dari kesenangan, dibangun untuk era AI Agentik. Entah Anda
 
 <!-- Star History -->
 <p align="center">
-  <a href="https://star-history.com/#fajarhide/omni&Date">
+  <a href="https://star-history.dera.page/#fajarhide/omni&Date">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=fajarhide/omni&type=Date&theme=dark" />
-      <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=fajarhide/omni&type=Date" />
-      <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=fajarhide/omni&type=Date" width="600" />
+      <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=fajarhide/omni&type=Date&theme=dark" />
+      <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=fajarhide/omni&type=Date" />
+      <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=fajarhide/omni&type=Date" width="600" />
     </picture>
   </a>
 </p>

--- a/i18n/README-ja.md
+++ b/i18n/README-ja.md
@@ -271,11 +271,11 @@ brew install fajarhide/tap/omni && omni init
 
 <!-- Star History -->
 <p align="center">
-  <a href="https://star-history.com/#fajarhide/omni&Date">
+  <a href="https://star-history.dera.page/#fajarhide/omni&Date">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=fajarhide/omni&type=Date&theme=dark" />
-      <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=fajarhide/omni&type=Date" />
-      <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=fajarhide/omni&type=Date" width="600" />
+      <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=fajarhide/omni&type=Date&theme=dark" />
+      <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=fajarhide/omni&type=Date" />
+      <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=fajarhide/omni&type=Date" width="600" />
     </picture>
   </a>
 </p>

--- a/i18n/README-ko.md
+++ b/i18n/README-ko.md
@@ -272,11 +272,11 @@ brew install fajarhide/tap/omni && omni init
 
 <!-- Star History -->
 <p align="center">
-  <a href="https://star-history.com/#fajarhide/omni&Date">
+  <a href="https://star-history.dera.page/#fajarhide/omni&Date">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=fajarhide/omni&type=Date&theme=dark" />
-      <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=fajarhide/omni&type=Date" />
-      <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=fajarhide/omni&type=Date" width="600" />
+      <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=fajarhide/omni&type=Date&theme=dark" />
+      <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=fajarhide/omni&type=Date" />
+      <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=fajarhide/omni&type=Date" width="600" />
     </picture>
   </a>
 </p>

--- a/i18n/README-vi.md
+++ b/i18n/README-vi.md
@@ -280,11 +280,11 @@ brew install fajarhide/tap/omni && omni init
 
 <!-- Star History -->
 <p align="center">
-  <a href="https://star-history.com/#fajarhide/omni&Date">
+  <a href="https://star-history.dera.page/#fajarhide/omni&Date">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=fajarhide/omni&type=Date&theme=dark" />
-      <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=fajarhide/omni&type=Date" />
-      <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=fajarhide/omni&type=Date" width="600" />
+      <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=fajarhide/omni&type=Date&theme=dark" />
+      <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=fajarhide/omni&type=Date" />
+      <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=fajarhide/omni&type=Date" width="600" />
     </picture>
   </a>
 </p>

--- a/i18n/README-zh.md
+++ b/i18n/README-zh.md
@@ -256,11 +256,11 @@ brew install fajarhide/tap/omni && omni init
 
 <!-- Star History -->
 <p align="center">
-  <a href="https://star-history.com/#fajarhide/omni&Date">
+  <a href="https://star-history.dera.page/#fajarhide/omni&Date">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=fajarhide/omni&type=Date&theme=dark" />
-      <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=fajarhide/omni&type=Date" />
-      <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=fajarhide/omni&type=Date" width="600" />
+      <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=fajarhide/omni&type=Date&theme=dark" />
+      <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=fajarhide/omni&type=Date" />
+      <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=fajarhide/omni&type=Date" width="600" />
     </picture>
   </a>
 </p>


### PR DESCRIPTION
The star history chart in the README (and its localized translations) no longer renders because the old endpoint can no longer serve it under GitHub stargazer API restrictions. This change points the chart at the maintained star-history.dera.page endpoint so the chart works again. The fix is needed because the current chart is broken.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR replaces the broken Star History links and chart image endpoints with `star-history.dera.page` across the primary README and all six localized versions.

- Updates dark-theme, light-theme, and fallback chart image URLs consistently.
- Updates the clickable chart destination consistently.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the documentation-only endpoint replacement applied consistently across every changed README.

The change preserves the existing chart parameters, theme variants, fallback image, and repository identifier while uniformly replacing only the obsolete Star History host.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Consistently updates the Star History destination and all chart image variants to the maintained endpoint. |
| i18n/README-ar.md | Mirrors the chart endpoint update in the Arabic README without altering localized content. |
| i18n/README-id.md | Mirrors the chart endpoint update in the Indonesian README without altering localized content. |
| i18n/README-ja.md | Mirrors the chart endpoint update in the Japanese README without altering localized content. |
| i18n/README-ko.md | Mirrors the chart endpoint update in the Korean README without altering localized content. |
| i18n/README-vi.md | Mirrors the chart endpoint update in the Vietnamese README without altering localized content. |
| i18n/README-zh.md | Mirrors the chart endpoint update in the Chinese README without altering localized content. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: point the star history chart at a ..."](https://github.com/fajarhide/omni/commit/fcd42ec19e2e2f44f6eb6092ada8bcf977f46e5e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54724870)</sub>

<!-- /greptile_comment -->