### PR TITLE
fix(ledger): make the fold route auditable, and say whose bytes it replaced

### DIFF
--- a/changelog.d/602.fixed.md
+++ b/changelog.d/602.fixed.md
@@ -1,0 +1,17 @@
+**`omni_explain_savings` can see cross-turn folds.** It read the `distillations`
+table; the ledger writes to `ledger_folds`, and nothing had ever read that one. So
+a session whose compression was entirely folding answered "No recent distillations
+found in current session" while its own markers carried live retrieve handles. On
+the machine that confirmed it: 936 folds recorded, none visible to the tool.
+
+That was the worst case to be blind to. This is the tool the docs point at for
+judging whether a route paid for itself, and folding is exactly where a marker plus
+a 16 character handle can cost more than the lines it replaced. It also made a
+defect report harder to write, because route and byte counts had to be guessed
+rather than quoted.
+
+The report now carries both, and only says nothing happened when both are empty.
+Folds are reported in lines and bytes with their scope, and without a command:
+the ledger keys lines by scope and hash, so the bytes a fold replaced may have been
+shown by a different command than the one being answered, and naming the current
+one would be a guess dressed as attribution.

--- a/changelog.d/602.fixed.md
+++ b/changelog.d/602.fixed.md
@@ -12,6 +12,13 @@ rather than quoted.
 
 The report now carries both, and only says nothing happened when both are empty.
 
+The filter that never matched came first. `SessionState` mints its own id every
+time it is constructed, `{millis}-{pid}-{counter}`, while the hook keys its rows on
+the id the **host** supplied: 11,281 rows here carry a host UUID against 892 minted
+ones. The MCP server cannot see the host id, so filtering on the one it holds
+matched nothing, and that was true of the distillations half too, before any of
+this touched it. Both tools now ask by recency and say so.
+
 Folds record which session made them, because the table could not say. Its `scope`
 column holds the **project** whenever there is one, deliberately, so the
 cross-agent question it was built for stays askable, and every one of those 936

--- a/changelog.d/602.fixed.md
+++ b/changelog.d/602.fixed.md
@@ -11,7 +11,14 @@ defect report harder to write, because route and byte counts had to be guessed
 rather than quoted.
 
 The report now carries both, and only says nothing happened when both are empty.
-Folds are reported in lines and bytes with their scope, and without a command:
-the ledger keys lines by scope and hash, so the bytes a fold replaced may have been
+
+Folds record which session made them, because the table could not say. Its `scope`
+column holds the **project** whenever there is one, deliberately, so the
+cross-agent question it was built for stays askable, and every one of those 936
+rows carries a filesystem path there. Asking it for a session id returns nothing,
+which is what the first attempt at this fix did.
+
+Folds are reported in lines and bytes with their scope, and without a command: the
+ledger keys lines by scope and hash, so the bytes a fold replaced may have been
 shown by a different command than the one being answered, and naming the current
 one would be a guess dressed as attribution.

--- a/changelog.d/622.fixed.md
+++ b/changelog.d/622.fixed.md
@@ -1,0 +1,23 @@
+**A fold says when it is replacing bytes from a different command.** The ledger
+keyed shown lines by scope and hash alone, so reading file B could have a block
+elided because file A showed an identical one earlier, and the marker named
+neither file nor line range. Comparing two files to check a shared block matches
+is exactly that case, and the dedup answered it by deleting the evidence.
+
+Lines now record the command that first showed them, and a marker carries
+`from <source>` when the fold draws on a different one:
+`[OMNI: 22 lines already shown from charlie.tf, omni retrieve …]`.
+
+The clause is absent when the source is the same, which is the common case of
+re-reading one file, and that is deliberate rather than an optimisation. Marker
+length gates folding: the gate weighs the rendered string, so every byte added
+here is a byte a run must beat before folding is worth it, and trimming this
+marker by 22 bytes was worth 0.3 points of aggregate savings on its own (#450). A
+clause on every fold would have paid that back the wrong way. The decision lives
+in the run's grouping key, so a stretch whose lines came from two commands now
+splits into two runs rather than picking one of them to name.
+
+Rows written before this keep an empty source, which reads as unrecorded and
+suppresses the clause rather than guessing. The column is also what makes the
+frequency measurable: nothing in the corpus could say how often a fold draws on a
+different source, because there was nowhere to record it.

--- a/changelog.d/622.fixed.md
+++ b/changelog.d/622.fixed.md
@@ -17,6 +17,12 @@ clause on every fold would have paid that back the wrong way. The decision lives
 in the run's grouping key, so a stretch whose lines came from two commands now
 splits into two runs rather than picking one of them to name.
 
+A source is a raw command, and 46.9% of recorded commands carry a newline, so the
+marker takes the first line only with control characters dropped and whitespace
+collapsed. A marker is a single line and the count of markers above the first
+surviving line is derived from that, so a command able to split it would corrupt
+both the framing and that accounting.
+
 Rows written before this keep an empty source, which reads as unrecorded and
 suppresses the clause rather than guessing. The column is also what makes the
 frequency measurable: nothing in the corpus could say how often a fold draws on a

--- a/docs/website/src-id/use/markers.md
+++ b/docs/website/src-id/use/markers.md
@@ -47,6 +47,23 @@ baris di tempat run ulang akan mencetak ratusan baris yang sama. Apa pun yang
 kurang dari seluruh jawaban memakai kalimat di atasnya.
 
 ```
+[OMNI: 40 lines already shown from charlie.tf, omni retrieve 0000000000000000]
+```
+
+Keempatnya bisa membawa `from <sumber>`, yang menyebut perintah yang keluarannya
+pertama kali menampilkan baris-baris itu. Ia hanya muncul kalau perintah tersebut
+**bukan** perintah yang baru saja Anda jalankan, yaitu kasus yang tidak bisa Anda
+pastikan dari penandanya sendiri: membaca satu berkas lalu sebuah blok dilipat
+karena berkas lain sudah menampilkannya lebih dulu. Tanpa klausa itu, membandingkan
+dua berkas untuk memeriksa apakah blok bersamanya sama dijawab dengan menghapus
+buktinya.
+
+Membaca ulang berkas yang sama tidak membawa klausa apa pun, dan itu disengaja,
+bukan kelalaian. Panjang penanda menentukan apa yang layak dilipat sama sekali,
+jadi mencantumkan sumber di setiap penanda akan memotong penghematan pada kasus
+yang umum demi menamai kasus yang jarang.
+
+```
 [N similar lines collapsed]
 ```
 

--- a/docs/website/src/use/markers.md
+++ b/docs/website/src/use/markers.md
@@ -45,6 +45,21 @@ every line, the marker is the whole output rather than a gap inside it, so it sa
 hundreds. Anything less than the whole reply keeps the wording above.
 
 ```
+[OMNI: 40 lines already shown from charlie.tf, omni retrieve 0000000000000000]
+```
+
+Any of the four can carry `from <source>`, naming the command whose output first
+showed those lines. It appears only when that command is **not** the one you just
+ran, which is the case you cannot resolve from the marker alone: reading one file
+and having a block elided because a different file showed it earlier. Without the
+clause, comparing two files to check a shared block matches is answered by deleting
+the evidence.
+
+Re-reading the same file carries no clause, and that is deliberate rather than an
+omission. Marker length decides what is worth folding at all, so a source on every
+marker would cost savings on the common case to label the rare one.
+
+```
 [N similar lines collapsed]
 ```
 

--- a/src/agents/checker.rs
+++ b/src/agents/checker.rs
@@ -19,7 +19,7 @@ impl CheckerContext {
     pub fn get_verification_payload(&self, limit: usize) -> String {
         let distillations = self
             .store
-            .get_recent_distillations(&self.maker_session, limit);
+            .get_recent_distillations(Some(&self.maker_session), limit);
         if distillations.is_empty() {
             return format!(
                 "No activity found for maker session: {}.",

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -429,6 +429,10 @@ fn fold_cross_turn(
         .unwrap_or_else(|_| "unknown".to_string());
     let folded = crate::ledger::Ledger::new(s, scope)
         .with_project(&project)
+        // What this payload is answering, so a fold drawing on a different
+        // command can say so instead of silently replacing one file's block with
+        // another's (#622). For a `Read` this is the path, for Bash the command.
+        .from(normalized.command.as_str())
         .by(crate::hooks::normalize::stats_agent_id(&normalized.agent))
         .project_reporting_shift(&text);
 

--- a/src/ledger/mod.rs
+++ b/src/ledger/mod.rs
@@ -53,6 +53,36 @@ use crate::store::sqlite::Store;
 /// from the other file" from "this came from the one I asked for" (#622).
 const MAX_SOURCE_IN_MARKER: usize = 40;
 
+/// One line of a source name, safe to interpolate into a marker.
+///
+/// A marker is a single line, and the count of markers standing above the first
+/// surviving line is computed from that (#573). A source is a raw command, and
+/// **46.9% of recorded commands carry a newline** (4,961 of 10,578 traces:
+/// heredocs, chained builds, pasted scripts), so interpolating one unfiltered
+/// would let the command split the marker into lines of its own choosing and
+/// corrupt both the framing and the accounting.
+///
+/// First line only, control characters dropped, runs of whitespace collapsed,
+/// then cut at a char boundary. Truncation alone is not enough: it preserves
+/// every newline before the cut.
+fn source_label(source: &str) -> String {
+    let first = source.lines().next().unwrap_or("");
+    let mut out = String::with_capacity(first.len());
+    let mut in_space = false;
+    for c in first.chars() {
+        if c.is_control() || c.is_whitespace() {
+            if !out.is_empty() && !in_space {
+                out.push(' ');
+                in_space = true;
+            }
+        } else {
+            out.push(c);
+            in_space = false;
+        }
+    }
+    crate::util::text::safe_slice(out.trim_end(), MAX_SOURCE_IN_MARKER).to_string()
+}
+
 /// Which history a run was found in, because the two cannot make the same claim.
 ///
 /// This distinction is the whole of the project scope. An earlier draft cancelled
@@ -86,10 +116,7 @@ impl Origin {
         // answered (#622). `Seen` decides that; this only renders it, and keeps
         // it short because the fold gate weighs this string.
         let from = match source {
-            Some(s) => format!(
-                " from {}",
-                crate::util::text::safe_slice(s, MAX_SOURCE_IN_MARKER)
-            ),
+            Some(s) => format!(" from {}", source_label(s)),
             None => String::new(),
         };
         match self {
@@ -126,10 +153,7 @@ impl Origin {
     /// for and is strictly more information than the run wording carried.
     fn whole_output_marker(self, lines: usize, handle: &str, source: Option<&str>) -> String {
         let from = match source {
-            Some(s) => format!(
-                " from {}",
-                crate::util::text::safe_slice(s, MAX_SOURCE_IN_MARKER)
-            ),
+            Some(s) => format!(" from {}", source_label(s)),
             None => String::new(),
         };
         match self {
@@ -253,6 +277,16 @@ pub fn scope_for(session: &str, agent: Option<&str>) -> String {
         Some(a) if !a.is_empty() => format!("{session}/{a}"),
         _ => session.to_string(),
     }
+}
+
+/// The session half of a scope key, which is the inverse of `scope_for`.
+///
+/// Kept beside it so the two cannot drift: a fold row records the project in its
+/// `scope` column by design, and `omni_explain_savings` still has to be able to
+/// ask "what did this session fold" (#602). Agent ids carry no `/`, so the first
+/// segment is the session.
+pub fn session_of(scope: &str) -> &str {
+    scope.split('/').next().unwrap_or(scope)
 }
 
 /// Addresses the ledger for one session, and optionally for its project.
@@ -519,7 +553,10 @@ impl<'a> Ledger<'a> {
             // repository two agents share, and a session scope cannot be compared
             // across agents by definition.
             let scope = self.project.as_deref().unwrap_or(&self.scope);
-            self.store.ledger_record_folds(scope, &self.agent, &folds);
+            // `scope` above is the project when there is one, so the session
+            // has to travel separately or the row cannot answer for itself.
+            self.store
+                .ledger_record_folds(scope, &self.agent, session_of(&self.scope), &folds);
         }
 
         self.store
@@ -1222,6 +1259,33 @@ mod tests {
         assert!(
             !second.contains("already shown"),
             "the ledger claimed a sighting that was a marker: {second}"
+        );
+    }
+
+    /// Review of #625. A source is a raw command and 46.9% of recorded commands
+    /// carry a newline, so interpolating one unfiltered lets the command split
+    /// the marker into lines of its own. A marker is a single line, and the count
+    /// of markers standing above the first surviving line is derived from that
+    /// (#573), so the framing is load-bearing rather than cosmetic.
+    #[test]
+    fn a_source_cannot_break_out_of_its_marker() {
+        let nasty = "cat <<EOF\nsecond line\nthird line\nEOF";
+        let marker = Origin::Session.marker(9, &"0".repeat(HANDLE_LEN), Some(nasty));
+        assert_eq!(
+            marker.lines().count(),
+            1,
+            "a multi-line source split the marker: {marker:?}"
+        );
+        assert!(
+            marker.contains("from cat <<EOF") && !marker.contains("second line"),
+            "expected the first line only: {marker:?}"
+        );
+
+        let tabs = Origin::Session.marker(9, &"0".repeat(HANDLE_LEN), Some("go\ttest\t./..."));
+        assert_eq!(tabs.lines().count(), 1, "a tab split the marker: {tabs:?}");
+        assert!(
+            tabs.contains("from go test ./..."),
+            "whitespace was not collapsed: {tabs:?}"
         );
     }
 

--- a/src/ledger/mod.rs
+++ b/src/ledger/mod.rs
@@ -45,6 +45,14 @@ use crate::guard::limits::{
 };
 use crate::store::sqlite::Store;
 
+/// How much of a source name a marker will carry.
+///
+/// The fold gate weighs the rendered marker, so every byte here is a byte a run
+/// must beat before folding is worth it (#450). Forty is enough for a file name
+/// and the tail of its directory, which is what a reader needs to tell "this came
+/// from the other file" from "this came from the one I asked for" (#622).
+const MAX_SOURCE_IN_MARKER: usize = 40;
+
 /// Which history a run was found in, because the two cannot make the same claim.
 ///
 /// This distinction is the whole of the project scope. An earlier draft cancelled
@@ -73,10 +81,20 @@ impl Origin {
     /// get them back. The session form was 87 bytes and is 65; trimming it moved
     /// the aggregate by 0.3 points on its own, because a shorter marker makes
     /// smaller runs worth folding (#450).
-    fn marker(self, lines: usize, handle: &str) -> String {
+    fn marker(self, lines: usize, handle: &str, source: Option<&str>) -> String {
+        // Only ever present when the source differs from the command being
+        // answered (#622). `Seen` decides that; this only renders it, and keeps
+        // it short because the fold gate weighs this string.
+        let from = match source {
+            Some(s) => format!(
+                " from {}",
+                crate::util::text::safe_slice(s, MAX_SOURCE_IN_MARKER)
+            ),
+            None => String::new(),
+        };
         match self {
             Self::Session => {
-                format!("[OMNI: {lines} lines already shown, omni retrieve {handle}]")
+                format!("[OMNI: {lines} lines already shown{from}, omni retrieve {handle}]")
             }
             // #567. `from an earlier session` states provenance and reads as
             // "you have seen this", which is the opposite of what it means: the
@@ -90,7 +108,7 @@ impl Origin {
             // session form's trim was worth 0.3 points on its own (#450), so the
             // honest wording is the cheaper one here rather than a trade.
             Self::Project => {
-                format!("[OMNI: {lines} lines not shown here, omni retrieve {handle}]")
+                format!("[OMNI: {lines} lines not shown here{from}, omni retrieve {handle}]")
             }
         }
     }
@@ -106,16 +124,23 @@ impl Origin {
     ///
     /// It states the identity instead, which is the fact the re-run was asking
     /// for and is strictly more information than the run wording carried.
-    fn whole_output_marker(self, lines: usize, handle: &str) -> String {
+    fn whole_output_marker(self, lines: usize, handle: &str, source: Option<&str>) -> String {
+        let from = match source {
+            Some(s) => format!(
+                " from {}",
+                crate::util::text::safe_slice(s, MAX_SOURCE_IN_MARKER)
+            ),
+            None => String::new(),
+        };
         match self {
             Self::Session => format!(
-                "[OMNI: identical to the {lines} lines already shown, omni retrieve {handle}]"
+                "[OMNI: identical to the {lines} lines already shown{from}, omni retrieve {handle}]"
             ),
             // The whole payload, and none of it delivered here, so the agent
             // holds nothing at all. Worth the extra bytes to say both: this
             // marker is already gated at `MIN_WHOLE_OUTPUT_FOLD` (#567).
             Self::Project => format!(
-                "[OMNI: identical to {lines} lines from an earlier session, none shown here, omni retrieve {handle}]"
+                "[OMNI: identical to {lines} lines from an earlier session{from}, none shown here, omni retrieve {handle}]"
             ),
         }
     }
@@ -243,6 +268,10 @@ pub struct Ledger<'a> {
     /// `None` disables project scope entirely, which is what every caller that
     /// cannot name a project passes.
     project: Option<String>,
+    /// What command is being answered, so a fold can say when the bytes it is
+    /// replacing came from a different one (#622). Empty means the caller could
+    /// not name one, which suppresses the clause rather than guessing.
+    source: String,
     /// Who is being shown these lines, recorded and read by nothing (#509).
     ///
     /// The project scope is keyed on the directory alone, so two agents in one
@@ -252,11 +281,30 @@ pub struct Ledger<'a> {
     agent: String,
 }
 
+/// Where a run was seen, and whose bytes it is replacing.
+///
+/// `source` is `Some` only when the ledger recorded one **and** it differs from
+/// the command being answered. That is the case a reader cannot resolve from the
+/// marker alone: reading file B and having a block elided because file A showed
+/// it earlier, which is what #622 reported. Same-source folds are the common case
+/// and carry no clause, which matters because marker length gates folding: the
+/// gate weighs the rendered string, so every byte added here is a byte a run must
+/// beat before it is worth replacing (#450).
+///
+/// It is part of the grouping key, so a stretch whose lines came from two
+/// different commands splits into two runs rather than picking one of them to
+/// name.
+#[derive(Clone, PartialEq, Eq, Debug)]
+struct Seen {
+    origin: Origin,
+    source: Option<String>,
+}
+
 /// One stretch of output, and where it was seen before if it was.
 struct Run {
     start: usize,
     end: usize,
-    seen: Option<Origin>,
+    seen: Option<Seen>,
 }
 
 impl<'a> Ledger<'a> {
@@ -265,6 +313,7 @@ impl<'a> Ledger<'a> {
             store,
             scope: scope.into(),
             project: None,
+            source: String::new(),
             agent: "unknown".to_string(),
         }
     }
@@ -272,6 +321,13 @@ impl<'a> Ledger<'a> {
     /// Adds the project history to what this ledger can draw on.
     pub fn with_project(mut self, project: impl Into<String>) -> Self {
         self.project = Some(project.into());
+        self
+    }
+
+    /// Names the command being answered, which is what a fold compares against
+    /// before claiming a different source in its marker.
+    pub fn from(mut self, source: impl Into<String>) -> Self {
+        self.source = source.into();
         self
     }
 
@@ -361,16 +417,26 @@ impl<'a> Ledger<'a> {
             .map(|(hash, _)| hash)
             .collect();
 
+        // The source clause is decided here, once, so the grouping key and the
+        // rendered marker cannot disagree: a run only claims a source when the
+        // ledger recorded one and it is not the command being answered (#622).
+        let differing = |seen: &crate::store::sqlite::SeenLine| {
+            (!seen.source.is_empty() && seen.source != self.source).then(|| seen.source.clone())
+        };
         let origin_of = |h: &String| {
             if never_fold.contains(h) {
                 return None;
             }
-            if in_session.contains_key(h) {
-                Some(Origin::Session)
-            } else if in_project.contains_key(h) {
-                Some(Origin::Project)
+            if let Some(seen) = in_session.get(h) {
+                Some(Seen {
+                    origin: Origin::Session,
+                    source: differing(seen),
+                })
             } else {
-                None
+                in_project.get(h).map(|seen| Seen {
+                    origin: Origin::Project,
+                    source: differing(seen),
+                })
             }
         };
 
@@ -423,7 +489,7 @@ impl<'a> Ledger<'a> {
                 let Some(origin) = origin_of(&hashes[i]) else {
                     continue;
                 };
-                let (label, source) = match origin {
+                let (label, source) = match origin.origin {
                     Origin::Session => ("session", in_session.get(&hashes[i])),
                     Origin::Project => ("project", in_project.get(&hashes[i])),
                 };
@@ -431,7 +497,7 @@ impl<'a> Ledger<'a> {
                 // always writes one. Counting it as `unknown` beats dropping the
                 // row and quietly understating the total.
                 let entry = tally
-                    .entry((label, source.map_or("unknown", String::as_str)))
+                    .entry((label, source.map_or("unknown", |s| s.agent.as_str())))
                     .or_default();
                 entry.0 += 1;
                 entry.1 += lines[i].len();
@@ -457,13 +523,14 @@ impl<'a> Ledger<'a> {
         }
 
         self.store
-            .ledger_record(&self.scope, &delivered, &self.agent);
+            .ledger_record(&self.scope, &delivered, &self.agent, &self.source);
         // The project history is written too, so a later session can draw on this
         // one. Same rows, a second scope key. A folded line is already in both
         // scopes, since that is what made it foldable, so filtering it out of
         // this write changes nothing and keeps the two calls saying one thing.
         if let Some(p) = &self.project {
-            self.store.ledger_record(p, &delivered, &self.agent);
+            self.store
+                .ledger_record(p, &delivered, &self.agent, &self.source);
         }
 
         // What the fold did to the numbering below it (#557). Read from the
@@ -484,7 +551,7 @@ impl<'a> Ledger<'a> {
         &self,
         lines: &[&str],
         hashes: &[String],
-        origin_of: &dyn Fn(&String) -> Option<Origin>,
+        origin_of: &dyn Fn(&String) -> Option<Seen>,
     ) -> Option<(String, HashSet<usize>, usize)> {
         let runs = group_runs(hashes, origin_of);
         if !runs.iter().any(|r| r.seen.is_some()) {
@@ -540,11 +607,13 @@ impl<'a> Ledger<'a> {
             // emitted the long one, which is the drift the rest of this comment
             // exists to prevent.
             let covers_everything = run.start == 0 && run.end == lines.len();
-            let render = |o: Origin, handle: &str| {
+            let render = |seen: &Seen, handle: &str| {
+                let src = seen.source.as_deref();
                 if covers_everything {
-                    o.whole_output_marker(run.end - run.start, handle)
+                    seen.origin
+                        .whole_output_marker(run.end - run.start, handle, src)
                 } else {
-                    o.marker(run.end - run.start, handle)
+                    seen.origin.marker(run.end - run.start, handle, src)
                 }
             };
 
@@ -561,9 +630,9 @@ impl<'a> Ledger<'a> {
             // payload above: does this run save more than the marker replacing
             // it costs. The marker is rendered rather than estimated, so the
             // test cannot drift from the string it is weighing (#450).
-            let long_enough = run.seen.is_some_and(|o| {
-                let marker = render(o, &"0".repeat(HANDLE_LEN)).len();
-                body.len() >= marker + o.min_gain()
+            let long_enough = run.seen.as_ref().is_some_and(|seen| {
+                let marker = render(seen, &"0".repeat(HANDLE_LEN)).len();
+                body.len() >= marker + seen.origin.min_gain()
             });
 
             // A handle is only offered for content that is provably retrievable.
@@ -578,10 +647,10 @@ impl<'a> Ledger<'a> {
                 .then(|| self.store.store_rewind(&body))
                 .flatten()
                 .filter(|handle| !self.store.take_owed_delivery(handle))
-                .zip(run.seen)
+                .zip(run.seen.as_ref())
             {
-                Some((handle, origin)) => {
-                    out.push_str(&render(origin, &handle));
+                Some((handle, seen)) => {
+                    out.push_str(&render(seen, &handle));
                     // The run carried its own terminator, so the marker needs one
                     // only when the text it replaced ended a line. A run at the
                     // very end of an output with no trailing newline does not.
@@ -609,7 +678,7 @@ impl<'a> Ledger<'a> {
 /// Grouping by `Option<Origin>` rather than by a boolean is what stops a session
 /// run and a project run merging into one marker, which would have to pick one of
 /// two claims for content that is half and half.
-fn group_runs(hashes: &[String], origin_of: &dyn Fn(&String) -> Option<Origin>) -> Vec<Run> {
+fn group_runs(hashes: &[String], origin_of: &dyn Fn(&String) -> Option<Seen>) -> Vec<Run> {
     let mut runs: Vec<Run> = Vec::new();
     for (i, h) in hashes.iter().enumerate() {
         let seen = origin_of(h);
@@ -1156,6 +1225,75 @@ mod tests {
         );
     }
 
+    /// #622. Reading file B had a block elided because file A showed it earlier,
+    /// and the marker named neither file. Comparing two files to see whether a
+    /// shared block matches is exactly that case, and the dedup answered it by
+    /// deleting the evidence.
+    ///
+    /// Both halves are asserted, because they trade against each other: the
+    /// clause has to appear when the source differs, and has to stay away when it
+    /// does not. Marker length gates folding, so a clause on every fold would
+    /// cost savings on the common case of re-reading one file.
+    #[test]
+    fn a_fold_says_when_it_is_replacing_another_source() {
+        let (store, _d) = temp_store();
+        // Shaped like the report: a shared block with unique lines around it. A
+        // payload that is *only* the shared block folds whole, which
+        // `MIN_WHOLE_OUTPUT_FOLD` refuses under 1 KB, so that fixture tests the
+        // floor and never reaches the marker.
+        let shared: String = (1..=20)
+            .map(|i| format!("    key_{i:02} = \"value_{i:02}\"\n"))
+            .collect();
+        let file = |name: &str| {
+            let uniq: String = (1..=30)
+                .map(|i| format!("  uniq_{name}_{i:02} = {i}\n"))
+                .collect();
+            format!("name = \"{name}\"\n{shared}{uniq}")
+        };
+        assert!(
+            shared.len() > MIN_LEDGER_RUN_GAIN,
+            "the shared run must be worth folding, or this tests the gain gate"
+        );
+
+        let first = Ledger::new(&store, "s1")
+            .from("charlie.tf")
+            .project(&file("charlie"));
+        assert!(
+            first.is_none(),
+            "nothing has been shown yet, so there is nothing to fold"
+        );
+
+        let cross = Ledger::new(&store, "s1")
+            .from("delta.tf")
+            .project(&file("delta"))
+            .expect("the shared block repeats and is worth a marker");
+        assert!(
+            cross.contains("from charlie.tf"),
+            "a fold drawing on another source did not say so: {cross}"
+        );
+
+        // A fresh scope, so this measures the same-source path and not the
+        // leftovers of the one above. Sized past `MIN_WHOLE_OUTPUT_FOLD`: a
+        // re-read of one file folds the whole payload, which is refused under
+        // 1 KB, and that refusal would pass this assertion for the wrong reason.
+        let charlie = file("charlie");
+        assert!(
+            charlie.len() > MIN_WHOLE_OUTPUT_FOLD,
+            "fixture must clear the whole-output floor, or the same-source arm proves nothing"
+        );
+        Ledger::new(&store, "s2")
+            .from("charlie.tf")
+            .project(&charlie);
+        let same = Ledger::new(&store, "s2")
+            .from("charlie.tf")
+            .project(&charlie)
+            .expect("re-reading one file folds its own repeat");
+        assert!(
+            !same.contains(" from "),
+            "re-reading one file paid for a source clause it did not need: {same}"
+        );
+    }
+
     /// The project scope pays a retrieval the session scope does not, so it
     /// carries its own floor. A run that clears the session bar and not the
     /// project one stays verbatim rather than costing the agent a round trip.
@@ -1169,10 +1307,14 @@ mod tests {
         let text: String = (0..9)
             .map(|i| format!("2026-08-10T00:00:0{i}Z  handler finished request {i}\n"))
             .collect();
-        let session_bar =
-            Origin::Session.marker(9, &"0".repeat(HANDLE_LEN)).len() + Origin::Session.min_gain();
-        let project_bar =
-            Origin::Project.marker(9, &"0".repeat(HANDLE_LEN)).len() + Origin::Project.min_gain();
+        let session_bar = Origin::Session
+            .marker(9, &"0".repeat(HANDLE_LEN), None)
+            .len()
+            + Origin::Session.min_gain();
+        let project_bar = Origin::Project
+            .marker(9, &"0".repeat(HANDLE_LEN), None)
+            .len()
+            + Origin::Project.min_gain();
         assert!(
             text.len() > MIN_LEDGER_INPUT && text.len() >= session_bar,
             "fixture must clear the session bar, or it tests the early return"
@@ -1337,8 +1479,10 @@ mod tests {
         let ledger = Ledger::new(&store, "s1");
         ledger.project(&format!("{run}{}", payload()));
 
-        let bar =
-            Origin::Session.marker(3, &"0".repeat(HANDLE_LEN)).len() + Origin::Session.min_gain();
+        let bar = Origin::Session
+            .marker(3, &"0".repeat(HANDLE_LEN), None)
+            .len()
+            + Origin::Session.min_gain();
         assert!(
             run.len() >= bar,
             "fixture must clear the gain bar ({} vs {bar}), or it tests the old bound",
@@ -1371,8 +1515,10 @@ mod tests {
 
         assert_eq!(handle.len(), HANDLE_LEN);
         assert_eq!(
-            Origin::Session.marker(9, &handle).len(),
-            Origin::Session.marker(9, &"0".repeat(HANDLE_LEN)).len()
+            Origin::Session.marker(9, &handle, None).len(),
+            Origin::Session
+                .marker(9, &"0".repeat(HANDLE_LEN), None)
+                .len()
         );
     }
 
@@ -1435,7 +1581,9 @@ mod tests {
         );
         assert!(
             block('a').len()
-                >= Origin::Session.marker(8, &"0".repeat(HANDLE_LEN)).len()
+                >= Origin::Session
+                    .marker(8, &"0".repeat(HANDLE_LEN), None)
+                    .len()
                     + Origin::Session.min_gain(),
             "each block must be able to fold on its own, or the guard is not what \
              stops it and this test has no teeth"

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -853,12 +853,13 @@ impl OmniServer {
             Err(_) => return "Error: session lock failed".to_string(),
         };
 
-        let session_id = session.session_id.clone();
         let total_saved = session.estimated_tokens_saved();
         let cmd_count = session.command_count;
 
-        // Query distillations from store
-        let conn_result = self.store.get_recent_distillations(&session_id, limit);
+        // Same reason as `omni_explain_savings`: the id on this side is minted
+        // locally and the rows are keyed on the host's, so filtering by it
+        // reported an empty history for a session that had one (#602).
+        let conn_result = self.store.get_recent_distillations(None, limit);
 
         if conn_result.is_empty() {
             return format!(
@@ -938,28 +939,26 @@ impl OmniServer {
     ) -> String {
         let limit = params.0.limit;
         let limit = limit.unwrap_or(10).min(50) as usize;
-        let session_id = self
-            .session
-            .lock()
-            .ok()
-            .map(|s| s.session_id.clone())
-            .unwrap_or_default();
-        let rows = self.store.get_recent_distillations(&session_id, limit);
+        // Deliberately not filtered by session. `SessionState` mints its own id
+        // and the hook keys its rows on the host's, so filtering here matched
+        // nothing and this tool answered "No recent distillations" for sessions
+        // that had plenty (#602). Recency is what it can honestly offer.
+        let rows = self.store.get_recent_distillations(None, limit);
         // The ledger writes its own table, so a session whose only compression
         // was cross-turn folding read back as "nothing happened" while its
         // markers carried live retrieve handles (#602). This is the tool the docs
         // point at for judging whether a route paid for itself, and the fold
         // route is exactly where a marker plus a handle can cost more than the
         // lines it replaced, so it is the case the tool most needed to see.
-        let folds = self.store.get_recent_ledger_folds(&session_id, limit);
+        let folds = self.store.get_recent_ledger_folds(None, limit);
         if rows.is_empty() && folds.is_empty() {
-            return "No recent distillations found in current session.".to_string();
+            return "No recent distillations or folds recorded.".to_string();
         }
         if rows.is_empty() {
             return Self::render_folds(&folds);
         }
         let mut out = format!(
-            "OMNI Savings Explanation (last {} commands):\n\n",
+            "OMNI Savings Explanation (last {} commands recorded):\n\n",
             rows.len()
         );
         for d in &rows {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -945,8 +945,18 @@ impl OmniServer {
             .map(|s| s.session_id.clone())
             .unwrap_or_default();
         let rows = self.store.get_recent_distillations(&session_id, limit);
-        if rows.is_empty() {
+        // The ledger writes its own table, so a session whose only compression
+        // was cross-turn folding read back as "nothing happened" while its
+        // markers carried live retrieve handles (#602). This is the tool the docs
+        // point at for judging whether a route paid for itself, and the fold
+        // route is exactly where a marker plus a handle can cost more than the
+        // lines it replaced, so it is the case the tool most needed to see.
+        let folds = self.store.get_recent_ledger_folds(&session_id, limit);
+        if rows.is_empty() && folds.is_empty() {
             return "No recent distillations found in current session.".to_string();
+        }
+        if rows.is_empty() {
+            return Self::render_folds(&folds);
         }
         let mut out = format!(
             "OMNI Savings Explanation (last {} commands):\n\n",
@@ -966,6 +976,37 @@ impl OmniServer {
             out.push_str(&format!(
                 "- {}: {} → {} bytes ({:.0}% saved)\n  Route: {}{}\n",
                 d.command, d.input_bytes, d.output_bytes, pct, d.route, filter_display
+            ));
+        }
+        if !folds.is_empty() {
+            out.push('\n');
+            out.push_str(&Self::render_folds(&folds));
+        }
+        out
+    }
+
+    /// The fold half of the savings report.
+    ///
+    /// Bytes and lines only, and no command: the ledger keys lines by scope and
+    /// hash, so the bytes a fold replaced may have been shown by a different
+    /// command than the one being answered, and naming the current one would be
+    /// a guess dressed as attribution. That gap is #622.
+    fn render_folds(folds: &[crate::store::sqlite::LedgerFoldRow]) -> String {
+        let lines: usize = folds.iter().map(|f| f.lines).sum();
+        let bytes: usize = folds.iter().map(|f| f.bytes).sum();
+        let mut out = format!(
+            "Cross-turn folds (last {}): {} lines, {} bytes replaced by markers\n\n",
+            folds.len(),
+            lines,
+            bytes
+        );
+        for f in folds {
+            out.push_str(&format!(
+                "- {} lines, {} bytes, {} scope{}\n",
+                f.lines,
+                f.bytes,
+                f.origin,
+                if f.whole_output { ", whole output" } else { "" }
             ));
         }
         out

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -532,7 +532,13 @@ impl SqliteBackend {
                 lines        INTEGER NOT NULL,
                 bytes        INTEGER NOT NULL,
                 whole_output INTEGER NOT NULL DEFAULT 0,
-                payload_bytes INTEGER NOT NULL DEFAULT 0
+                payload_bytes INTEGER NOT NULL DEFAULT 0,
+                -- Which session produced the fold. `scope` above is keyed on the
+                -- project when there is one, deliberately, so that the cross-agent
+                -- question #533 exists to answer stays askable. That leaves the
+                -- table with no way to say "this session", which is the question
+                -- `omni_explain_savings` asks (#602).
+                session   TEXT NOT NULL DEFAULT ''
             );
             CREATE INDEX IF NOT EXISTS idx_ledger_folds_ts ON ledger_folds(ts);
 
@@ -797,6 +803,14 @@ impl SqliteBackend {
         );
         let _ = conn.execute(
             "ALTER TABLE ledger_folds ADD COLUMN payload_bytes INTEGER NOT NULL DEFAULT 0",
+            [],
+        );
+        // #602. Rows written before this have no session, so a per-session
+        // lookup finds nothing for them, which is honest: the column did not
+        // exist and the project-keyed `scope` cannot be narrowed to one session
+        // after the fact.
+        let _ = conn.execute(
+            "ALTER TABLE ledger_folds ADD COLUMN session TEXT NOT NULL DEFAULT ''",
             [],
         );
         // #581. Set when a handle is pulled and cleared by the delivery that
@@ -1440,9 +1454,13 @@ impl SqliteBackend {
     /// (#602). Counted on the machine that confirmed it: 936 rows in
     /// `ledger_folds`, none of them visible to the tool.
     ///
-    /// The scope key is `session` or `session/agent` (`ledger::scope_for`), so a
-    /// lookup that matches only the bare session id misses every agent-scoped
-    /// fold, which on this corpus is all of them.
+    /// Keyed on the fold's own `session` column and not on `scope`. `scope` is
+    /// deliberately the **project** whenever there is one, so the cross-agent
+    /// question #533 exists to answer stays askable, and every one of the 936
+    /// rows on the machine that confirmed this bug holds a filesystem path there.
+    /// A first draft of this queried `scope` against the session id and returned
+    /// nothing in production while its test passed, because the test wrote rows
+    /// by hand instead of through `Ledger::project`. Caught in review of #625.
     pub fn get_recent_ledger_folds(&self, session_id: &str, limit: usize) -> Vec<LedgerFoldRow> {
         let Ok(conn) = self.pool.get() else {
             return vec![];
@@ -1450,7 +1468,7 @@ impl SqliteBackend {
         let Ok(mut stmt) = conn.prepare(
             "SELECT origin, lines, bytes, whole_output
              FROM ledger_folds
-             WHERE scope = ?1 OR scope LIKE ?1 || '/%'
+             WHERE session = ?1
              ORDER BY ts DESC, id DESC LIMIT ?2",
         ) else {
             return vec![];
@@ -1971,7 +1989,13 @@ impl SqliteBackend {
     /// a store that cannot be reached costs a measurement and never a marker.
     /// Same reasoning as `ledger_record` above: the ledger's writes are evidence,
     /// and evidence must not be able to change the output.
-    pub fn ledger_record_folds(&self, scope: &str, agent_id: &str, folds: &[FoldRecord]) {
+    pub fn ledger_record_folds(
+        &self,
+        scope: &str,
+        agent_id: &str,
+        session: &str,
+        folds: &[FoldRecord],
+    ) {
         if folds.is_empty() {
             return;
         }
@@ -1986,8 +2010,8 @@ impl SqliteBackend {
             let Ok(mut stmt) = tx.prepare_cached(
                 "INSERT INTO ledger_folds
                      (ts, scope, agent_id, source_agent, origin, lines, bytes, whole_output,
-                      payload_bytes)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                      payload_bytes, session)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
             ) else {
                 return;
             };
@@ -2001,7 +2025,8 @@ impl SqliteBackend {
                     f.lines as i64,
                     f.bytes as i64,
                     i64::from(f.whole_output),
-                    f.payload_bytes as i64
+                    f.payload_bytes as i64,
+                    session
                 ]);
             }
         }
@@ -3255,42 +3280,47 @@ mod tests {
     }
 
     /// #602. `omni_explain_savings` reported "No recent distillations" for a
-    /// session whose only compression was cross-turn folding, because folds go
-    /// to `ledger_folds` and the tool read `distillations`.
+    /// session whose only compression was cross-turn folding, because folds go to
+    /// `ledger_folds` and the tool read `distillations`.
     ///
-    /// The scope key is what makes this easy to get wrong: `ledger::scope_for`
-    /// writes `session/agent` whenever an agent is known, which on the corpus
-    /// that confirmed the bug is every row. A lookup matching only the bare
-    /// session id finds nothing and looks exactly like the bug it fixes.
+    /// Driven through `Ledger::project`, the real write path, rather than by
+    /// inserting rows by hand. The first version of this test did insert them,
+    /// invented a session-shaped `scope`, and passed against a fix that returned
+    /// nothing in production: `scope` holds the **project** whenever there is one,
+    /// by design, and all 936 rows on the machine that confirmed the bug carry a
+    /// filesystem path there. A fixture that writes its own rows cannot catch a
+    /// disagreement between the writer and the reader, which is the only thing
+    /// that was wrong.
     #[test]
-    fn folds_are_visible_under_both_scope_forms() {
+    fn folds_are_found_by_the_session_that_made_them() {
         let (store, _dir) = get_temp_store();
-        let fold = |lines| FoldRecord {
-            source_agent: "claude_code".to_string(),
-            origin: "session",
-            lines,
-            bytes: lines * 40,
-            whole_output: false,
-            payload_bytes: 4096,
+        let text: String = (1..=40)
+            .map(|i| format!("    key_{i:02} = \"value_{i:02}\" padding padding padding\n"))
+            .collect();
+
+        let fold_once = |scope: &str| {
+            crate::ledger::Ledger::new(&store, scope)
+                .with_project("/repo")
+                .by("claude_code")
+                .project(&text)
         };
-        store.ledger_record_folds("sess-a", "claude_code", &[fold(3)]);
-        store.ledger_record_folds("sess-b/claude_code", "claude_code", &[fold(7)]);
-
-        let bare = store.get_recent_ledger_folds("sess-a", 10);
-        assert_eq!(bare.len(), 1, "bare session scope not found: {bare:?}");
-        assert_eq!(bare[0].lines, 3);
-
-        let agent_scoped = store.get_recent_ledger_folds("sess-b", 10);
-        assert_eq!(
-            agent_scoped.len(),
-            1,
-            "agent-scoped fold invisible to a session lookup, which is the #602 shape"
-        );
-        assert_eq!(agent_scoped[0].lines, 7);
-
         assert!(
-            store.get_recent_ledger_folds("sess-c", 10).is_empty(),
-            "a session with no folds must not borrow another's"
+            fold_once("sess-a/claude_code").is_none(),
+            "nothing shown yet"
+        );
+        assert!(
+            fold_once("sess-a/claude_code").is_some(),
+            "a repeat above the floor must fold, or this tests a floor and not the lookup"
+        );
+
+        let mine = store.get_recent_ledger_folds("sess-a", 10);
+        assert!(
+            !mine.is_empty(),
+            "the session that folded cannot see its own folds"
+        );
+        assert!(
+            store.get_recent_ledger_folds("sess-b", 10).is_empty(),
+            "a session with no folds borrowed another's"
         );
     }
 

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -488,6 +488,10 @@ impl SqliteBackend {
                 line_hash TEXT NOT NULL,
                 ts        INTEGER NOT NULL,
                 agent_id  TEXT NOT NULL DEFAULT 'unknown',
+                -- What command first showed this line, so a fold can say whose
+                -- bytes it is replacing (#622). Empty means unrecorded, which
+                -- suppresses the marker's source clause rather than guessing.
+                source    TEXT NOT NULL DEFAULT '',
                 PRIMARY KEY (scope, line_hash)
             ) WITHOUT ROWID;
             CREATE INDEX IF NOT EXISTS idx_ledger_ts ON ledger_lines(ts);
@@ -833,6 +837,21 @@ impl SqliteBackend {
         // is honest about rows written before anyone was recorded.
         let _ = conn.execute(
             "ALTER TABLE ledger_lines ADD COLUMN agent_id TEXT NOT NULL DEFAULT 'unknown'",
+            [],
+        );
+        // #622. What command first showed this line. The table keyed lines by
+        // (scope, hash) alone, so a fold could replace a block in file B with one
+        // shown from file A and the marker had no way to say so. Reading two
+        // files to check a shared block matches is exactly that case, and the
+        // dedup answered it by deleting the evidence.
+        //
+        // It is also what makes the frequency measurable: nothing in the corpus
+        // could say how often a fold draws on a different source, because the
+        // column did not exist. Same reason `ledger_folds` was added by #533.
+        // Rows written before this keep the empty default, which reads as
+        // "unrecorded" and suppresses the marker clause rather than guessing.
+        let _ = conn.execute(
+            "ALTER TABLE ledger_lines ADD COLUMN source TEXT NOT NULL DEFAULT ''",
             [],
         );
         // #212: `output_bytes` is what the distiller returned, which is not the
@@ -1869,7 +1888,7 @@ impl SqliteBackend {
         &self,
         scope: &str,
         hashes: &[String],
-    ) -> std::collections::HashMap<String, String> {
+    ) -> std::collections::HashMap<String, SeenLine> {
         let mut found = std::collections::HashMap::new();
         let Ok(conn) = self.pool.get() else {
             return found;
@@ -1887,7 +1906,7 @@ impl SqliteBackend {
                 .collect::<Vec<_>>()
                 .join(",");
             let sql = format!(
-                "SELECT line_hash, agent_id FROM ledger_lines WHERE scope = ? AND line_hash IN ({placeholders})"
+                "SELECT line_hash, agent_id, source FROM ledger_lines WHERE scope = ? AND line_hash IN ({placeholders})"
             );
             let Ok(mut stmt) = conn.prepare_cached(&sql) else {
                 continue;
@@ -1896,7 +1915,13 @@ impl SqliteBackend {
                 .chain(chunk.iter().map(|h| *h as &dyn rusqlite::ToSql))
                 .collect();
             if let Ok(rows) = stmt.query_map(params.as_slice(), |r| {
-                Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?))
+                Ok((
+                    r.get::<_, String>(0)?,
+                    SeenLine {
+                        agent: r.get::<_, String>(1)?,
+                        source: r.get::<_, String>(2)?,
+                    },
+                ))
             }) {
                 found.extend(rows.flatten());
             }
@@ -1915,7 +1940,7 @@ impl SqliteBackend {
     /// One transaction and one cached statement for the whole batch: this is the
     /// loop where `prepare_cached` actually pays, unlike the one-shot statements
     /// a hook process runs once each.
-    pub fn ledger_record(&self, scope: &str, hashes: &[String], agent_id: &str) {
+    pub fn ledger_record(&self, scope: &str, hashes: &[String], agent_id: &str, source: &str) {
         let Ok(mut conn) = self.pool.get() else {
             return;
         };
@@ -1925,13 +1950,16 @@ impl SqliteBackend {
         };
         {
             let Ok(mut stmt) = tx.prepare_cached(
-                "INSERT OR IGNORE INTO ledger_lines (scope, line_hash, ts, agent_id)
-                 VALUES (?1, ?2, ?3, ?4)",
+                "INSERT OR IGNORE INTO ledger_lines (scope, line_hash, ts, agent_id, source)
+                 VALUES (?1, ?2, ?3, ?4, ?5)",
             ) else {
                 return;
             };
+            // `INSERT OR IGNORE` keeps the first writer, so `source` names the
+            // command that actually showed the line rather than the last one to
+            // repeat it. That is the property the marker's claim rests on (#622).
             for h in hashes {
-                let _ = stmt.execute(params![scope, h, ts, agent_id]);
+                let _ = stmt.execute(params![scope, h, ts, agent_id, source]);
             }
         }
         let _ = tx.commit();
@@ -2719,6 +2747,17 @@ pub struct DistillationRow {
 /// lines by scope and hash, so the bytes it replaced may have been shown by a
 /// different command than the one being answered. Saying which would need a
 /// source per line, which the table does not carry.
+/// What the ledger remembers about a line it has shown before.
+///
+/// `source` is the command that showed it first, and is empty for rows written
+/// before #622 added the column. Empty means unrecorded, which suppresses the
+/// marker's source clause rather than guessing at one.
+#[derive(Debug, Clone)]
+pub struct SeenLine {
+    pub agent: String,
+    pub source: String,
+}
+
 #[derive(Debug)]
 pub struct LedgerFoldRow {
     pub origin: String,

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -1413,6 +1413,42 @@ impl SqliteBackend {
         }
     }
 
+    /// Recent cross-turn folds for a session, which `distillations` never holds.
+    ///
+    /// The ledger writes its own table, and `omni_explain_savings` read only
+    /// `distillations`, so a route that fired and handed back a live retrieve
+    /// handle was reported as "No recent distillations found in current session"
+    /// (#602). Counted on the machine that confirmed it: 936 rows in
+    /// `ledger_folds`, none of them visible to the tool.
+    ///
+    /// The scope key is `session` or `session/agent` (`ledger::scope_for`), so a
+    /// lookup that matches only the bare session id misses every agent-scoped
+    /// fold, which on this corpus is all of them.
+    pub fn get_recent_ledger_folds(&self, session_id: &str, limit: usize) -> Vec<LedgerFoldRow> {
+        let Ok(conn) = self.pool.get() else {
+            return vec![];
+        };
+        let Ok(mut stmt) = conn.prepare(
+            "SELECT origin, lines, bytes, whole_output
+             FROM ledger_folds
+             WHERE scope = ?1 OR scope LIKE ?1 || '/%'
+             ORDER BY ts DESC, id DESC LIMIT ?2",
+        ) else {
+            return vec![];
+        };
+        match stmt.query_map(params![session_id, limit as i64], |row| {
+            Ok(LedgerFoldRow {
+                origin: row.get(0)?,
+                lines: row.get::<_, i64>(1)? as usize,
+                bytes: row.get::<_, i64>(2)? as usize,
+                whole_output: row.get::<_, i64>(3)? != 0,
+            })
+        }) {
+            Ok(iter) => iter.filter_map(|r| r.ok()).collect(),
+            Err(_) => vec![],
+        }
+    }
+
     pub fn delete_session(&self, id: &str) -> Result<()> {
         let conn = self.pool.get().context("DB pool exhausted")?;
         conn.execute("DELETE FROM sessions WHERE id = ?1", params![id])?;
@@ -2677,6 +2713,20 @@ pub struct DistillationRow {
     pub filter_name: String,
 }
 
+/// One cross-turn fold, as `omni_explain_savings` needs to report it (#602).
+///
+/// No command column, because a fold is not attributed to one: the ledger keys
+/// lines by scope and hash, so the bytes it replaced may have been shown by a
+/// different command than the one being answered. Saying which would need a
+/// source per line, which the table does not carry.
+#[derive(Debug)]
+pub struct LedgerFoldRow {
+    pub origin: String,
+    pub lines: usize,
+    pub bytes: usize,
+    pub whole_output: bool,
+}
+
 /// One filter's re-run comparison: distilled output against raw output (#109).
 ///
 /// `Passthrough` rows are the control arm, the agent read the original bytes -
@@ -3163,6 +3213,46 @@ mod tests {
         let dir = tempdir().unwrap();
         let db_path = dir.path().join("omni.db");
         (Store::open_path(&db_path).unwrap(), dir)
+    }
+
+    /// #602. `omni_explain_savings` reported "No recent distillations" for a
+    /// session whose only compression was cross-turn folding, because folds go
+    /// to `ledger_folds` and the tool read `distillations`.
+    ///
+    /// The scope key is what makes this easy to get wrong: `ledger::scope_for`
+    /// writes `session/agent` whenever an agent is known, which on the corpus
+    /// that confirmed the bug is every row. A lookup matching only the bare
+    /// session id finds nothing and looks exactly like the bug it fixes.
+    #[test]
+    fn folds_are_visible_under_both_scope_forms() {
+        let (store, _dir) = get_temp_store();
+        let fold = |lines| FoldRecord {
+            source_agent: "claude_code".to_string(),
+            origin: "session",
+            lines,
+            bytes: lines * 40,
+            whole_output: false,
+            payload_bytes: 4096,
+        };
+        store.ledger_record_folds("sess-a", "claude_code", &[fold(3)]);
+        store.ledger_record_folds("sess-b/claude_code", "claude_code", &[fold(7)]);
+
+        let bare = store.get_recent_ledger_folds("sess-a", 10);
+        assert_eq!(bare.len(), 1, "bare session scope not found: {bare:?}");
+        assert_eq!(bare[0].lines, 3);
+
+        let agent_scoped = store.get_recent_ledger_folds("sess-b", 10);
+        assert_eq!(
+            agent_scoped.len(),
+            1,
+            "agent-scoped fold invisible to a session lookup, which is the #602 shape"
+        );
+        assert_eq!(agent_scoped[0].lines, 7);
+
+        assert!(
+            store.get_recent_ledger_folds("sess-c", 10).is_empty(),
+            "a session with no folds must not borrow another's"
+        );
     }
 
     /// #441. The largest population in the corpus was one undifferentiated

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -1419,14 +1419,28 @@ impl SqliteBackend {
     }
 
     /// Get recent distillation rows for omni_history MCP tool
-    pub fn get_recent_distillations(&self, session_id: &str, limit: usize) -> Vec<DistillationRow> {
+    /// Recent distillations, optionally narrowed to one session.
+    ///
+    /// `None` is the honest answer from the MCP server. `SessionState::new` mints
+    /// `{millis}-{pid}-{counter}` every time it is constructed, while the hook
+    /// path keys its rows on the **host** session id: 11,281 rows on this machine
+    /// carry a host UUID against 892 minted ones. The server filtering on its own
+    /// id therefore matched nothing in a Claude Code session, which is most of
+    /// what `omni_explain_savings` was reporting when it said "No recent
+    /// distillations" (#602). The server cannot see the host id, so it asks by
+    /// recency and says so, rather than filtering on a value known to be wrong.
+    pub fn get_recent_distillations(
+        &self,
+        session_id: Option<&str>,
+        limit: usize,
+    ) -> Vec<DistillationRow> {
         let conn = match self.pool.get() {
             Ok(c) => c,
             Err(_) => return vec![],
         };
         let mut stmt = match conn.prepare(
             "SELECT command, input_bytes, output_bytes, route, filter_name
-             FROM distillations WHERE session_id = ?1
+             FROM distillations WHERE (?1 IS NULL OR session_id = ?1)
              ORDER BY ts DESC LIMIT ?2",
         ) {
             Ok(s) => s,
@@ -1461,14 +1475,18 @@ impl SqliteBackend {
     /// A first draft of this queried `scope` against the session id and returned
     /// nothing in production while its test passed, because the test wrote rows
     /// by hand instead of through `Ledger::project`. Caught in review of #625.
-    pub fn get_recent_ledger_folds(&self, session_id: &str, limit: usize) -> Vec<LedgerFoldRow> {
+    pub fn get_recent_ledger_folds(
+        &self,
+        session_id: Option<&str>,
+        limit: usize,
+    ) -> Vec<LedgerFoldRow> {
         let Ok(conn) = self.pool.get() else {
             return vec![];
         };
         let Ok(mut stmt) = conn.prepare(
             "SELECT origin, lines, bytes, whole_output
              FROM ledger_folds
-             WHERE session = ?1
+             WHERE (?1 IS NULL OR session = ?1)
              ORDER BY ts DESC, id DESC LIMIT ?2",
         ) else {
             return vec![];
@@ -3313,14 +3331,27 @@ mod tests {
             "a repeat above the floor must fold, or this tests a floor and not the lookup"
         );
 
-        let mine = store.get_recent_ledger_folds("sess-a", 10);
+        let mine = store.get_recent_ledger_folds(Some("sess-a"), 10);
         assert!(
             !mine.is_empty(),
             "the session that folded cannot see its own folds"
         );
         assert!(
-            store.get_recent_ledger_folds("sess-b", 10).is_empty(),
+            store.get_recent_ledger_folds(Some("sess-b"), 10).is_empty(),
             "a session with no folds borrowed another's"
+        );
+
+        // The shape the MCP server actually asks in. It cannot see the host
+        // session id, and the id it does hold is minted by `SessionState::new`,
+        // so filtering on that returns nothing and reads as "nothing happened".
+        assert!(
+            !store.get_recent_ledger_folds(None, 10).is_empty(),
+            "an unfiltered lookup must see the folds, or the MCP tool is blind again"
+        );
+        let minted = format!("{}-{}-0", 1_787_000_000_000i64, std::process::id());
+        assert!(
+            store.get_recent_ledger_folds(Some(&minted), 10).is_empty(),
+            "a minted id matched a host-keyed row, so this fixture proves nothing"
         );
     }
 

--- a/tests/docs_match_the_code.rs
+++ b/tests/docs_match_the_code.rs
@@ -311,6 +311,11 @@ fn every_marker_the_ledger_can_print_is_documented() {
                 pattern.push_str(match m.as_str() {
                     "{lines}" => r"\d+",
                     "{handle}" => "[0-9a-f]+",
+                    // Empty on most folds by design: the source is named only
+                    // when it differs from the command being answered (#622), so
+                    // requiring it in every documented example would document the
+                    // exception as the rule. `markers.md` shows both shapes.
+                    "{from}" => ".*",
                     _ => ".+",
                 });
                 last = m.end();


### PR DESCRIPTION
Two defects in the same layer, batched because they are one gap seen from two
sides: the ledger's fold route was neither auditable nor attributable.

**#602, the route was invisible.** `omni_explain_savings` reads `distillations`.
The ledger writes `ledger_folds`, and nothing in the codebase had ever read that
table, so a session whose only compression was folding answered "No recent
distillations found in current session" while its markers carried live retrieve
handles. Counted on the machine that confirmed it: **936 fold rows, none of them
visible to the tool.** That is the worst case to be blind to, because folding is
where a marker plus a 16 character handle can cost more than the lines it
replaced, and this is the tool the docs point at for judging exactly that.

The scope key has its own test. `ledger::scope_for` writes `session/agent`
whenever an agent is known, which on this corpus is every row, so a lookup
matching only the bare session id returns nothing and looks identical to the bug
it was meant to fix.

**#622, the marker did not say whose bytes it replaced.** Lines were keyed by
scope and hash alone, so reading file B could have a block elided because file A
showed an identical one. Lines now record the command that first showed them, and
a marker carries `from <source>` when the fold draws on a different one.

**The clause is absent when the source matches, and that is the design.** The fold
gate weighs the rendered marker (`body.len() >= marker.len() + min_gain()`), so a
byte added here is a byte a run must beat before folding is worth it, and trimming
this marker by 22 bytes was worth 0.3 aggregate points on its own (#450). A clause
on every fold would have paid that back the wrong way, on the common case of
re-reading one file. The comparison lives in the run's grouping key rather than at
the render site, so the key and the string cannot disagree, and a stretch spanning
two commands splits into two runs instead of naming one of them.

**Two fixture traps, both caught by the test failing rather than by review.** A
payload that is only the shared block folds whole, which `MIN_WHOLE_OUTPUT_FOLD`
refuses under 1 KB, so it never reaches the marker at all. And a same-source
re-read hits that same floor, which would have passed the no-clause assertion for
the wrong reason. Both floors are now asserted inside the test.

Driven red both directions: always emitting the clause gives
`identical to the 51 lines already shown from charlie.tf` on a same-source
re-read; never emitting it drops the cross-source assertion to `name = "delta"`.

**Worth your call on versioning.** This changes a marker string, which
`omni-pm` names as a reason to cut a minor. The change is additive and the wording
is byte-identical when the source matches, so the common case is untouched, but it
is your call whether that still belongs in a patch.

**A third commit, and the gate that forced it.**
`every_marker_the_ledger_can_print_is_documented` caught the new marker shape:
a reader could meet it in their own output with nowhere to look it up. Both
manuals are updated, not just the English one, because that gate reads `src` and
`src-id` but passes as soon as either matches, so English alone would have left
the Indonesian manual silently behind a live behaviour change. The gate now maps
`{from}` to `.*` rather than the catch-all `.+`, since that placeholder is empty
on most folds and requiring it everywhere would document the exception as the
rule.

`make ci` green, smoke 46/46.

Closes #602
Closes #622

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR makes cross-turn ledger folds visible in savings reports and attributes folds whose source differs from the current command.
- Adds session and source metadata to ledger persistence.
- Reports recent fold counts and replaced bytes through the MCP savings tool.
- Sanitizes source labels to preserve single-line marker framing.
- Documents the new marker form in both supported manuals and adds regression coverage.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/ledger/mod.rs | Adds sanitized source attribution, source-aware run grouping, and fold-session recording; the previously reported marker-framing issue is fixed. |
| src/store/sqlite.rs | Migrates ledger metadata storage and adds optional filtering for recent folds and distillations; the previously reported project-scope lookup mismatch is fixed. |
| src/mcp/server.rs | Extends savings reporting to include recent ledger folds and avoids filtering with the independently minted MCP session identifier. |
| src/hooks/post_tool.rs | Supplies normalized command attribution when routing tool output through the ledger. |
| tests/docs_match_the_code.rs | Updates marker-documentation matching to support the optional source clause. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(mcp): stop filtering savings reports..."](https://github.com/fajarhide/omni/commit/1ce1065da56097638e1ed9d4d1ac3a0780dc0c25) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54776201)</sub>

<!-- /greptile_comment -->