### PR TITLE
fix(cloud): stop counting terraform resources out of error prose

### DIFF
--- a/changelog.d/633.fixed.md
+++ b/changelog.d/633.fixed.md
@@ -1,0 +1,19 @@
+**A failing `terraform validate` was rendered as a clean plan.** The terraform
+summariser counted a resource for any line containing `will be created`, and
+terraform's own error prose contains it: "so if this file will be created by a
+resource in this configuration". A validate that exited 1 came back as
+`terraform: +1 ~0 -0 resources` with `+ configuration` under it, the `configuration`
+being the first word of the next wrapped line. That is the shape of a clean plan,
+nothing in it says the command failed, and the reporter read it as "validate
+passed, one resource to add" and moved on.
+
+Plan lines are now matched only on terraform's resource-address comment
+(`  # aws_instance.web will be created`), and the `Plan:` and `Apply complete!`
+summaries only at the start of a line. A real plan distills exactly as before, and
+the fixture proves it: `+2 ~1 -1` with all four addresses.
+
+The guard that should have caught this is #120, which refuses to distill a command
+that exited non-zero. It was blind here because the reported command ended in
+`| tail -4`, so the exit code the host reports belongs to `tail`. A summariser
+cannot rely on the exit code reaching it, and has to be anchored to syntax the
+output it claims to read actually uses.

--- a/src/distillers/cloud.rs
+++ b/src/distillers/cloud.rs
@@ -375,20 +375,28 @@ fn distill_terraform(input: &str) -> String {
     for line in input.lines() {
         let trimmed = line.trim();
 
-        // terraform plan lines like: "# aws_instance.web will be created"
-        if trimmed.contains("will be created") {
+        // A plan line is terraform's resource-address comment and nothing else:
+        // "  # aws_instance.web will be created". Matching the verb phrase
+        // anywhere in the line also matched terraform's own error prose, so a
+        // *failing* `terraform validate` came back as "+1 ~0 -0 resources" with
+        // "+ configuration" under it, which is the shape of a clean plan (#633).
+        // The pipe made #120's failed-command guard blind to it: the exit code
+        // the host sees belongs to `tail`, not to terraform.
+        let plan_line = trimmed.strip_prefix("# ").unwrap_or("");
+
+        if plan_line.contains("will be created") {
             parsed = true;
             added += 1;
             if let Some(res) = extract_tf_resource(trimmed) {
                 resources.push(format!("+ {}", res));
             }
-        } else if trimmed.contains("will be updated") || trimmed.contains("must be replaced") {
+        } else if plan_line.contains("will be updated") || plan_line.contains("must be replaced") {
             parsed = true;
             changed += 1;
             if let Some(res) = extract_tf_resource(trimmed) {
                 resources.push(format!("~ {}", res));
             }
-        } else if trimmed.contains("will be destroyed") {
+        } else if plan_line.contains("will be destroyed") {
             parsed = true;
             destroyed += 1;
             if let Some(res) = extract_tf_resource(trimmed) {
@@ -399,7 +407,8 @@ fn distill_terraform(input: &str) -> String {
         let t_lower = trimmed.to_lowercase();
 
         // Also catch the summary line: "Plan: X to add, Y to change, Z to destroy."
-        if t_lower.contains("plan:") {
+        // Anchored for the same reason: prose quoting `terraform plan:` is not one.
+        if t_lower.starts_with("plan:") {
             parsed = true;
             // Parse "Plan: 3 to add, 1 to change, 0 to destroy."
             for part in trimmed.split(',') {
@@ -426,7 +435,7 @@ fn distill_terraform(input: &str) -> String {
         }
 
         // "Apply complete! Resources: X added, Y changed, Z destroyed."
-        if t_lower.contains("apply complete!") {
+        if t_lower.starts_with("apply complete!") {
             return format!(
                 "terraform: apply complete +{} ~{} -{}",
                 added, changed, destroyed
@@ -699,6 +708,21 @@ kube-系统   auth-5d4f6c8b99-abc12    0/1     CrashLoopBackOff   15         2h"
     fn refuses_a_plan_summary_when_no_plan_was_read() {
         let input =
             "Terraform has been successfully initialized!\n\nTry running \"terraform plan\".\n";
+        assert_eq!(distill_as("terraform", input), input);
+    }
+
+    /// #633: a failing `terraform validate` came back as `+1 ~0 -0 resources`
+    /// with `+ configuration` under it, because the error prose says "so if this
+    /// file will be created by a resource in this configuration" and the counter
+    /// matched that phrase anywhere in the line. The rendering is the shape of a
+    /// clean plan, so the failure reads as success. Wrapped exactly as terraform
+    /// wraps it: the phrase and the address token land on different lines.
+    #[test]
+    fn refuses_to_count_resources_out_of_terraform_error_prose() {
+        let input = "function works only with files that are distributed as part of the\n\
+                     configuration source code, so if this file will be created by a resource in\n\
+                     this configuration you must instead obtain this result from an attribute of\n\
+                     that resource.\n";
         assert_eq!(distill_as("terraform", input), input);
     }
 


### PR DESCRIPTION
A failing `terraform validate` was rendered as `terraform: +1 ~0 -0 resources` with
`+ configuration` under it, which is the shape of a clean plan. The counter matched
`will be created` anywhere in a line, and terraform's own error prose carries the
phrase: "so if this file will be created by a resource in this configuration". The
address extractor then took the first word of the next wrapped line.

Plan lines now have to be terraform's resource-address comment, and the `Plan:` and
`Apply complete!` summaries have to start their line.

#120's failed-command guard could not catch this. The reported command ended in
`| tail -4`, so the exit code the host sees belongs to `tail`, not to terraform.

Verified in both directions. Un-anchoring the counter turns the new test red
(rc=101); making the anchor unmatchable turns the recorded plan snapshot red while
the new test stays green. A real plan distills unchanged, `+2 ~1 -1` with all four
addresses. `make ci` green, smoke test 46/46.

Closes #633

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR prevents Terraform error prose from being mistaken for a successful resource plan.
- Restricts resource-action matching to Terraform resource-address comment lines.
- Anchors `Plan:` and `Apply complete!` summary recognition to the beginning of trimmed lines.
- Adds a regression test for wrapped `terraform validate` error prose and documents the fix.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The narrowed matches preserve the repository’s canonical Terraform plan and summary formats while rejecting the reported error-prose false positive, and unmatched input continues to pass through unchanged.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/distillers/cloud.rs | Narrows Terraform plan parsing to canonical syntax and adds a focused regression test without identifying a concrete regression. |
| changelog.d/633.fixed.md | Accurately documents the false-positive parsing failure, its pipeline trigger, and the implemented fix. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cloud): stop counting terraform reso..."](https://github.com/fajarhide/omni/commit/58440bdd0ab42bf04d29741315592ddf7a1889ca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55034391)</sub>

<!-- /greptile_comment -->