### PR TITLE
fix(retrieve): say when a handle holds one block of a larger output

### DIFF
--- a/changelog.d/627.fixed.md
+++ b/changelog.d/627.fixed.md
@@ -1,0 +1,19 @@
+**`omni retrieve` framed one block of an output as the whole output.** A reader
+followed a `[OMNI: 10 lines already shown, omni retrieve …]` marker and got ten
+lines under `10 lines · 227 B`, for a command that had produced fourteen. Nothing
+was lost: the other four were on screen, and a ledger fold archives the run it
+replaced rather than the reply. The frame is what was wrong, and it reads as a
+measurement of the whole, so a short file listing looked complete and the reader
+nearly designed a dependency layering off it.
+
+`rewind_store.original_len` was written as `content.len()` on every insert, so the
+one column that could have answered "is this all of it" duplicated the content
+length instead. It now carries the size of the payload the block was cut from, and
+`omni retrieve` says `· one block of a 797 B output` when the two differ. A handle
+that does hold an entire output keeps the short frame, so nothing is added to the
+common case.
+
+Rows written before this ship with the old value and read as whole; they age out
+with the 30 day retention window. The MCP `omni_retrieve` tool is deliberately
+unchanged: its result is a single string the agent may paste or parse, and the CLI
+keeps its frame on stderr for the same reason.

--- a/src/cli/retrieve.rs
+++ b/src/cli/retrieve.rs
@@ -35,6 +35,32 @@ fn print_help() {
     );
 }
 
+/// The stderr frame, built where a test can read it.
+///
+/// `N lines · N B` reads as a measurement of the whole command's output, and for
+/// a ledger fold it measures one block of it: a reader took ten of fourteen
+/// entries as a complete listing and nearly designed a dependency layering
+/// against it (#627). The extra clause is said only when the two differ, so a
+/// handle that does hold an entire output keeps the short frame.
+fn frame(handle: &str, content: &str, whole_len: usize) -> String {
+    let part = if whole_len > content.len() {
+        format!(
+            " · one block of a {} output",
+            super::stats::format_bytes(whole_len as u64)
+        )
+    } else {
+        String::new()
+    };
+    format!(
+        "{} {} · {} lines · {}{}",
+        "omni retrieve".bold().cyan(),
+        handle.bright_black(),
+        content.lines().count(),
+        super::stats::format_bytes(content.len() as u64).bright_black(),
+        part.bright_black()
+    )
+}
+
 pub fn run(args: &[String], store: &Store) -> Result<()> {
     if args.iter().any(|a| a == "--help" || a == "-h") {
         print_help();
@@ -71,8 +97,8 @@ pub fn run(args: &[String], store: &Store) -> Result<()> {
         );
     }
 
-    match store.retrieve_rewind(handle) {
-        Some(content) => {
+    match store.retrieve_rewind_sized(handle) {
+        Some((content, whole_len)) => {
             // The same door the marker tells the agent to use, so it counts the
             // same as the MCP tool (#512).
             store.record_rewind_pull(handle);
@@ -81,14 +107,7 @@ pub fn run(args: &[String], store: &Store) -> Result<()> {
             // header on stdout would have done it by editing archived bytes that
             // a caller is about to paste or parse. Same rule the pipeline holds
             // itself to: what a later step reads is not ours to decorate.
-            let lines = content.lines().count();
-            eprintln!(
-                "{} {} · {} lines · {}",
-                "omni retrieve".bold().cyan(),
-                handle.bright_black(),
-                lines,
-                super::stats::format_bytes(content.len() as u64).bright_black()
-            );
+            eprintln!("{}", frame(handle, &content, whole_len));
             print!("{content}");
             if !content.ends_with('\n') {
                 println!();
@@ -112,12 +131,34 @@ mod tests {
         v.iter().map(|s| s.to_string()).collect()
     }
 
+    /// #627. `omni retrieve` returned ten of the fourteen lines a command
+    /// produced, under `10 lines · 227 B`. Nothing was lost, the other four were
+    /// on screen and the handle holds what the fold replaced, but the frame
+    /// reads as a measurement of the whole and the reader took the short listing
+    /// as complete.
+    #[test]
+    fn says_when_a_handle_holds_one_block_of_a_larger_output() {
+        let block = "one\ntwo\nthree\n";
+
+        let whole = frame("abcd", block, block.len());
+        assert!(
+            !whole.contains("one block of"),
+            "a handle holding everything keeps the short frame: {whole}"
+        );
+
+        let part = frame("abcd", block, block.len() * 4);
+        assert!(
+            part.contains("one block of"),
+            "a fragment must not be framed as the whole output: {part}"
+        );
+    }
+
     #[test]
     fn prints_what_the_marker_archived() {
         let dir = tempfile::tempdir().expect("tempdir");
         let store = Store::open_path(&dir.path().join("omni.db")).expect("store");
         let handle = store
-            .store_rewind("the original forty lines\n")
+            .store_rewind_whole("the original forty lines\n")
             .expect("archived");
 
         assert!(run(&args(&["omni", "retrieve", &handle]), &store).is_ok());
@@ -163,7 +204,7 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let db = dir.path().join("omni.db");
         let store = Store::open_path(&db).expect("store");
-        let handle = store.store_rewind("archived output\n").expect("archived");
+        let handle = store.store_rewind_whole("archived output\n").expect("archived");
 
         // No distillation row names this hash, so the family resolves to
         // `unknown`, which is the key the row lands under.
@@ -185,7 +226,7 @@ mod tests {
     fn accepts_the_handle_in_every_shape_a_marker_has_printed() {
         let dir = tempfile::tempdir().expect("tempdir");
         let store = Store::open_path(&dir.path().join("omni.db")).expect("store");
-        let handle = store.store_rewind("content\n").expect("archived");
+        let handle = store.store_rewind_whole("content\n").expect("archived");
 
         for form in [
             handle.clone(),

--- a/src/cli/retrieve.rs
+++ b/src/cli/retrieve.rs
@@ -204,7 +204,9 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let db = dir.path().join("omni.db");
         let store = Store::open_path(&db).expect("store");
-        let handle = store.store_rewind_whole("archived output\n").expect("archived");
+        let handle = store
+            .store_rewind_whole("archived output\n")
+            .expect("archived");
 
         // No distillation row names this hash, so the family resolves to
         // `unknown`, which is the key the row lands under.

--- a/src/hooks/pipe.rs
+++ b/src/hooks/pipe.rs
@@ -319,8 +319,8 @@ fn distill(
         // Safety truncation. The marker carries the line count: `ps aux` lost
         // 416 of 556 rows here behind a bare `[OMNI: output truncated]` while
         // the footer reported it as a 62.2% saving (#219).
-        crate::util::text::truncate_with_marker(&mut out, MAX_OUTPUT_BYTES, |dropped| {
-            store.and_then(|s| s.store_rewind(dropped))
+        crate::util::text::truncate_with_marker(&mut out, MAX_OUTPUT_BYTES, |dropped, whole| {
+            store.and_then(|s| s.store_rewind(dropped, whole))
         });
 
         (
@@ -388,7 +388,7 @@ fn distill(
                 input_text.len(),
                 crate::guard::limits::MAX_REWIND_BYTES
             )
-        } else if let Some(hash) = store.and_then(|s| s.store_rewind(&input_text)) {
+        } else if let Some(hash) = store.and_then(|s| s.store_rewind(&input_text, input_text.len())) {
             let marker = if std::io::stdout().is_terminal() {
                 format!(
                     "\n{} {} {} {}. The hash {} stores the full output in RewindStore for retrieval.\n",
@@ -439,8 +439,8 @@ fn distill(
     // Safety truncation. The marker carries the line count: `ps aux` lost 416 of
     // 556 rows here behind a bare `[OMNI: output truncated]` while the footer
     // reported it as a 62.2% saving (#219).
-    crate::util::text::truncate_with_marker(&mut output, MAX_OUTPUT_BYTES, |dropped| {
-        store.and_then(|s| s.store_rewind(dropped))
+    crate::util::text::truncate_with_marker(&mut output, MAX_OUTPUT_BYTES, |dropped, whole| {
+        store.and_then(|s| s.store_rewind(dropped, whole))
     });
 
     PipelineResult {

--- a/src/hooks/pipe.rs
+++ b/src/hooks/pipe.rs
@@ -388,7 +388,8 @@ fn distill(
                 input_text.len(),
                 crate::guard::limits::MAX_REWIND_BYTES
             )
-        } else if let Some(hash) = store.and_then(|s| s.store_rewind(&input_text, input_text.len())) {
+        } else if let Some(hash) = store.and_then(|s| s.store_rewind(&input_text, input_text.len()))
+        {
             let marker = if std::io::stdout().is_terminal() {
                 format!(
                     "\n{} {} {} {}. The hash {} stores the full output in RewindStore for retrieval.\n",

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -212,7 +212,7 @@ fn rewind_marker(
     // The old code took the key `store_rewind` returned on every path, including
     // a swallowed insert, and printed `omni_retrieve("<key>")` for a row that was
     // never written (#388).
-    match store.and_then(|s| s.store_rewind(content)) {
+    match store.and_then(|s| s.store_rewind(content, content.len())) {
         Some(hash) => (
             format!("\n[OMNI: {lost} omitted, omni retrieve {hash} for full output]\n"),
             hash,
@@ -1103,7 +1103,7 @@ pub fn process_payload(
     crate::util::text::truncate_with_marker(
         &mut final_out,
         crate::guard::limits::MAX_OUTPUT_BYTES,
-        |dropped| store.as_ref().and_then(|s| s.store_rewind(dropped)),
+        |dropped, whole| store.as_ref().and_then(|s| s.store_rewind(dropped, whole)),
     );
 
     // The breakdown counts what the agent was handed, which is neither the

--- a/src/ledger/mod.rs
+++ b/src/ledger/mod.rs
@@ -680,8 +680,12 @@ impl<'a> Ledger<'a> {
             // the answer to the pull, and folding it hands the reader back the
             // marker it was following (#581). The flag is consumed here, so this
             // costs one delivery rather than exempting the content for good.
+            // The run, and the payload it was cut out of. A fold archives one
+            // block of a reply, never the reply, so a handle that reported its
+            // own length as the whole let `omni retrieve` present ten of
+            // fourteen lines as a complete answer (#627).
             match long_enough
-                .then(|| self.store.store_rewind(&body))
+                .then(|| self.store.store_rewind(&body, payload_bytes))
                 .flatten()
                 .filter(|handle| !self.store.take_owed_delivery(handle))
                 .zip(run.seen.as_ref())
@@ -798,6 +802,44 @@ mod tests {
 
         assert!(second.len() < text.len());
         assert!(second.contains("lines already shown"));
+    }
+
+    /// #627. A fold archives the run it replaced, never the reply, so the handle
+    /// has to carry the size of the payload it came out of. Without it
+    /// `omni retrieve` frames ten folded lines of a fourteen line output as
+    /// `10 lines · 227 B`, which reads as the whole answer.
+    #[test]
+    fn a_folded_run_records_the_payload_it_was_cut_from() {
+        let (store, _d) = temp_store();
+        let seen: Vec<String> = (0..10)
+            .map(|i| format!("2026-08-10T00:00:{i:02}Z  handler finished request {i} in 12ms"))
+            .collect();
+        let first = seen.join("\n");
+        let mut both = seen.clone();
+        for i in 0..4 {
+            both.push(format!("2026-08-10T00:01:{i:02}Z  a line nobody has seen, number {i}"));
+        }
+        let second_input = both.join("\n");
+
+        let ledger = Ledger::new(&store, "s1");
+        ledger.project(&first);
+        let view = ledger.project(&second_input).expect("the repeat folds");
+
+        let handle = view
+            .split("omni retrieve ")
+            .nth(1)
+            .and_then(|s| s.split(']').next())
+            .expect("the marker names a handle");
+        let (content, whole) = store
+            .retrieve_rewind_sized(handle)
+            .expect("the handle resolves");
+
+        assert!(
+            whole > content.len(),
+            "a folded run is one block of the reply, not the reply: {} vs {}",
+            whole,
+            content.len()
+        );
     }
 
     /// #519. A re-run of an identical command folded into one run covering the
@@ -1574,7 +1616,7 @@ mod tests {
     fn renders_a_marker_the_gain_test_can_predict() {
         let (store, _d) = temp_store();
         let handle = store
-            .store_rewind("some content worth archiving\n")
+            .store_rewind_whole("some content worth archiving\n")
             .expect("a healthy store archives");
 
         assert_eq!(handle.len(), HANDLE_LEN);

--- a/src/ledger/mod.rs
+++ b/src/ledger/mod.rs
@@ -817,7 +817,9 @@ mod tests {
         let first = seen.join("\n");
         let mut both = seen.clone();
         for i in 0..4 {
-            both.push(format!("2026-08-10T00:01:{i:02}Z  a line nobody has seen, number {i}"));
+            both.push(format!(
+                "2026-08-10T00:01:{i:02}Z  a line nobody has seen, number {i}"
+            ));
         }
         let second_input = both.join("\n");
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1715,7 +1715,9 @@ mod tests {
     async fn test_omni_retrieve_returns_stored_content() {
         let dir = tempdir().unwrap();
         let store = Arc::new(Store::open_path(&dir.path().join("omni.db")).unwrap());
-        let hash = store.store_rewind_whole("testing_payload").expect("archived");
+        let hash = store
+            .store_rewind_whole("testing_payload")
+            .expect("archived");
         let session = Arc::new(Mutex::new(SessionState::new()));
 
         let server = OmniServer { store, session };

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1715,7 +1715,7 @@ mod tests {
     async fn test_omni_retrieve_returns_stored_content() {
         let dir = tempdir().unwrap();
         let store = Arc::new(Store::open_path(&dir.path().join("omni.db")).unwrap());
-        let hash = store.store_rewind("testing_payload").expect("archived");
+        let hash = store.store_rewind_whole("testing_payload").expect("archived");
         let session = Arc::new(Mutex::new(SessionState::new()));
 
         let server = OmniServer { store, session };

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -1301,7 +1301,13 @@ impl SqliteBackend {
     /// which is the one promise this store exists to keep (#388). Rare while the
     /// archive fired on 139 of 14,962 calls; routine once the ledger records
     /// every emitted block.
-    pub fn store_rewind(&self, content: &str) -> Option<String> {
+    /// `whole_len` is the length of the payload `content` was cut out of, which
+    /// is `content.len()` when the handle holds an entire output. It is the only
+    /// thing that lets `omni retrieve` tell a reader whether it is holding the
+    /// whole answer or one block of it (#627). Before this it was written as
+    /// `content.len()` unconditionally, so the column duplicated the content
+    /// length and could never answer that.
+    pub fn store_rewind(&self, content: &str, whole_len: usize) -> Option<String> {
         let mut hasher = Sha256::new();
         hasher.update(content.as_bytes());
         // The reserved example handle must never name real content, or the
@@ -1314,12 +1320,19 @@ impl SqliteBackend {
         let conn = self.pool.get().ok()?;
 
         let ts = chrono::Utc::now().timestamp();
-        let original_len = content.len() as i64;
+        // A caller that understates the whole would make `retrieve` claim
+        // completeness for a fragment, which is the defect being fixed, so the
+        // floor is the content itself rather than trust.
+        let original_len = whole_len.max(content.len()) as i64;
 
         conn.execute(
             "INSERT INTO rewind_store (hash, content, ts, original_len, retrieved)
              VALUES (?1, ?2, ?3, ?4, 0)
-             ON CONFLICT(hash) DO UPDATE SET ts = excluded.ts",
+             -- One row per content hash, so the same block can arrive from two
+             -- different wholes. Keep the larger: understating completeness
+             -- costs a reader one check, overstating it is the bug (#627).
+             ON CONFLICT(hash) DO UPDATE SET ts = excluded.ts,
+                 original_len = MAX(rewind_store.original_len, excluded.original_len)",
             params![rewind_key, content, ts, original_len],
         )
         .ok()?;
@@ -1393,17 +1406,32 @@ impl SqliteBackend {
         .unwrap_or(false)
     }
 
+    /// Archive a payload that is the whole of what a marker replaced. Test-only:
+    /// production callers state the whole explicitly, because the interesting
+    /// case is the one where it differs.
+    #[cfg(test)]
+    pub fn store_rewind_whole(&self, content: &str) -> Option<String> {
+        self.store_rewind(content, content.len())
+    }
+
     pub fn retrieve_rewind(&self, hash: &str) -> Option<String> {
+        self.retrieve_rewind_sized(hash).map(|(content, _)| content)
+    }
+
+    /// The archived block and the size of the payload it was cut out of. Equal
+    /// when the handle holds a whole output; `whole_len` is larger when it holds
+    /// one block of one, which is what a ledger fold archives (#627).
+    pub fn retrieve_rewind_sized(&self, hash: &str) -> Option<(String, usize)> {
         let conn = match self.pool.get() {
             Ok(c) => c,
             Err(_) => return None,
         };
 
-        let content: Option<String> = conn
+        let content: Option<(String, i64)> = conn
             .query_row(
-                "SELECT content FROM rewind_store WHERE hash = ?1",
+                "SELECT content, original_len FROM rewind_store WHERE hash = ?1",
                 params![hash],
-                |row| row.get(0),
+                |row| Ok((row.get(0)?, row.get(1)?)),
             )
             .optional()
             .unwrap_or(None);
@@ -1415,7 +1443,10 @@ impl SqliteBackend {
             );
         }
 
-        content
+        content.map(|(c, whole)| {
+            let whole = usize::try_from(whole).unwrap_or(0).max(c.len());
+            (c, whole)
+        })
     }
 
     /// Get recent distillation rows for omni_history MCP tool
@@ -4090,8 +4121,8 @@ mod tests {
         let (store, _dir) = get_temp_store();
         let content = "the same 200 lines of output";
 
-        let first = store.store_rewind(content).expect("archived");
-        let second = store.store_rewind(content).expect("archived");
+        let first = store.store_rewind_whole(content).expect("archived");
+        let second = store.store_rewind_whole(content).expect("archived");
 
         assert_eq!(first, second, "the key is the content, so it cannot differ");
         assert_eq!(
@@ -4111,7 +4142,7 @@ mod tests {
     fn a_report_read_does_not_owe_a_delivery() {
         let dir = tempfile::tempdir().expect("tempdir");
         let store = Store::open_path(&dir.path().join("omni.db")).expect("store");
-        let handle = store.store_rewind("archived body\n").expect("archived");
+        let handle = store.store_rewind_whole("archived body\n").expect("archived");
 
         store.retrieve_rewind(&handle).expect("content");
 
@@ -4128,7 +4159,7 @@ mod tests {
     fn two_pulls_earn_two_verbatim_deliveries() {
         let dir = tempfile::tempdir().expect("tempdir");
         let store = Store::open_path(&dir.path().join("omni.db")).expect("store");
-        let handle = store.store_rewind("archived body\n").expect("archived");
+        let handle = store.store_rewind_whole("archived body\n").expect("archived");
 
         store.record_rewind_pull(&handle);
         store.record_rewind_pull(&handle);
@@ -4154,7 +4185,7 @@ mod tests {
             .execute("DROP TABLE rewind_store", [])
             .expect("drop");
 
-        assert_eq!(store.store_rewind("content nobody can retrieve"), None);
+        assert_eq!(store.store_rewind_whole("content nobody can retrieve"), None);
     }
 
     /// Different content still gets its own row, so the deduplication is by
@@ -4164,10 +4195,10 @@ mod tests {
         let (store, _dir) = get_temp_store();
 
         let a = store
-            .store_rewind("output of the first command")
+            .store_rewind_whole("output of the first command")
             .expect("archived");
         let b = store
-            .store_rewind("output of the second command")
+            .store_rewind_whole("output of the second command")
             .expect("archived");
 
         assert_ne!(a, b);
@@ -4182,7 +4213,7 @@ mod tests {
     fn rewinds_and_retrieves_content() {
         let (store, _dir) = get_temp_store();
         let content = "this is some compressed content";
-        let hash = store.store_rewind(content).expect("archived");
+        let hash = store.store_rewind_whole(content).expect("archived");
 
         // A content address and nothing else. The nanosecond prefix this used to
         // carry is what made `INSERT OR IGNORE` decoration (#274).
@@ -4215,8 +4246,8 @@ mod tests {
         let (store, _dir) = get_temp_store();
         let content = "duplicate me";
 
-        let hash1 = store.store_rewind(content).expect("archived");
-        let hash2 = store.store_rewind(content).expect("archived");
+        let hash1 = store.store_rewind_whole(content).expect("archived");
+        let hash2 = store.store_rewind_whole(content).expect("archived");
 
         assert_eq!(store.retrieve_rewind(&hash1), Some(content.to_string()));
         assert_eq!(store.retrieve_rewind(&hash2), Some(content.to_string()));

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -4142,7 +4142,9 @@ mod tests {
     fn a_report_read_does_not_owe_a_delivery() {
         let dir = tempfile::tempdir().expect("tempdir");
         let store = Store::open_path(&dir.path().join("omni.db")).expect("store");
-        let handle = store.store_rewind_whole("archived body\n").expect("archived");
+        let handle = store
+            .store_rewind_whole("archived body\n")
+            .expect("archived");
 
         store.retrieve_rewind(&handle).expect("content");
 
@@ -4159,7 +4161,9 @@ mod tests {
     fn two_pulls_earn_two_verbatim_deliveries() {
         let dir = tempfile::tempdir().expect("tempdir");
         let store = Store::open_path(&dir.path().join("omni.db")).expect("store");
-        let handle = store.store_rewind_whole("archived body\n").expect("archived");
+        let handle = store
+            .store_rewind_whole("archived body\n")
+            .expect("archived");
 
         store.record_rewind_pull(&handle);
         store.record_rewind_pull(&handle);
@@ -4185,7 +4189,10 @@ mod tests {
             .execute("DROP TABLE rewind_store", [])
             .expect("drop");
 
-        assert_eq!(store.store_rewind_whole("content nobody can retrieve"), None);
+        assert_eq!(
+            store.store_rewind_whole("content nobody can retrieve"),
+            None
+        );
     }
 
     /// Different content still gets its own row, so the deduplication is by

--- a/src/util/text.rs
+++ b/src/util/text.rs
@@ -35,9 +35,11 @@ const TAIL_BUDGET_FRACTION: usize = 5;
 /// reporting 42% saved (#508). Keeping the head alone inverts what the tool is
 /// for on exactly the payload that matters most.
 ///
-/// `archive` is handed the elided middle and returns the handle it stored it
-/// under, so the marker can name a way back. It is a callback because only the
-/// hooks own a store, and this module is not going to grow one.
+/// `archive` is handed the elided middle and the size of the output it came out
+/// of, and returns the handle it stored it under, so the marker can name a way
+/// back. It is a callback because only the hooks own a store, and this module is
+/// not going to grow one. The second argument is what stops `omni retrieve` from
+/// labelling that middle as if it were the whole output (#627).
 ///
 /// Trims to line boundaries, so the counts are exact and nobody is handed half a
 /// row. Output with no newline at all has no lines to count, so it keeps the
@@ -45,7 +47,7 @@ const TAIL_BUDGET_FRACTION: usize = 5;
 pub fn truncate_with_marker(
     s: &mut String,
     max_bytes: usize,
-    archive: impl FnOnce(&str) -> Option<String>,
+    archive: impl FnOnce(&str, usize) -> Option<String>,
 ) {
     if s.len() <= max_bytes {
         return;
@@ -70,7 +72,7 @@ pub fn truncate_with_marker(
         // long there is nothing left to keep at the end. Report bytes, because
         // "1 of 1 lines kept" for a fragment is a count that says nothing.
         let end = floor_boundary(s, max_bytes);
-        let handle = archived_handle(&s[end..], archive);
+        let handle = archived_handle(&s[end..], total_bytes, archive);
         s.truncate(end);
         s.push_str(&format!(
             "\n[OMNI: output truncated, {end} of {total_bytes} bytes kept{handle}]\n"
@@ -79,7 +81,7 @@ pub fn truncate_with_marker(
     }
 
     let dropped_lines = s[head_end..tail_start].lines().count();
-    let handle = archived_handle(&s[head_end..tail_start], archive);
+    let handle = archived_handle(&s[head_end..tail_start], total_bytes, archive);
     let marker = format!(
         "[OMNI: output truncated, {} of {total_lines} lines kept, {dropped_lines} dropped from the middle{handle}]\n",
         total_lines - dropped_lines
@@ -128,11 +130,15 @@ pub fn avoid_example_handle(key: String) -> String {
 /// is what keeps 30 days of history at 13.3 MB instead of 83.1 MB (#271). A
 /// failed insert reads the same as no store, for the reason `post_tool`'s
 /// `rewind_marker` gives: what the reader can do about it is identical (#388).
-fn archived_handle(dropped: &str, archive: impl FnOnce(&str) -> Option<String>) -> String {
+fn archived_handle(
+    dropped: &str,
+    whole_len: usize,
+    archive: impl FnOnce(&str, usize) -> Option<String>,
+) -> String {
     if dropped.len() > crate::guard::limits::MAX_REWIND_BYTES {
         return String::new();
     }
-    match archive(dropped) {
+    match archive(dropped, whole_len) {
         Some(hash) => format!(", omni retrieve {hash}"),
         None => String::new(),
     }
@@ -213,7 +219,7 @@ mod tests {
     fn truncation_marker_states_how_many_lines_survived() {
         let mut s: String = (0..100).map(|i| format!("row {i}\n")).collect();
 
-        truncate_with_marker(&mut s, 100, |_| None);
+        truncate_with_marker(&mut s, 100, |_, _| None);
 
         let kept = s.lines().filter(|l| l.starts_with("row ")).count();
         assert!(
@@ -239,7 +245,7 @@ mod tests {
             .collect();
         s.push_str("RuntimeError: FATAL: connection pool exhausted (max=64)\n");
 
-        truncate_with_marker(&mut s, 50_000, |_| None);
+        truncate_with_marker(&mut s, 50_000, |_, _| None);
 
         assert!(
             s.contains("RuntimeError: FATAL"),
@@ -260,7 +266,7 @@ mod tests {
         let mut s: String = (0..1000).map(|i| format!("row {i:04}\n")).collect();
         let mut archived = String::new();
 
-        truncate_with_marker(&mut s, 500, |dropped| {
+        truncate_with_marker(&mut s, 500, |dropped, _| {
             archived = dropped.to_string();
             Some(EXAMPLE_HANDLE.to_string())
         });
@@ -282,7 +288,7 @@ mod tests {
         let mut s: String = (0..20_000).map(|i| format!("row {i:06}\n")).collect();
         let mut offered = false;
 
-        truncate_with_marker(&mut s, 50_000, |_| {
+        truncate_with_marker(&mut s, 50_000, |_, _| {
             offered = true;
             Some("nope".to_string())
         });
@@ -306,7 +312,7 @@ mod tests {
         // 9 bytes per row, so 58 lands four bytes into the seventh, far enough
         // in that the fragment still reads as a row and a `starts_with` filter
         // cannot quietly drop it.
-        truncate_with_marker(&mut s, 58, |_| None);
+        truncate_with_marker(&mut s, 58, |_, _| None);
 
         let last_row = s
             .lines()
@@ -321,7 +327,7 @@ mod tests {
     fn reports_bytes_when_the_output_has_no_line_break() {
         let mut s = "x".repeat(200);
 
-        truncate_with_marker(&mut s, 50, |_| None);
+        truncate_with_marker(&mut s, 50, |_, _| None);
 
         assert!(
             s.contains("[OMNI: output truncated, 50 of 200 bytes kept]"),
@@ -333,7 +339,7 @@ mod tests {
     fn leaves_output_untouched_when_it_fits() {
         let mut s = String::from("short\noutput\n");
 
-        truncate_with_marker(&mut s, 50_000, |_| None);
+        truncate_with_marker(&mut s, 50_000, |_, _| None);
 
         assert_eq!(s, "short\noutput\n");
     }


### PR DESCRIPTION
`omni retrieve` printed `10 lines · 227 B` for a handle holding ten lines of a
fourteen line output, so a short file listing read as complete and the reporter
nearly designed against it. Nothing was lost: a ledger fold archives the run it
replaced, and the other four lines were on screen above the marker.

`rewind_store.original_len` was written as `content.len()` on every insert, so the
one column that could have answered "is this all of it" duplicated the content
length. It now carries the size of the payload the block was cut from. Where two
different wholes hash to the same block the larger wins, because understating
completeness costs a reader one check and overstating it is this bug.

Verified on the real binary through `--post-hook`, folding a 14 line output
against a 10 line one:

```
omni retrieve 11d288731bf7fecc · 10 lines · 570 B · one block of a 790 B output
```

Three break-tests, each verified by diff before running: the frame never saying
`one block` (red), always saying it (red), and the ledger archiving its own length
as the whole (red). `make ci` green, smoke 46/46.

The MCP tool is unchanged on purpose. Its result is one string a caller may paste
or parse, which is why the CLI keeps its frame on stderr.

Filed #635 while verifying this: a whitespace-only stderr is delivered as a bare
`[stderr]` header, which is the unexplained marker in #627's own log section.

Closes #627

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR preserves the source payload size alongside archived rewind blocks so `omni retrieve` can distinguish complete outputs from fragments.
- Passes whole-payload lengths through ledger folding and safety truncation archive callbacks.
- Reads stored lengths in the CLI and adds a fragment qualifier only when archived content is smaller than its source payload.
- Conservatively retains the largest source length when identical archived content appears in multiple payloads.
- Adds regression coverage and updates affected test helpers and call sites.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the changed archive paths consistently preserving the payload length needed for accurate retrieval framing.

The storage API, ledger and truncation callers, retrieval conversion, and CLI framing agree on the source-payload-length contract, and no concrete blocking or non-blocking defect remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/store/sqlite.rs | Extends rewind storage and retrieval to persist source-payload length, retaining the conservative maximum on hash conflicts. |
| src/ledger/mod.rs | Records the complete ledger payload byte length when archiving a folded run and adds regression coverage. |
| src/cli/retrieve.rs | Uses sized rewind retrieval to qualify archived fragments in the stderr frame while preserving payload output. |
| src/util/text.rs | Extends truncation archive callbacks with the pre-truncation payload length. |
| src/hooks/pipe.rs | Propagates correct whole-output lengths through pipe rewind and truncation archive paths. |
| src/hooks/post_tool.rs | Propagates whole-output lengths through post-tool rewind and safety-truncation paths. |
| src/mcp/server.rs | Updates tests for the new storage API while intentionally leaving MCP retrieval output unchanged. |
| changelog.d/627.fixed.md | Documents the corrected retrieval framing, legacy-row behavior, and intentional MCP behavior. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Output payload] --> B{Archive path}
    B -->|Ledger fold| C[Archived repeated block]
    B -->|Safety truncation| D[Archived dropped middle]
    B -->|Whole-output rewind| E[Archived complete output]
    C --> F[(rewind_store: content + original_len)]
    D --> F
    E --> F
    F --> G[omni retrieve]
    G --> H{original_len > content length?}
    H -->|Yes| I[Frame as one block of larger output]
    H -->|No| J[Use short complete-output frame]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["style: cargo fmt after the store\_rewind ..."](https://github.com/fajarhide/omni/commit/a4be1ff44a1faca20769cdd785c69a300d5259c4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55039321)</sub>

<!-- /greptile_comment -->