### PR TITLE
fix(paths): create OMNI's own directory and database owner-only

### DIFF
--- a/changelog.d/631.fixed.md
+++ b/changelog.d/631.fixed.md
@@ -1,0 +1,16 @@
+**`~/.omni` and the database were left at whatever the umask gave them.** Nothing
+in the tree ever called `set_permissions`, so a default umask of 022 produced a
+0755 directory holding a 0644 database: on the machine that found it, 147 MB of
+recorded command output readable by every other local account. Redaction does not
+cover this and is not meant to, since the archive keeps the original on purpose so
+`omni retrieve` can return it.
+
+The directory is now 0700 and the database, including its `-wal` and `-shm`
+sidecars, is 0600. Set explicitly rather than left to the umask, and applied on
+every open, so an existing install is tightened on the next run instead of keeping
+the modes it already has.
+
+A directory named by `OMNI_DB_PATH` is left alone, because it can be any directory
+on the machine and narrowing one the user chose would take access away from
+whoever else is in it. The database file itself is tightened wherever it lives.
+Windows has no umask or mode bits in this sense, so that path is unchanged.

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -120,9 +120,75 @@ pub fn exports_directory() -> PathBuf {
     data_home().join("exports")
 }
 
+/// Narrow a path OMNI owns to its owner: `0700` for a directory, `0600` for a
+/// file.
+///
+/// Nothing in the tree asked for a mode before this, so `~/.omni` and the
+/// database inherited the umask and a default 022 left 147 MB of recorded
+/// command output world readable (#631). Redaction does not cover it and is not
+/// meant to: redaction protects what the *model* sees, while the archive keeps
+/// the original on purpose so `omni retrieve` can return it.
+///
+/// Reads the mode before writing it, because this sits on the hook path and a
+/// `stat` is cheaper than a `chmod` on the run where nothing has to change,
+/// which is every run after the first.
+///
+/// Errors are the caller's to ignore. A store that cannot be tightened is still
+/// a store, and `CONTRIBUTING.md` requires hooks to fail open.
+#[cfg(unix)]
+pub fn restrict_to_owner(path: &std::path::Path) -> std::io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let meta = std::fs::metadata(path)?;
+    let want = if meta.is_dir() { 0o700 } else { 0o600 };
+    if meta.permissions().mode() & 0o777 != want {
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(want))?;
+    }
+    Ok(())
+}
+
+/// Windows has no umask and no mode bits in this sense, so there is nothing to
+/// narrow and the ACL it inherits is the one the user's profile already carries.
+#[cfg(not(unix))]
+pub fn restrict_to_owner(_path: &std::path::Path) -> std::io::Result<()> {
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #631. Nothing in the tree set a mode, so `~/.omni` and a 147 MB database
+    /// of recorded command output sat at 0755 and 0644 under a default umask.
+    ///
+    /// Driven from deliberately loose modes rather than by setting a umask: the
+    /// umask is process state, `cargo` runs tests in parallel, and a suite that
+    /// mutates it fails a different test on a different machine. This is also
+    /// the half that matters most, since the sensitive bytes are already on disk
+    /// on every existing install.
+    #[cfg(unix)]
+    #[test]
+    fn tightens_a_directory_and_a_file_that_are_already_loose() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sub = dir.path().join("omni-home");
+        std::fs::create_dir(&sub).expect("mkdir");
+        let file = sub.join("omni.db");
+        std::fs::write(&file, b"rows").expect("write");
+
+        std::fs::set_permissions(&sub, std::fs::Permissions::from_mode(0o777)).expect("chmod dir");
+        std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o666)).expect("chmod file");
+
+        restrict_to_owner(&sub).expect("dir");
+        restrict_to_owner(&file).expect("file");
+
+        let mode = |p: &std::path::Path| {
+            std::fs::metadata(p).expect("stat").permissions().mode() & 0o777
+        };
+        assert_eq!(mode(&sub), 0o700, "a directory OMNI owns is owner only");
+        assert_eq!(mode(&file), 0o600, "a file OMNI owns is owner only");
+    }
 
     /// #307: without an override the suite wrote into the developer's live
     /// `~/.omni`. `.cargo/config.toml` points `OMNI_HOME` at the workspace's

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -178,14 +178,14 @@ mod tests {
         std::fs::write(&file, b"rows").expect("write");
 
         std::fs::set_permissions(&sub, std::fs::Permissions::from_mode(0o777)).expect("chmod dir");
-        std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o666)).expect("chmod file");
+        std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o666))
+            .expect("chmod file");
 
         restrict_to_owner(&sub).expect("dir");
         restrict_to_owner(&file).expect("file");
 
-        let mode = |p: &std::path::Path| {
-            std::fs::metadata(p).expect("stat").permissions().mode() & 0o777
-        };
+        let mode =
+            |p: &std::path::Path| std::fs::metadata(p).expect("stat").permissions().mode() & 0o777;
         assert_eq!(mode(&sub), 0o700, "a directory OMNI owns is owner only");
         assert_eq!(mode(&file), 0o600, "a file OMNI owns is owner only");
     }

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -98,6 +98,12 @@ impl SqliteBackend {
         let parent = path.parent().unwrap_or_else(|| std::path::Path::new(""));
         if !parent.as_os_str().is_empty() {
             std::fs::create_dir_all(parent).context("Failed to create .omni directory")?;
+            // Only a directory OMNI resolved for itself. `OMNI_DB_PATH` can name
+            // any directory on the machine, and tightening one the user chose
+            // would take access away from whoever else is in it (#631).
+            if parent == paths::data_home() || parent == paths::config_home() {
+                let _ = paths::restrict_to_owner(parent);
+            }
         }
 
         let manager = SqliteConnectionManager::file(path);
@@ -122,6 +128,21 @@ impl SqliteBackend {
 
         let store = Self { pool };
         store.init_schema()?;
+
+        // After the schema, because WAL mode is what creates the sidecars and
+        // they hold committed rows that have not been checkpointed yet. Tighten
+        // the database whatever directory it was asked for: the file is OMNI's
+        // own, unlike the directory above (#631).
+        // The sidecar names append to the whole filename rather than replacing an
+        // extension, which `cli::reset` learned when 4.2 MB of `-wal` survived a
+        // wipe that reported success (#446).
+        let _ = paths::restrict_to_owner(path);
+        for sidecar in ["-wal", "-shm"] {
+            let mut p = path.to_path_buf().into_os_string();
+            p.push(sidecar);
+            let _ = paths::restrict_to_owner(&std::path::PathBuf::from(p));
+        }
+
         Ok(store)
     }
 
@@ -3326,6 +3347,36 @@ mod tests {
         let dir = tempdir().unwrap();
         let db_path = dir.path().join("omni.db");
         (Store::open_path(&db_path).unwrap(), dir)
+    }
+
+    /// #631. The database holds raw command output, and it inherited the umask:
+    /// 0644 on the machine that reported it, for 147 MB of it.
+    ///
+    /// Loosened by hand and reopened rather than tested straight after creation,
+    /// for two reasons. A runner with a strict umask would give 0600 anyway and
+    /// the assertion would pass against no code at all, and an existing install
+    /// already has the bytes on disk, so tightening on the next run is the case
+    /// that matters.
+    #[cfg(unix)]
+    #[test]
+    fn a_reopen_tightens_a_database_left_world_readable() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("omni.db");
+        drop(Store::open_path(&db_path).unwrap());
+
+        std::fs::set_permissions(&db_path, std::fs::Permissions::from_mode(0o666))
+            .expect("loosen the database");
+
+        drop(Store::open_path(&db_path).unwrap());
+
+        let mode = std::fs::metadata(&db_path)
+            .expect("stat")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600, "recorded output must not stay world readable");
     }
 
     /// #602. `omni_explain_savings` reported "No recent distillations" for a


### PR DESCRIPTION
Nothing in the tree called `set_permissions`, so `~/.omni` and everything in it
inherited the process umask. A default 022 gave a 0755 directory holding a 0644
database, which on the reporting machine was 147 MB of recorded command output
readable by every other local account. Redaction does not cover this and is not
meant to: it protects what the model sees, while the archive keeps the original
so `omni retrieve` can return it.

`restrict_to_owner` lives in `paths`, where the paths are already resolved, and
reads the mode before writing it so a run that has nothing to change costs a stat
rather than a chmod on the hook path. Applied on every open, so an existing
install is tightened on the next run.

Verified on the debug binary under umask 022:

```
$ ls -ld ~/.omni; ls -l ~/.omni/omni.db          # fresh install
drwx------  3 user  wheel      96 .omni
-rw-------  1 user  wheel  274432 omni.db

$ chmod 755 ~/.omni; chmod 644 ~/.omni/omni.db   # an existing one
$ omni stats >/dev/null; ls -ld ~/.omni
drwx------  3 user  wheel      96 .omni
```

Three break-tests, verified by diff before running: `restrict_to_owner` returning
early (red), giving a directory the file mode (red), and the store never
tightening the database (red). Neither test sets a umask, because that is process
state and the suite runs in parallel; both drive deliberately loose modes instead,
which is also the case every existing install is in. `make ci` green, smoke 46/46.

Two deliberate limits. A directory named by `OMNI_DB_PATH` is left alone, since it
can be any directory on the machine and narrowing one the user chose takes access
away from whoever else is in it; the database file is tightened wherever it lives.
Files under `~/.omni` other than the database are covered by the 0700 directory
rather than individually, because a recursive walk on a 10 ms hook budget is not
worth it.

Closes #631

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR restricts OMNI’s Unix data directory and SQLite database artifacts to owner-only access, including tightening existing installations whenever the store opens.

- Adds a Unix permission helper that applies `0700` to directories and `0600` to files.
- Restricts OMNI-resolved data/config directories while leaving directories selected through `OMNI_DB_PATH` unchanged.
- Restricts the database and its WAL/SHM sidecars after schema initialization.
- Adds regression tests for loose existing directory and database modes and documents the security fix.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge and consistently narrows access to OMNI-owned database artifacts without changing custom parent-directory permissions.

The changed paths apply owner-only modes after directory creation and SQLite initialization, cover existing installations on reopen, and preserve the explicitly documented behavior for user-selected database directories.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/paths.rs | Adds platform-gated owner-only permission enforcement and a Unix regression test covering both directory and file modes. |
| src/store/sqlite.rs | Applies restrictive permissions to OMNI-owned directories, the database, and SQLite sidecars on every store open, with a reopen regression test. |
| changelog.d/631.fixed.md | Documents the prior local disclosure, the new permission behavior, and the deliberate handling of custom database directories and Windows. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Open SQLite store] --> B[Resolve database path]
    B --> C[Create parent directory]
    C --> D{Parent is OMNI data or config home?}
    D -- Yes --> E[Restrict directory to 0700]
    D -- No --> F[Leave user-selected directory unchanged]
    E --> G[Initialize SQLite schema and WAL]
    F --> G
    G --> H[Restrict database to 0600]
    H --> I[Restrict WAL and SHM sidecars to 0600]
    I --> J[Return store]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["style: cargo fmt"](https://github.com/fajarhide/omni/commit/eda9b7f604fd6f22c00975adfe3c23adb37019dc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55041766)</sub>

<!-- /greptile_comment -->