### PR TITLE
fix(hermes): install a plugin that parses, and register the hooks that replace a result

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,25 @@ jobs:
         working-directory: plugins/pi
         run: npm run typecheck
 
+  plugin-hermes:
+    name: checks (plugins/hermes)
+    # The plugin used to be a Rust raw string, so no job in this file could see
+    # that every copy OMNI installed was a Python syntax error (#628). It is a
+    # real file now and this is the job that compiles it.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Compile
+        run: python -m py_compile plugins/hermes/__init__.py
+
+      - name: Checks
+        run: python plugins/hermes/test_plugin.py
+
   manual-translations:
     name: manual translations in step
     # Seconds of git, so it runs on its own rather than behind thirteen minutes

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,11 @@
 *.log
 actual_stdout.txt
 *.py
+# Except the agent-host plugins, which are shipped source: the Hermes one
+# is compiled into the binary with include_str! and a fresh clone cannot
+# build without it (#628).
+!plugins/**/*.py
+__pycache__/
 node_modules/
 # --- Environment & Configuration ---
 .env

--- a/changelog.d/628.fixed.md
+++ b/changelog.d/628.fixed.md
@@ -1,0 +1,34 @@
+**The Hermes plugin was a Python syntax error and had never loaded.** It lived in
+a Rust raw string that opened with five quote characters, so every `__init__.py`
+`omni init --hermes` ever wrote failed to parse at line 32. The install printed
+`✓ Installed Hermes plugin` and the host has produced zero rows since 2026-08-11.
+Nothing caught it because nothing could: a Rust string literal is not Python to
+any tool in this repo.
+
+Even with the quoting fixed the three handlers would not have run. Hermes calls a
+hook as `cb(**kwargs)` and passes thirteen keys, so `def on_post_tool_call(tool_name,
+params, result)` raises TypeError on every call and `invoke_hook` swallows it into
+a debug log.
+
+The plugin is now a real file at `plugins/hermes/__init__.py`, compiled and
+exercised by a `checks (plugins/hermes)` CI job, and it registers the two hooks
+whose return value Hermes actually uses: `transform_terminal_output` and
+`transform_tool_result`. The second fires for **every** tool, which makes the
+Read, Grep and WebFetch distillers reachable for the first time; they have been
+written since #172 and never executed, because Claude Code's PostToolUse matcher
+is Bash-only.
+
+Hermes also gets its own payload format rather than borrowing one. `OMNI_AGENT_ID`
+can only override a Claude-Code-shaped payload, so reusing Codex's shape would
+have filed every Hermes row under `codex_cli`, and Claude Code's shape has nowhere
+to put an exit code, which is what #120 needs to refuse a failed command. Hermes'
+tool names are translated to the arms that exist: `terminal` used to fall into the
+unhandled-tool bucket, so even a loading plugin would have distilled nothing.
+
+Measured end to end through the installed plugin, driven with the kwargs Hermes
+really passes: 790 B to 283 B, two `hermes` rows in `distillations` and one ledger
+fold, on a host whose lifetime total was zero. A failing command is left alone.
+
+OpenClaw, the other half of the report, is untouched here. It cannot run on the
+machine this was verified on and its plugin is served over HTTP from `main`, which
+is a different delivery path and deserves its own change.

--- a/plugins/hermes/__init__.py
+++ b/plugins/hermes/__init__.py
@@ -1,0 +1,162 @@
+"""OMNI Context OS integration for Hermes Agent.
+
+A real file rather than a Rust string literal, and that is the point. The
+previous version lived in a `r#"…"#` in `src/agents/hermes.rs` and opened with
+five quote characters, so every `__init__.py` OMNI ever wrote was a Python
+syntax error and the plugin has never once loaded (#628). Nothing checked,
+because nothing could: a Rust string is not Python to any tool in this repo.
+`plugin-hermes` in CI compiles this file now.
+
+Two of the hooks here replace what the model sees. The other three are
+observers and are registered for their side effects only.
+"""
+
+import json
+import os
+import subprocess
+
+_OMNI_BIN = "{{OMNI_BIN}}"
+
+# Hermes calls a hook as `cb(**kwargs)` and adds keys over time
+# (`telemetry_schema_version` arrives that way). A handler with named positional
+# parameters therefore raises TypeError on every call, which `invoke_hook`
+# swallows into a debug log. Every handler here takes `**kw` for that reason,
+# and the old ones did not.
+
+
+def _omni_env():
+    """A copy of the environment naming this host."""
+    env = os.environ.copy()
+    env["OMNI_AGENT_ID"] = "hermes"
+    for var in ("OMNI_LOOP_ID", "OMNI_LOOP_GOAL", "OMNI_LOOP_BUDGET"):
+        if var in os.environ:
+            env[var] = os.environ[var]
+    return env
+
+
+def _run_omni(*args, stdin=None):
+    """Run the OMNI binary, fail-open. Never raises, never blocks Hermes."""
+    try:
+        return subprocess.run(
+            [_OMNI_BIN] + list(args),
+            input=stdin.encode("utf-8") if stdin else None,
+            env=_omni_env(),
+            capture_output=True,
+            timeout=5,
+        )
+    except Exception:
+        return None
+
+
+def _distill(tool_name, command, output, exit_code, session_id):
+    """Return the shortened output, or None to leave Hermes' own bytes alone.
+
+    None on every uncertain path. A hook that guesses would replace a tool
+    result with something it did not read, which is the one failure this
+    project exists to prevent.
+    """
+    if not isinstance(output, str) or not output:
+        return None
+
+    payload = json.dumps(
+        {
+            "agent": "hermes",
+            "tool_name": tool_name or "Bash",
+            "command": command or "",
+            "output": output,
+            "exit_code": exit_code,
+            "session_id": session_id or "",
+        }
+    )
+    res = _run_omni("--post-hook", stdin=payload)
+    if not res or res.returncode != 0 or not res.stdout:
+        return None
+
+    try:
+        updated = json.loads(res.stdout)["hookSpecificOutput"]["updatedToolOutput"]
+        text = updated.get("result")
+    except Exception:
+        return None
+
+    # A replacement that is not shorter is not a saving, and returning it would
+    # spend a hook on nothing. OMNI already declines by emitting no rewrite; this
+    # is the second half of the same rule, on this side of the boundary.
+    if not isinstance(text, str) or not text or len(text) >= len(output):
+        return None
+    return text
+
+
+def _command_of(args):
+    """The command a tool call ran, when the tool has one."""
+    if isinstance(args, dict):
+        for key in ("command", "cmd", "query", "pattern", "file_path", "path"):
+            value = args.get(key)
+            if isinstance(value, str) and value:
+                return value
+    return ""
+
+
+def register(ctx):
+    def on_transform_terminal_output(**kw):
+        """Fires after terminal capture and before Hermes' own output limit."""
+        return _distill(
+            "terminal",
+            kw.get("command", ""),
+            kw.get("output", ""),
+            kw.get("returncode", 0),
+            kw.get("task_id", ""),
+        )
+
+    def on_transform_tool_result(**kw):
+        """Fires for every tool, which is what no other host offers.
+
+        OMNI's Read, Grep and WebFetch distillers are written and have never
+        executed, because Claude Code's PostToolUse matcher is Bash-only (#172).
+        This is the hook that reaches them.
+        """
+        # `terminal` already went through the hook above, and distilling a
+        # payload that is already a marker plus a remainder would fold OMNI's
+        # own output.
+        if kw.get("tool_name") == "terminal":
+            return None
+        return _distill(
+            kw.get("tool_name", ""),
+            _command_of(kw.get("args")),
+            kw.get("result", ""),
+            0 if kw.get("status", "success") == "success" else 1,
+            kw.get("session_id", ""),
+        )
+
+    def on_post_tool_call(**kw):
+        """Observer. Its return is ignored by Hermes, so it distills nothing.
+
+        Kept for the compaction signal only: OMNI reports context pressure and
+        Hermes is one of the few hosts that can act on it.
+        """
+        res = _run_omni("--post-hook")
+        if not res or not res.stdout:
+            return None
+        out = res.stdout.decode("utf-8", errors="ignore")
+        if "[omni:context pressure: CRITICAL]" in out or "[omni:context pressure: WARNING]" in out:
+            try:
+                if hasattr(ctx, "request_compaction"):
+                    ctx.request_compaction("OMNI context pressure threshold reached")
+                elif hasattr(ctx, "compact"):
+                    ctx.compact()
+            except Exception:
+                pass
+        return None
+
+    def on_pre_tool_call(**kw):
+        _run_omni("--pre-hook")
+        return None
+
+    def on_session_start(**kw):
+        _run_omni("--session-start")
+        return None
+
+    ctx.register_hook("transform_terminal_output", on_transform_terminal_output)
+    ctx.register_hook("transform_tool_result", on_transform_tool_result)
+    ctx.register_hook("post_tool_call", on_post_tool_call)
+    ctx.register_hook("pre_tool_call", on_pre_tool_call)
+    ctx.register_hook("on_session_start", on_session_start)

--- a/plugins/hermes/test_plugin.py
+++ b/plugins/hermes/test_plugin.py
@@ -1,0 +1,95 @@
+"""Checks for the Hermes plugin, run by the `plugin-hermes` CI job.
+
+Plain asserts and no framework, because the thing being guarded is that this
+file is importable Python at all. The previous plugin was generated from a Rust
+raw string with five leading quote characters, so every copy OMNI installed was
+a syntax error, and no Rust test could see it (#628).
+
+Run: python3 plugins/hermes/test_plugin.py
+"""
+
+import importlib.util
+import pathlib
+import sys
+
+HERE = pathlib.Path(__file__).resolve().parent
+
+
+def load():
+    spec = importlib.util.spec_from_file_location("omni_hermes", HERE / "__init__.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def registered_hooks(module):
+    hooks = {}
+
+    class Ctx:
+        def register_hook(self, name, callback):
+            hooks[name] = callback
+
+    module.register(Ctx())
+    return hooks
+
+
+def test_registers_the_two_hooks_that_can_replace_a_result():
+    hooks = registered_hooks(load())
+    for name in ("transform_terminal_output", "transform_tool_result"):
+        assert name in hooks, f"{name} is what makes this host more than an observer"
+
+
+def test_every_handler_survives_kwargs_it_does_not_know():
+    """Hermes calls hooks as `cb(**kwargs)` and adds keys over time.
+
+    The old handlers were `def on_post_tool_call(tool_name, params, result)`,
+    which raises TypeError against the real call and is swallowed into a debug
+    log, so all three ran zero times even before the syntax error.
+    """
+    module = load()
+    module._OMNI_BIN = "/nonexistent/omni"  # fail-open path, no subprocess worth running
+    hooks = registered_hooks(module)
+
+    everything = dict(
+        tool_name="terminal",
+        args={"command": "ls"},
+        result="out",
+        command="ls",
+        output="out",
+        returncode=0,
+        task_id="t",
+        session_id="s",
+        tool_call_id="c",
+        turn_id="u",
+        api_request_id="a",
+        duration_ms=1.0,
+        status="success",
+        error_type=None,
+        error_message=None,
+        env_type="local",
+        middleware_trace=[],
+        telemetry_schema_version=1,
+        a_key_hermes_adds_next_year="ignored",
+    )
+    for name, callback in hooks.items():
+        callback(**everything)  # a TypeError here is the whole bug
+
+
+def test_an_unreachable_binary_leaves_the_output_alone():
+    module = load()
+    module._OMNI_BIN = "/nonexistent/omni"
+    assert module._distill("terminal", "ls", "some output", 0, "s") is None
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"ok   {name}")
+            except Exception as exc:  # noqa: BLE001 - a runner, not a library
+                failures += 1
+                print(f"FAIL {name}: {exc!r}")
+    print(f"\n{failures} failed")
+    sys.exit(1 if failures else 0)

--- a/src/agents/hermes.rs
+++ b/src/agents/hermes.rs
@@ -277,6 +277,17 @@ fn configured_compression_in_config(config_path: &Path) -> bool {
         .unwrap_or(false)
 }
 
+/// The plugin source with the binary path substituted in.
+///
+/// The path goes in as a JSON string rather than raw text. JSON string syntax is
+/// a subset of Python's, so this escapes the two characters that would otherwise
+/// produce a file Python cannot read: a quote closes the literal, and a Windows
+/// path's `\U` is a unicode escape (`C:\Users\…` is a syntax error, not a path).
+fn render_plugin(exe_path: &str) -> String {
+    let literal = serde_json::to_string(exe_path).unwrap_or_else(|_| "\"omni\"".to_string());
+    include_str!("../../plugins/hermes/__init__.py").replace("\"{{OMNI_BIN}}\"", &literal)
+}
+
 impl AgentIntegration for HermesIntegration {
     fn id(&self) -> &'static str {
         "hermes"
@@ -298,83 +309,11 @@ version: "1.0"
 description: OMNI Signal Engine integration for Hermes Agent hooks
 "#;
 
-        let init_py_content = format!(
-            r#""""""OMNI Context OS integration for Hermes Agent.
-
-This plugin wires three lifecycle hooks so OMNI can distill
-terminal output, track sessions, and manage context pressure.
-
-It also exposes helper utilities that make the 27 OMNI MCP tools
-(loop_memory, knowledge, retrieve, learn) work seamlessly during
-Hermes autonomous multi-step loops.
-""""""
-import json
-import os
-import subprocess
-import time
-
-_OMNI_BIN = "{}"
-_STEP_COUNTER = 0
-_SESSION_START_TS = None
-
-
-def _omni_env():
-    """Return a copy of the environment with OMNI_AGENT_ID set."""
-    env = os.environ.copy()
-    env["OMNI_AGENT_ID"] = "hermes"
-    # Forward loop control vars when present
-    for var in ("OMNI_LOOP_ID", "OMNI_LOOP_GOAL", "OMNI_LOOP_BUDGET"):
-        if var in os.environ:
-            env[var] = os.environ[var]
-    return env
-
-
-def _run_omni(*args):
-    """Run the OMNI binary with fail-open semantics."""
-    try:
-        return subprocess.run(
-            [_OMNI_BIN] + list(args),
-            env=_omni_env(),
-            capture_output=True,
-            timeout=5,
-        )
-    except Exception:
-        return None  # fail-open: never block Hermes
-
-
-def register(ctx):
-    global _SESSION_START_TS
-    _SESSION_START_TS = time.time()
-
-    def on_post_tool_call(tool_name, params, result):
-        global _STEP_COUNTER
-        _STEP_COUNTER += 1
-        res = _run_omni("--post-hook")
-        
-        # Explicit feedback loop: OMNI pressure -> Hermes compaction
-        if res and res.stdout:
-            out = res.stdout.decode('utf-8', errors='ignore')
-            if "[omni:context pressure: CRITICAL]" in out or "[omni:context pressure: WARNING]" in out:
-                try:
-                    if hasattr(ctx, 'request_compaction'):
-                        ctx.request_compaction("OMNI context pressure threshold reached")
-                    elif hasattr(ctx, 'compact'):
-                        ctx.compact()
-                except Exception:
-                    pass
-
-    def on_pre_tool_call(tool_name, params):
-        _run_omni("--pre-hook")
-
-    def on_session_start():
-        _run_omni("--session-start")
-
-    ctx.register_hook("post_tool_call", on_post_tool_call)
-    ctx.register_hook("pre_tool_call", on_pre_tool_call)
-    ctx.register_hook("on_session_start", on_session_start)
-"#,
-            exe_path
-        );
+        // The plugin is a real Python file in `plugins/hermes/`, compiled by
+        // CI, rather than a Rust string literal. The literal that used to live
+        // here opened with five quote characters, so every `__init__.py` OMNI
+        // wrote was a syntax error and the plugin never loaded once (#628).
+        let init_py_content = render_plugin(exe_path);
 
         fs::write(dest.join("plugin.yaml"), plugin_yaml_content)?;
         fs::write(dest.join("__init__.py"), init_py_content)?;
@@ -956,5 +895,48 @@ plugins:
         if let Some(msg) = &result {
             assert!(msg.contains("OMNI × Hermes") || msg.contains("Startup Validation"));
         }
+    }
+
+    /// #628. The plugin lived in a Rust raw string that opened with five quote
+    /// characters, so every `__init__.py` OMNI wrote was a Python syntax error
+    /// and the plugin never loaded once, while `omni init --hermes` reported
+    /// success. It is a real file under `plugins/hermes/` now, compiled by the
+    /// `plugin-hermes` CI job, and these three properties are what the Rust side
+    /// can still get wrong.
+    #[test]
+    fn the_rendered_plugin_registers_the_hooks_that_replace_a_result() {
+        let src = super::render_plugin("/usr/local/bin/omni");
+
+        for hook in ["transform_terminal_output", "transform_tool_result"] {
+            assert!(
+                src.contains(&format!("ctx.register_hook(\"{hook}\"")),
+                "the only two hooks whose return value Hermes uses: {hook}"
+            );
+        }
+        assert!(
+            !src.contains("{{OMNI_BIN}}"),
+            "the placeholder must not survive into the installed file"
+        );
+        assert!(
+            src.contains("_OMNI_BIN = \"/usr/local/bin/omni\""),
+            "the binary path is what the hooks shell out to: {src:.400}"
+        );
+    }
+
+    /// A Windows path is the case that breaks quietly: `C:\Users\…` puts `\U`
+    /// in a Python string literal, which is a unicode escape and a syntax error,
+    /// so the plugin would fail to import on exactly one platform.
+    #[test]
+    fn a_windows_path_is_escaped_rather_than_pasted() {
+        let src = super::render_plugin(r"C:\Users\dev\.cargo\bin\omni.exe");
+
+        assert!(
+            src.contains(r"C:\\Users\\dev"),
+            "backslashes have to survive as escapes, not as escape sequences"
+        );
+        assert!(
+            !src.contains(r#"= "C:\Users"#),
+            "a raw Windows path in a Python string is a unicode-escape error"
+        );
     }
 }

--- a/src/hooks/normalize.rs
+++ b/src/hooks/normalize.rs
@@ -12,7 +12,17 @@ pub enum AgentFormat {
     Aider,          // piped stdin, OMNI_CMD env
     GenericMCP,     // JSON-RPC 2.0 tool result
     Pi,             // camelCase toolName + toolResponse from Pi extension
-    Unknown,        // fallback ke ClaudeCode parser
+    /// `agent: "hermes"` + `exit_code`, sent by the plugin's transform hooks.
+    ///
+    /// Its own arm rather than a reshaped Codex or Claude Code payload, for two
+    /// reasons that both bit this project before. `resolve_agent_id` only lets
+    /// `OMNI_AGENT_ID` override a `ClaudeCode` or `Unknown` format, so borrowing
+    /// Codex's shape would file every Hermes row under `codex_cli`, which is the
+    /// mislabelling #212 traced a wrong headline to. And Claude Code's shape has
+    /// nowhere to put an exit code, so #120's refusal to distill a failed command
+    /// would never fire on this host (#628).
+    Hermes,
+    Unknown, // fallback ke ClaudeCode parser
 }
 
 /// Internal representation setelah normalization
@@ -92,6 +102,13 @@ pub fn detect_agent(input: &str) -> AgentFormat {
         return AgentFormat::Pi;
     }
 
+    // Hermes, before the ClaudeCode test below: its payload also carries
+    // `tool_name`, and the plugin names itself so no other host reaches this by
+    // accident.
+    if obj.get("agent").and_then(|a| a.as_str()) == Some("hermes") {
+        return AgentFormat::Hermes;
+    }
+
     // ClaudeCode / CursorWindsurf: punya "tool_name" dan "tool_response"
     if obj.contains_key("tool_name") && obj.contains_key("tool_response") {
         // Cursor/Windsurf: content field di tool_response adalah array
@@ -148,6 +165,7 @@ pub fn normalize(input: &str) -> Option<NormalizedInput> {
         AgentFormat::Aider => normalize_aider(input, agent_id),
         AgentFormat::GenericMCP => normalize_generic_mcp(input, agent_id),
         AgentFormat::Pi => normalize_pi(input, agent_id),
+        AgentFormat::Hermes => normalize_hermes(input, agent_id),
     }?;
 
     // Read once here rather than in each of the eight per-agent parsers: the key
@@ -247,6 +265,7 @@ pub fn resolve_agent_id(agent: &AgentFormat, from_env: &str) -> String {
         AgentFormat::Aider => "aider".to_string(),
         AgentFormat::GenericMCP => "mcp_generic".to_string(),
         AgentFormat::Pi => "pi".to_string(),
+        AgentFormat::Hermes => "hermes".to_string(),
         AgentFormat::Unknown => "unknown".to_string(),
     }
 }
@@ -634,6 +653,73 @@ fn normalize_codex(input: &str, agent_id: String) -> Option<NormalizedInput> {
         agent_id,
         failed: parsed.exit_code.is_some_and(|c| c != 0),
         // Host contract not investigated (#187), keeps the MCP shape.
+        raw_response: None,
+        // Set by `normalize` for every agent; see the field's doc comment.
+        host_session_id: None,
+        host_agent_id: None,
+    })
+}
+
+// ── HERMES AGENT ──────────────────────────────────────────────────────
+/// Hermes' tool names, in the names `post_tool::process_payload` routes on.
+///
+/// Without this the mapping is not "unknown tool, do nothing", it is worse:
+/// `terminal` fell into the `_` arm, was counted by `record_unhandled_tool`, and
+/// every shell command on the host went undistilled while the install reported
+/// success. Confirmed by driving the hook with a Hermes payload.
+///
+/// Only names with a distiller behind them are translated. Anything else keeps
+/// the name Hermes gave it, so `record_unhandled_tool` counts the real thing and
+/// the next map is written from data rather than from a guess.
+fn hermes_tool_name(name: Option<&str>) -> String {
+    match name.unwrap_or("terminal") {
+        "terminal" => "Bash",
+        "read_file" => "Read",
+        "search_files" => "Grep",
+        "web_extract" => "WebFetch",
+        "write_file" => "Write",
+        "patch" => "Edit",
+        other => other,
+    }
+    .to_string()
+}
+
+/// The payload the Hermes plugin's transform hooks send.
+///
+/// ```json
+/// {"agent":"hermes","tool_name":"terminal","command":"cargo test",
+///  "output":"…","exit_code":1,"session_id":"…"}
+/// ```
+///
+/// `tool_name` is carried rather than assumed, because this is the first host
+/// whose replacement hook fires for **every** tool and not only the shell one.
+/// That is what makes the Read, Grep and WebFetch distillers reachable at all;
+/// they have been written and never executed, since Claude Code's PostToolUse
+/// matcher is Bash-only (#172).
+fn normalize_hermes(input: &str, agent_id: String) -> Option<NormalizedInput> {
+    #[derive(Deserialize)]
+    struct HermesInput {
+        tool_name: Option<String>,
+        command: Option<String>,
+        output: Option<String>,
+        exit_code: Option<i64>,
+    }
+
+    let parsed: HermesInput = serde_json::from_str(input).ok()?;
+    let content = parsed.output.filter(|o| !o.is_empty())?;
+
+    Some(NormalizedInput {
+        agent: AgentFormat::Hermes,
+        tool_name: hermes_tool_name(parsed.tool_name.as_deref()),
+        command: parsed.command.unwrap_or_default(),
+        content,
+        agent_id,
+        // The reason this format exists. Hermes hands the plugin a `returncode`,
+        // and no shape OMNI already parsed had anywhere to put it, so #120's
+        // refusal to distill a failed command could not have fired here.
+        failed: parsed.exit_code.is_some_and(|c| c != 0),
+        // The hook returns a bare string to Hermes, so there is no host response
+        // object to echo and the MCP shape is what the plugin reads back.
         raw_response: None,
         // Set by `normalize` for every agent; see the field's doc comment.
         host_session_id: None,
@@ -1056,5 +1142,56 @@ mod tests {
 
         assert_eq!(detect_agent(claude), AgentFormat::ClaudeCode);
         assert_eq!(detect_agent(pi), AgentFormat::Pi);
+    }
+
+    /// #628. Hermes had no format of its own, and neither shape it could have
+    /// borrowed works: `resolve_agent_id` only lets `OMNI_AGENT_ID` override a
+    /// `ClaudeCode` or `Unknown` payload, so a Codex-shaped one would file every
+    /// row under `codex_cli`, and a Claude-shaped one has nowhere to put the
+    /// exit code Hermes hands the plugin.
+    #[test]
+    fn a_hermes_payload_is_filed_under_hermes_and_carries_its_exit_code() {
+        let payload = |code: i64| {
+            serde_json::json!({
+                "agent": "hermes", "tool_name": "terminal", "command": "cargo test",
+                "output": "one\ntwo\n", "exit_code": code, "session_id": "s1"
+            })
+            .to_string()
+        };
+
+        let ok = normalize(&payload(0)).expect("a hermes payload normalizes");
+        assert_eq!(ok.agent, AgentFormat::Hermes);
+        assert_eq!(
+            ok.agent_id, "hermes",
+            "a row under any other id is a lost row"
+        );
+        assert!(!ok.failed);
+
+        let bad = normalize(&payload(1)).expect("a failing command still normalizes");
+        assert!(
+            bad.failed,
+            "#120 refuses to distill a failed command, and cannot fire without this"
+        );
+    }
+
+    /// The tool name decides which arm of `process_payload` runs, and Hermes
+    /// spells them differently. `terminal` fell into the `_` arm and was counted
+    /// as an unhandled tool, so every shell command on the host went undistilled
+    /// while the install reported success.
+    #[test]
+    fn hermes_tool_names_are_translated_to_the_arms_that_exist() {
+        for (theirs, ours) in [
+            ("terminal", "Bash"),
+            ("read_file", "Read"),
+            ("search_files", "Grep"),
+            ("web_extract", "WebFetch"),
+        ] {
+            assert_eq!(hermes_tool_name(Some(theirs)), ours, "{theirs}");
+        }
+        assert_eq!(
+            hermes_tool_name(Some("kanban_show")),
+            "kanban_show",
+            "an untranslated name has to reach record_unhandled_tool as itself"
+        );
     }
 }


### PR DESCRIPTION
`omni init --hermes` has never installed a working plugin. The Python lived in a
Rust raw string opening with five quote characters, so every `__init__.py` it
wrote failed to parse at line 32 while the install printed a tick:

```
$ python3 -m py_compile ~/.hermes/plugins/omni-signal-engine/__init__.py
SyntaxError: unterminated triple-quoted string literal (detected at line 73)
```

That is the reason for the zero rows, and it is upstream of the diagnosis in the
issue. Two further defects sat behind it, each sufficient alone: Hermes calls a
hook as `cb(**kwargs)` with thirteen keys, so the handlers' named positional
parameters raised TypeError into a swallowed debug log, and `terminal` is not a
name `process_payload` routes on, so it fell into the unhandled-tool arm.

The plugin is a real file under `plugins/hermes/` now, compiled and exercised by a
`checks (plugins/hermes)` job, registering `transform_terminal_output` and
`transform_tool_result`. The second fires for every tool, which is what makes the
Read, Grep and WebFetch distillers reachable at all: written since #172, never run,
because Claude Code's PostToolUse matcher is Bash-only.

Hermes gets its own payload format rather than borrowing one. `OMNI_AGENT_ID` only
overrides a Claude-Code-shaped payload, so Codex's shape would file every row under
`codex_cli`, and Claude Code's shape has nowhere to put the exit code #120 needs.

Verified by driving the installed plugin with the kwargs Hermes really passes:

```
input : 790 B
output: 283 B
[OMNI: 10 lines already shown, omni retrieve 11d288731bf7fecc]
...
failed command -> left alone

distillations by agent: [('hermes', 2)]     # lifetime total was 0
ledger folds: [(1,)]
```

Six break-tests, each verified by diff first: dropping the `transform_tool_result`
registration, pasting the binary path raw so a Windows `C:\Users\…` becomes a
unicode escape, filing rows under another id, ignoring the exit code, leaving
`terminal` untranslated, and giving a handler named positional parameters. All red.
`make ci` green, smoke 46/46.

One thing worth a reviewer's eye: `.gitignore` had a blanket `*.py`, so the plugin
would never have been committed and a fresh clone could not build the `include_str!`.
The negation is scoped to `plugins/**/*.py`.

OpenClaw is not touched. It cannot run on the machine that verified this, and its
plugin is served over HTTP from `main`, so it is a different delivery path.

Part of #628, which stays open for that half.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR replaces the malformed embedded Hermes plugin with a checked-in Python plugin, registers Hermes transform hooks, and adds a dedicated normalization format so tool output can be distilled with correct host identity and exit status.
- Adds compilable Hermes plugin source and focused Python checks in CI.
- Safely substitutes the OMNI executable path into the installed plugin.
- Normalizes Hermes payloads, translates supported tool names, and preserves failed-command behavior.
- Adjusts ignore rules so source-shipped Python plugins are included in fresh clones.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete changed-code failure identified.

The installed plugin is now syntactically checked, its callback contract and response parsing align with the Hermes and OMNI paths, executable-path substitution is escaped, and normalization preserves tool routing, host identity, session identity, and failed-command handling.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| plugins/hermes/__init__.py | Adds the importable Hermes plugin, fail-open OMNI invocation, transform callbacks, tool metadata extraction, and lifecycle hook registration. |
| src/hooks/normalize.rs | Adds explicit Hermes detection and normalization, supported tool-name translation, host attribution, and exit-code propagation. |
| src/agents/hermes.rs | Replaces malformed embedded Python with checked-in source and safely renders the executable path into the installed plugin. |
| plugins/hermes/test_plugin.py | Exercises plugin loading, required transform registration, callback tolerance for evolving kwargs, and fail-open behavior. |
| .github/workflows/ci.yml | Adds a Hermes plugin job that compiles and executes the standalone Python checks. |
| .gitignore | Unignores source-shipped Python files beneath plugins while continuing to ignore other Python files and bytecode caches. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant H as Hermes
    participant P as Hermes plugin
    participant O as omni --post-hook
    participant N as Hermes normalizer
    participant D as Tool distiller
    H->>P: "transform hook(**kwargs)"
    P->>O: JSON payload with tool, output, exit code, session
    O->>N: detect and normalize Hermes payload
    N->>D: canonical tool name and normalized input
    alt Successful shorter distillation
        D-->>O: distilled result
        O-->>P: updatedToolOutput.result
        P-->>H: replacement string
    else Failure, failed command, or no saving
        O-->>P: no usable replacement
        P-->>H: None (retain original output)
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(hermes): install a plugin that parse..."](https://github.com/fajarhide/omni/commit/d958a3bd3be7cb5a8975bb066303ad8e2850cac1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55045909)</sub>

<!-- /greptile_comment -->