### PR TITLE
fix(ledger): hold a sub-1 KB fold to three quarters, not four fifths

### DIFF
--- a/changelog.d/643.fixed.md
+++ b/changelog.d/643.fixed.md
@@ -1,0 +1,21 @@
+**A 527 byte `grep` came back with no content lines at all.** Fourteen lines were
+folded into one project-scope handle and the four lines left standing were shell
+scaffolding: two `echo` headers, a version string and an `ls -l`. The command had
+been run to check where a new export had landed in a sorted list, so the sort
+order was the whole answer, and the reply read as "no matches" rather than
+"matches withheld".
+
+The sub-1 KB coverage bar was four fifths. This reply was 78.7% covered, which
+cleared it, and the payload was not folded whole so the #567 whole-output floor
+did not apply either. Both guards were built for this exact case and neither
+reached it.
+
+The bar is three quarters now. The number is not derived from anything: the
+fixtures that must still fold sit at 72.1% and 63.9%, this report must not at
+78.7%, and three quarters is the only simple fraction in the gap. Priced over the
+recorded corpus it refuses 9 more of 108 sub-1 KB calls and gives up 3,768 bytes
+across five days, against a 13.3% retrieve rate on blocks that size.
+
+Reproduced from the row the report wrote (`payload_bytes` 695, one project run of
+527 B over 14 lines, `whole_output` 0) rather than from the prose, after a
+synthetic repro at 100% coverage came back clean on 0.7.6 and on `main` alike.

--- a/src/ledger/mod.rs
+++ b/src/ledger/mod.rs
@@ -603,21 +603,32 @@ impl<'a> Ledger<'a> {
         // The first draft weighed each run against the payload on its own, which
         // is the wrong denominator and reopens the hole it was closing: three
         // seen blocks of thirty percent, separated by a line or two of new
-        // content, each pass a four fifths test individually and together fold
-        // ninety percent of the reply. The reader is left with markers and the
+        // content, each pass the test individually and together fold ninety
+        // percent of the reply. The reader is left with markers and the
         // separators, which is the reported case wearing three markers instead
         // of one.
         //
         // Coverage is a property of the payload, so it is computed from the
-        // payload. This also subsumes the old whole-output floor exactly: one
-        // run covering everything is a hundred percent coverage, and the byte
-        // test it used to make is the same test this makes.
+        // payload. This also subsumes the whole-output floor exactly: one run
+        // covering everything is a hundred percent coverage, and the byte test
+        // #567 used to make is the same test this makes.
+        //
+        // Three quarters, not four fifths, since #643. That report is a 658 byte
+        // reply whose fourteen lines of `grep` output were the entire question
+        // and whose remaining four lines were shell scaffolding: two `echo`
+        // headers, a version string and an `ls -l`. At 78.7% it cleared four
+        // fifths, so the answer became a handle and the scaffolding was all the
+        // reader got. The number is not derived from anything: the fixtures that
+        // must still fold sit at 72.1% and 63.9%, that report must not, and
+        // three quarters is the only simple fraction in the gap. Priced over the
+        // recorded corpus it refuses 9 more of 108 sub-1 KB calls and gives up
+        // 3,768 bytes across five days.
         let seen_bytes: usize = runs
             .iter()
             .filter(|r| r.seen.is_some())
             .map(|r| lines[r.start..r.end].iter().map(|l| l.len()).sum::<usize>())
             .sum();
-        if payload_bytes < MIN_WHOLE_OUTPUT_FOLD && seen_bytes * 5 >= payload_bytes * 4 {
+        if payload_bytes < MIN_WHOLE_OUTPUT_FOLD && seen_bytes * 4 >= payload_bytes * 3 {
             return None;
         }
 
@@ -1011,7 +1022,7 @@ mod tests {
         );
 
         // Four new lines, not one. #601 widened the floor to cover a fold that
-        // takes four fifths or more of its payload, on the evidence that three
+        // takes three quarters or more of its payload, on the evidence that three
         // surviving lines out of twenty-six were not content anyone could use.
         // One appended line put this fixture on the wrong side of that, so the
         // arm below was asserting the floor rather than the absence of it, which
@@ -1023,8 +1034,8 @@ mod tests {
                 .collect::<String>()
         );
         assert!(
-            text.len() * 5 < extended.len() * 4,
-            "the repeated head must be under four fifths of the payload, or this \
+            text.len() * 4 < extended.len() * 3,
+            "the repeated head must be under three quarters of the payload, or this \
              arm tests the #601 floor instead of a partial fold"
         );
         let partial = ledger
@@ -1451,8 +1462,8 @@ mod tests {
                 .collect::<String>()
         );
         assert!(
-            text.len() * 5 < probe.len() * 4,
-            "the repeat must be under four fifths of the probe, or the #601 floor \
+            text.len() * 4 < probe.len() * 3,
+            "the repeat must be under three quarters of the probe, or the #601 floor \
              decides this before either bar is consulted"
         );
 
@@ -1643,7 +1654,7 @@ mod tests {
     /// this feature exists for.
     ///
     /// Coverage is what the fold takes of the payload; the floor only applies
-    /// once that is four fifths or more **and** the run is under
+    /// once that is three quarters or more **and** the run is under
     /// `MIN_WHOLE_OUTPUT_FOLD`.
     /// The hole the review of #601 found in its first draft, kept as its own
     /// test because the matrix above cannot express it: every row there has one
@@ -1680,11 +1691,11 @@ mod tests {
         );
         let seen = block('a').len() + block('b').len() + block('c').len();
         assert!(
-            seen * 5 >= second.len() * 4,
-            "the three blocks must clear four fifths together"
+            seen * 4 >= second.len() * 3,
+            "the three blocks must clear three quarters together"
         );
         assert!(
-            block('a').len() * 5 < second.len() * 4,
+            block('a').len() * 4 < second.len() * 3,
             "and no single block may clear it alone, or this tests the old rule"
         );
         assert!(
@@ -1701,6 +1712,72 @@ mod tests {
             ledger.project(&second),
             None,
             "three sub-threshold blocks folded to markers and two separators"
+        );
+    }
+
+    /// #643, taken from the row it wrote: `payload_bytes` 695, one project run of
+    /// 527 B over 14 lines, `whole_output` 0. Coverage is 75.8%, which clears the
+    /// old four-fifths test, so the answer folded and the reader kept four lines
+    /// of shell scaffolding: two `echo` headers, a version string and an `ls -l`.
+    ///
+    /// The numbers are the reported ones rather than round ones on purpose. A
+    /// fixture at 50% or at 90% sits on a side of the rule that was already
+    /// decided, and this is the band that was not.
+    #[test]
+    fn refuses_a_fold_that_leaves_only_scaffolding() {
+        let (store, _d) = temp_store();
+        let ledger = Ledger::new(&store, "s1").with_project("/repo");
+
+        // The fourteen lines a `grep -n` returned, which were the whole question.
+        let answer: String = (1..=14)
+            .map(|i| format!("{i:02}:export * from \"./module-name-{i:02}\";\n"))
+            .collect();
+        // What the command printed around them.
+        let scaffolding = "=== versi terpasang:\nomni 0.7.6\n\
+             lrwxr-xr-x@ 1 user  admin  29 Aug 18 16:33 /opt/local/bin/omni\n\
+             === repro 1 (persis yang tadi, urutan sort):\n";
+        let payload = format!("{scaffolding}{answer}");
+
+        assert!(
+            payload.len() < MIN_WHOLE_OUTPUT_FOLD && payload.len() > MIN_LEDGER_INPUT,
+            "the fixture has to sit under the whole-output floor and above the \
+             input floor, or it tests an early return: {} bytes",
+            payload.len()
+        );
+        // The fixture has to sit in the gap between the two bars, or it proves
+        // nothing: above three quarters so the current rule refuses it, below
+        // four fifths so the rule it replaced did not.
+        assert!(
+            answer.len() * 4 >= payload.len() * 3,
+            "the answer must clear three quarters, or something other than this \
+             rule is refusing the fold: {} of {}",
+            answer.len(),
+            payload.len()
+        );
+        assert!(
+            answer.len() * 5 < payload.len() * 4,
+            "the answer must NOT clear four fifths, or the old rule already \
+             refused this and the fixture proves nothing: {} of {}",
+            answer.len(),
+            payload.len()
+        );
+        assert!(
+            payload.len() - answer.len() < MIN_LEDGER_INPUT,
+            "what survives has to be too small to stand alone, which is the claim"
+        );
+
+        // Seen in the project scope, from another session, as a project fold needs.
+        Ledger::new(&store, "s0")
+            .with_project("/repo")
+            .project(&format!(
+                "{answer}{}",
+                (0..40).map(|i| row('p', i)).collect::<String>()
+            ));
+
+        assert_eq!(
+            ledger.project(&payload),
+            None,
+            "the answer folded and left the reader four lines of shell scaffolding"
         );
     }
 


### PR DESCRIPTION
A 658 byte reply whose fourteen `grep` lines were the entire question folded to a handle, and the four lines left standing were shell scaffolding: two `echo` headers, a version string and an `ls -l`. Coverage was 78.7%, which cleared the four fifths bar, and `whole_output` was 0, so #567's whole-output floor did not apply either. Both guards exist for this case and neither reached it.

The bar is three quarters now. The number is not derived from anything, and the comment says so: the fixtures that must still fold sit at 72.1% and 63.9%, this report must not at 78.7%, and three quarters is the only simple fraction in the gap.

## How it was found

Not by reproducing the prose. A synthetic payload at 100% coverage is refused by the old bar too, on `main` and on v0.7.6 alike, so the obvious repro exonerates the bug. What settled it was the row the report wrote:

```
id  |t                   |origin |lines|bytes|whole_output|payload_bytes
1151|2026-08-23 03:11:40 |project|   14|  527|           0|          695
```

527 of 695 is 75.8%, under four fifths, so the guard never fired. `execution_traces` held the same call at 695 B in and 249 B out.

## Before and after, through the binary on the hook path

Same payload, same seeded project scope, `origin/main` on the left of the divide and this branch on the right.

`origin/main` rewrites it, and the agent receives 222 B:

```
=== versi terpasang:
omni 0.7.6
lrwxr-xr-x@ 1 user  admin  29 Aug 18 16:33 /opt/local/bin/omni
=== repro 1 (persis yang tadi, urutan sort):
[OMNI: 14 lines not shown here, omni retrieve cfaa24b26cec495b]

[Partial signal]
```

```
ledger_folds:  project|14|518|658|0
distillations: claude_code|grep|658|222|Soft
```

This branch hands the payload back untouched:

```
ledger_folds:  (no row)
distillations: claude_code|grep|658|658|Passthrough
```

## What it costs

Priced over the recorded corpus, aggregating runs per call: 108 sub-1 KB calls, 24 already refused at four fifths, 33 refused at three quarters. So 9 more calls, 3,768 bytes across five days, against a 13.3% retrieve rate on blocks that size.

Two other rules were measured and dropped. Refusing every sub-1 KB fold gives up 43 KB and contradicts `never_folds_a_whole_output_that_cannot_pay_for_the_round_trip`, whose prose forbids exactly that. Requiring the remainder to clear `MIN_LEDGER_INPUT` refuses 59 of 108 and breaks three tests, because a 140 byte remainder of scaffolding and a 193 byte remainder of real content are the same number of bytes.

## Verification

`make ci` green. The new test was driven red before the fix, with the failure printing the reported shape. Four break directions, each red: revert the bar to four fifths, remove the guard, refuse every sub-1 KB fold, disable the coverage half.

Four premise assertions in neighbouring tests still named four fifths and are updated, since a premise describing a retired rule stops guarding its fixture.

Closes #643


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Lowers the refusal threshold for sub-1 KB ledger folds from 80% to 75%, preventing small responses from folding when most of their meaningful content would be replaced by a handle.
- Adds a regression test reproducing the reported 75.8% coverage case.
- Updates neighboring test premises and documentation to reflect the new threshold.
- Adds a detailed changelog entry describing the failure and measured tradeoff.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the stricter guard preserves complete output and the changed boundary is covered by targeted regression and premise tests.

The threshold change intentionally trades a small amount of folding efficiency for retaining meaningful content in sub-1 KB responses, while existing below-threshold partial-fold behavior remains covered.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/ledger/mod.rs | Changes the small-payload coverage guard to three quarters and adds focused boundary assertions and regression coverage without exposing a concrete correctness defect. |
| changelog.d/643.fixed.md | Documents the user-visible failure, threshold rationale, reproduction data, and expected compression cost. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ledger): hold a sub-1 KB fold to thr..."](https://github.com/fajarhide/omni/commit/f71df0d52f65a557652b8fecc466925f78f5b8a2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55950652)</sub>

<!-- /greptile_comment -->