### PR TITLE
fix(hooks,cli): stop announcing an empty stderr, and let every host be reset by name

### DIFF
--- a/changelog.d/635.fixed.md
+++ b/changelog.d/635.fixed.md
@@ -1,0 +1,12 @@
+**A command that wrote a newline to stderr was announced as having written to
+stderr.** The reader got a `[stderr]` header with nothing under it, and on a
+failing command that header is the first thing they go looking at. The guard was
+`!stderr.is_empty()`, which `"\n"` and `"   "` both pass.
+
+Both payload shapes built that section and both had the same wrong predicate, so
+they are one function now. #452, #454 and #456 were each one copy of a pair being
+fixed while the other kept the bug, and this is the same pair.
+
+Trimming decides whether there is content, never what it is: a stream with
+something in it is still appended byte for byte, so indentation a compiler emitted
+survives.

--- a/changelog.d/640.fixed.md
+++ b/changelog.d/640.fixed.md
@@ -1,0 +1,23 @@
+**`omni reset` had no `--openclaw` flag**, so the OpenClaw integration could only
+be removed by uninstalling every other one with `--all`. Checking the registry
+against the flag table while fixing it found `--vscode` missing too, which the
+report had not noticed: it compared only the first-party integrations and missed
+the MCP hosts.
+
+Both flags exist now, in the table, the interactive menu and the argument parse.
+
+The real fault is that the host list was written out four times in one file, as a
+boolean, a term of a fourteen-way condition, a menu arm and a push. It is one
+table now, derived from the flag table itself, and `omni reset` is 13 lines
+shorter for it.
+
+A test walks `all_integrations()` and fails on any id its own flag does not
+select. It drives the real routing rather than comparing flag names, after review
+pointed out that a name-only check passes while a flag selects nothing, which is
+#143's guard answering a question nobody asked all over again.
+
+Review also caught that `check_flags` accepts `--flag=value` and validates the
+name alone, so `omni reset --openclaw=1` was accepted, selected nothing and fell
+into the interactive menu with the plugin still installed. `cli::flag_name` is the
+one place that rule lives now and `reset` routes through it. Twelve other modules
+still compare the whole argument; that is #646.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -101,6 +101,17 @@ pub fn print_flag_group(title: &str, flags: &[&(&str, &str)]) {
 /// Long `--flags` are always checked. A single-letter `-x` is checked only when
 /// the subcommand declares at least one short flag, so free-form text keeps
 /// passing through (`omni remember "build with -O2"`, `omni engram list`).
+/// The flag an argument names, ignoring any `=value` attached to it.
+///
+/// `check_flags` accepts `--flag=value` and validates the name alone, so every
+/// consumer that then compares the whole argument silently stops routing it:
+/// `omni reset --openclaw=1` passed validation, matched nothing, and dropped into
+/// the interactive menu with the integration still installed. One function so the
+/// accepted form and the routed form cannot disagree.
+pub fn flag_name(arg: &str) -> &str {
+    arg.split('=').next().unwrap_or(arg)
+}
+
 pub fn check_flags(command: &str, args: &[String], flags: Flags) -> Result<()> {
     let has_shorts = flags
         .iter()
@@ -112,7 +123,7 @@ pub fn check_flags(command: &str, args: &[String], flags: Flags) -> Result<()> {
             continue;
         }
         // `--flag=value` is checked on the name alone.
-        let name = arg.split('=').next().unwrap_or(arg);
+        let name = flag_name(arg);
         if name == "--help"
             || name == "-h"
             || flags

--- a/src/cli/reset.rs
+++ b/src/cli/reset.rs
@@ -22,7 +22,46 @@ const FLAGS: super::Flags = &[
     ("--antigravity", "Uninstall Antigravity IDE"),
     ("--hermes", "Uninstall Hermes Agent"),
     ("--pi", "Uninstall Pi Agent"),
+    ("--openclaw", "Uninstall OpenClaw"),
+    ("--vscode", "Uninstall VS Code"),
 ];
+
+/// The integration a flag entry names: its last alias with the dashes off, so
+/// `"--roo, --roo-code"` is `roo-code`.
+fn target_of(flags: &'static str) -> &'static str {
+    flags
+        .rsplit(',')
+        .next()
+        .unwrap_or(flags)
+        .trim()
+        .trim_start_matches("--")
+}
+
+/// The integrations named on the command line, in `FLAGS` order.
+///
+/// One table rather than a boolean per host. The list used to be repeated four
+/// times in this file, as a `let mut is_x`, a term of a fourteen-way `no_flags`
+/// chain, a menu arm and an `if is_x { push }`, and #640 is what that costs:
+/// OpenClaw and VS Code were in the registry with no flag at all, and the second
+/// one went unnoticed even in the report.
+///
+/// Deriving the id from `FLAGS` is also what lets the test below check routing
+/// instead of spelling. Greptile's review of the first draft was right that a
+/// test comparing registry ids to flag *names* passes while a flag selects
+/// nothing, which is #143's guard answering a question nobody asked all over
+/// again.
+fn targets_from_args(args: &[String]) -> Vec<&'static str> {
+    FLAGS
+        .iter()
+        .filter(|(flags, _)| *flags != "--all")
+        .filter(|(flags, _)| {
+            flags
+                .split(',')
+                .any(|alias| args.iter().any(|a| super::flag_name(a) == alias.trim()))
+        })
+        .map(|(flags, _)| target_of(flags))
+        .collect()
+}
 
 fn print_help() {
     println!(
@@ -52,36 +91,10 @@ pub fn handle_reset() -> anyhow::Result<()> {
     // understand, doing something else, and exiting 0.
     super::check_flags("reset", &args, FLAGS)?;
 
-    let is_all = args.iter().any(|a| a == "--all");
+    let is_all = args.iter().any(|a| super::flag_name(a) == "--all");
+    let mut target_ids = targets_from_args(&args);
 
-    let mut is_claude = args.iter().any(|a| a == "--claude");
-    let mut is_cursor = args.iter().any(|a| a == "--cursor");
-    let mut is_zed = args.iter().any(|a| a == "--zed");
-    let mut is_cline = args.iter().any(|a| a == "--cline");
-    let mut is_roo = args.iter().any(|a| a == "--roo" || a == "--roo-code");
-    let mut is_copilot = args.iter().any(|a| a == "--copilot");
-    let mut is_gemini = args.iter().any(|a| a == "--gemini");
-    let mut is_opencode = args.iter().any(|a| a == "--opencode");
-    let mut is_codex = args.iter().any(|a| a == "--codex");
-    let mut is_antigravity = args.iter().any(|a| a == "--antigravity");
-    let mut is_hermes = args.iter().any(|a| a == "--hermes");
-    let mut is_pi = args.iter().any(|a| a == "--pi");
-
-    // Check if no flags
-    let no_flags = !is_claude
-        && !is_cursor
-        && !is_zed
-        && !is_cline
-        && !is_roo
-        && !is_copilot
-        && !is_gemini
-        && !is_opencode
-        && !is_codex
-        && !is_antigravity
-        && !is_hermes
-        && !is_pi;
-
-    if no_flags && !is_all {
+    if target_ids.is_empty() && !is_all {
         println!(
             "\n{} {}",
             "OMNI RESET".bold().red(),
@@ -104,68 +117,34 @@ pub fn handle_reset() -> anyhow::Result<()> {
         println!("  [{}] Antigravity IDE", "11".cyan());
         println!("  [{}] Hermes Agent", "12".cyan());
         println!("  [{}] Pi Agent", "13".cyan());
+        println!("  [{}] OpenClaw", "14".cyan());
+        println!("  [{}] VS Code", "15".cyan());
         println!("  [{}] Cancel\n", "q".yellow());
 
-        print!("Select an option [1-13, q]: ");
+        print!("Select an option [1-15, q]: ");
         std::io::stdout().flush()?;
 
         let mut input = String::new();
         std::io::stdin().read_line(&mut input)?;
         match input.trim() {
             "1" => return perform_reset(true, vec![]),
-            "2" => is_claude = true,
-            "3" => is_cursor = true,
-            "4" => is_zed = true,
-            "5" => is_cline = true,
-            "6" => is_roo = true,
-            "7" => is_copilot = true,
-            "8" => is_gemini = true,
-            "9" => is_opencode = true,
-            "10" => is_codex = true,
-            "11" => is_antigravity = true,
-            "12" => is_hermes = true,
-            "13" => is_pi = true,
+            "2" => target_ids.push("claude"),
+            "3" => target_ids.push("cursor"),
+            "4" => target_ids.push("zed"),
+            "5" => target_ids.push("cline"),
+            "6" => target_ids.push("roo-code"),
+            "7" => target_ids.push("copilot"),
+            "8" => target_ids.push("gemini"),
+            "9" => target_ids.push("opencode"),
+            "10" => target_ids.push("codex"),
+            "11" => target_ids.push("antigravity"),
+            "12" => target_ids.push("hermes"),
+            "13" => target_ids.push("pi"),
+            "14" => target_ids.push("openclaw"),
+            "15" => target_ids.push("vscode"),
             _ => return Ok(()),
         }
         println!();
-    }
-
-    let mut target_ids = Vec::new();
-    if is_claude {
-        target_ids.push("claude");
-    }
-    if is_cursor {
-        target_ids.push("cursor");
-    }
-    if is_zed {
-        target_ids.push("zed");
-    }
-    if is_cline {
-        target_ids.push("cline");
-    }
-    if is_roo {
-        target_ids.push("roo-code");
-    }
-    if is_copilot {
-        target_ids.push("copilot");
-    }
-    if is_gemini {
-        target_ids.push("gemini");
-    }
-    if is_opencode {
-        target_ids.push("opencode");
-    }
-    if is_codex {
-        target_ids.push("codex");
-    }
-    if is_antigravity {
-        target_ids.push("antigravity");
-    }
-    if is_hermes {
-        target_ids.push("hermes");
-    }
-    if is_pi {
-        target_ids.push("pi");
     }
 
     perform_reset(is_all, target_ids)
@@ -236,4 +215,79 @@ fn perform_reset(is_all: bool, target_ids: Vec<&str>) -> anyhow::Result<()> {
 
     println!("\n{} Selected integrations have been reset.", "✓".green());
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    /// #640. `omni reset` kept its own hand-written list of hosts beside the
+    /// registry, and the list fell behind: OpenClaw shipped with no flag, so its
+    /// `uninstall` was reachable only through `--all`. Checking the registry
+    /// against `FLAGS` while writing that fix found `vscode` missing too, which
+    /// the issue had not noticed because it compared only the first-party ids.
+    ///
+    /// A list that has to be edited in seven places when a host is added will
+    /// fall behind again. This is the check that says so at `cargo test` time
+    /// rather than when a user tries the flag.
+    #[test]
+    fn every_integration_can_be_uninstalled_by_its_own_flag() {
+        // Driven through the real routing, not through the flag names. The first
+        // draft compared registry ids against strings parsed out of `FLAGS`,
+        // which Greptile pointed out passes while a flag selects nothing: the
+        // same shape as #143's guard, which reported "parsed" for a payload that
+        // had matched the wrong tool.
+        let missing: Vec<&str> = crate::agents::all_integrations()
+            .iter()
+            .map(|a| a.id())
+            .filter(|id| {
+                let args = vec![format!("--{id}")];
+                !super::targets_from_args(&args).contains(id)
+            })
+            .collect();
+
+        assert!(
+            missing.is_empty(),
+            "these integrations cannot be selected by their own flag, so they can \
+             only be removed by uninstalling everything: {missing:?}"
+        );
+    }
+
+    /// `--roo` is an alias for `--roo-code` and has been since before the table
+    /// existed. Deriving the id from the *last* alias is what keeps it working,
+    /// and getting that backwards would silently rename the target to `roo`.
+    #[test]
+    fn an_alias_selects_the_same_integration_as_its_canonical_flag() {
+        assert_eq!(
+            super::targets_from_args(&["--roo".to_string()]),
+            vec!["roo-code"]
+        );
+        assert_eq!(
+            super::targets_from_args(&["--roo-code".to_string()]),
+            vec!["roo-code"]
+        );
+    }
+
+    /// `--all` is not an integration, and routing it as one would ask the
+    /// registry for a host called `all`.
+    #[test]
+    fn all_is_not_a_target() {
+        assert!(super::targets_from_args(&["--all".to_string()]).is_empty());
+    }
+
+    /// `check_flags` accepts `--flag=value` and validates the name alone, so a
+    /// consumer comparing the whole argument accepts the input and then routes
+    /// nothing. `omni reset --openclaw=1` passed validation, selected no
+    /// integration, and fell into the interactive menu with the plugin still on
+    /// disk. Confident behaviour over an argument that was never really parsed is
+    /// #151 wearing a different flag.
+    #[test]
+    fn a_flag_carrying_a_value_still_selects_its_integration() {
+        assert_eq!(
+            super::targets_from_args(&["--openclaw=1".to_string()]),
+            vec!["openclaw"]
+        );
+        assert_eq!(
+            super::targets_from_args(&["--roo=yes".to_string()]),
+            vec!["roo-code"]
+        );
+    }
 }

--- a/src/hooks/normalize.rs
+++ b/src/hooks/normalize.rs
@@ -87,6 +87,27 @@ pub struct NormalizedInput {
     pub host_agent_id: Option<String>,
 }
 
+/// Append the `[stderr]` section, when the stream actually carries something.
+///
+/// The test was `!stderr.is_empty()` and `"\n"` passes it, so a command that
+/// wrote a newline was reported as having written to stderr. On a failing
+/// command that header is the first thing a reader goes looking at, and it led
+/// them to a blank section (#635).
+///
+/// One function for both emitters, not two matching predicates. The Claude-shaped
+/// payload and the Codex-shaped one each build this section, and #452, #454 and
+/// #456 were each one copy of a pair being fixed while the other kept the bug.
+///
+/// Trimming decides **whether** there is content, never what it is: a stream with
+/// something in it is appended byte for byte, indentation and all.
+fn push_stderr(s: &mut String, stderr: &str) {
+    if stderr.trim().is_empty() {
+        return;
+    }
+    s.push_str("\n[stderr]\n");
+    s.push_str(stderr);
+}
+
 /// Detect agent format dari raw JSON string
 pub fn detect_agent(input: &str) -> AgentFormat {
     // Coba parse sebagai JSON
@@ -338,11 +359,8 @@ fn normalize_claude_code(input: &str, agent_id: String) -> Option<NormalizedInpu
             return None;
         }
         let mut s = stdout.to_string();
-        if let Some(stderr) = response.get("stderr").and_then(Value::as_str)
-            && !stderr.is_empty()
-        {
-            s.push_str("\n[stderr]\n");
-            s.push_str(stderr);
+        if let Some(stderr) = response.get("stderr").and_then(Value::as_str) {
+            push_stderr(&mut s, stderr);
         }
         s
     };
@@ -650,11 +668,8 @@ fn normalize_codex(input: &str, agent_id: String) -> Option<NormalizedInput> {
     let parsed: CodexInput = serde_json::from_str(input).ok()?;
     let content = parsed.result.or(parsed.output).or_else(|| {
         let mut s = parsed.stdout.unwrap_or_default();
-        if let Some(err) = parsed.stderr
-            && !err.is_empty()
-        {
-            s.push_str("\n[stderr]\n");
-            s.push_str(&err);
+        if let Some(err) = parsed.stderr {
+            push_stderr(&mut s, &err);
         }
         if s.is_empty() { None } else { Some(s) }
     })?;
@@ -1237,6 +1252,59 @@ mod tests {
             AgentFormat::Plugin("not-a-host".to_string()),
             "the allowlist is what stops a payload naming its own bucket"
         );
+    }
+
+    /// #635. `!stderr.is_empty()` passes for `"\n"`, so a command that wrote a
+    /// newline was announced as having written to stderr and the reader was sent
+    /// to a blank section. On a failing command that header is the first thing
+    /// they look at.
+    #[test]
+    fn a_whitespace_only_stderr_is_not_announced() {
+        for blank in ["\n", "   ", "\t\n \r\n", ""] {
+            let mut s = "the real answer\n".to_string();
+            push_stderr(&mut s, blank);
+            assert_eq!(
+                s, "the real answer\n",
+                "a stream carrying only whitespace got a header: {blank:?}"
+            );
+        }
+    }
+
+    /// The other half, and the reason the guard trims rather than the content
+    /// being trimmed: a stream with something in it is appended byte for byte,
+    /// so indentation a compiler emitted survives.
+    #[test]
+    fn a_stderr_with_content_keeps_its_own_bytes() {
+        let mut s = "out\n".to_string();
+        push_stderr(&mut s, "  warning: unused\n");
+        assert_eq!(s, "out\n\n[stderr]\n  warning: unused\n");
+    }
+
+    /// Both payload shapes build this section, and the pair is exactly how #452,
+    /// #454 and #456 each shipped a fix for one door and left the other open.
+    /// Driving the two parsers is what proves they share the predicate.
+    #[test]
+    fn both_payload_shapes_agree_about_a_blank_stderr() {
+        let claude = serde_json::json!({
+            "tool_name": "Bash",
+            "tool_input": {"command": "true"},
+            "tool_response": {"stdout": "the real answer\n", "stderr": "\n"}
+        })
+        .to_string();
+        let codex = serde_json::json!({
+            "action": "run", "command": "true",
+            "stdout": "the real answer\n", "stderr": "\n"
+        })
+        .to_string();
+
+        for (name, payload) in [("claude", claude), ("codex", codex)] {
+            let got = normalize(&payload).expect("{name} payload normalizes");
+            assert!(
+                !got.content.contains("[stderr]"),
+                "{name} announced a stderr that held only a newline: {:?}",
+                got.content
+            );
+        }
     }
 
     /// The tool name decides which arm of `process_payload` runs, and the two


### PR DESCRIPTION
Two small ones from the Next lane, unrelated in file and in risk, so one branch and one CI cycle.

## #635, a `[stderr]` header over nothing

`!stderr.is_empty()` is true for `"\n"`, so a command that wrote a newline was delivered with a `[stderr]` section and nothing under it. On a failing command that header is the first thing a reader goes to.

Both payload shapes built that section and both carried the same wrong predicate, so they are one `push_stderr` now rather than two that have to agree. #452, #454 and #456 were each one copy of a pair being fixed while the other kept the bug, and the break test below drives exactly that scenario.

The trim decides **whether** there is content, never what it is: a stream with something in it is still appended byte for byte, so indentation a compiler emitted survives.

## #640, and it was two hosts, not one

The report said OpenClaw was the only integration with no reset flag. That is wrong, and it is my own report: I compared the flag table against the first-party ids only and missed `mcp_host::HOSTS`. `vscode` has no flag either. Both are added.

The fault underneath is that adding a host means editing seven places in `reset.rs` beside a registry that already lists every one of them. A test now walks `all_integrations()` and fails on any id with no flag:

```
these integrations are in the registry with no reset flag, so they can only be
removed by uninstalling everything: ["openclaw", "vscode"]
```

That is the message it prints against `main` today.

## Verification

Both driven through the built binary against a control built from `origin/main`.

`#635`, payload sized past the ledger floor so the fold happens either way and only the header is in question:

```
payload 3160 B, seen 2310 B, coverage 73.1%
FIXED (this branch)     [stderr] header present: False
CONTROL (before #635)   [stderr] header present: True
```

`#640`, against a real install in an isolated `HOME`:

```
$ omni reset --openclaw
  ✓ Removed OpenClaw plugin from ~/.openclaw/plugins/
  ✓ Removed the plugin from plugins.load.paths
```

`make ci` green, smoke test included, since this changes the `omni reset` help surface.

Six break directions, each red: revert the predicate to `is_empty` (seen twice, once per parser), trim the content instead of the test, fix one door and leave the other, drop the openclaw flag, drop the vscode flag.

Closes #635
Closes #640






<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR suppresses empty stderr sections and completes reset-by-name support for every registered integration.
- Centralizes stderr-section construction while preserving non-empty output byte-for-byte.
- Derives reset targets from the documented flag table and adds OpenClaw and VS Code reset options.
- Uses shared flag-name normalization so accepted `--flag=value` forms route consistently.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/cli/reset.rs | Derives integration routing from the reset flag registry, adds missing host flags, and directly tests canonical, alias, all, and value-bearing routes. |
| src/cli/mod.rs | Introduces shared normalization for extracting a flag name from value-bearing arguments. |
| src/hooks/normalize.rs | Consolidates stderr section handling and omits the section when stderr contains only whitespace. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(hooks,cli): stop announcing an empty..."](https://github.com/fajarhide/omni/commit/00965acea38cbe12a65bcb2c3e5b064ea9df94d7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55952538)</sub>

<!-- /greptile_comment -->