### PR TITLE
fix(ci,docs): pin every action to a SHA, attest the release, and stop asking for public disclosure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,22 +21,22 @@ jobs:
     name: make ci (ubuntu)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       # Pinned rather than `stable`. `rust-toolchain.toml` pins 1.97.0, so asking
       # for `stable` made rustup fetch a second toolchain that was then never
       # used. Keep this in step with the pin, the way `release.yml` has to (#179).
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
           toolchain: "1.97.0"
           components: rustfmt, clippy
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
 
       # Prebuilt binaries. `cargo install --locked` compiled both of these from
       # source on every run, minutes of a 13 minute job spent rebuilding tools
       # that publish releases (#179).
-      - uses: taiki-e/install-action@v2.86.1
+      - uses: taiki-e/install-action@288e746965032cfcc232e09af2daf5f23c14d780 # v2.86.1
         with:
           tool: cargo-insta,cargo-audit
 
@@ -56,13 +56,13 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
           toolchain: "1.97.0"
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
 
       - name: Run tests
         run: cargo test --all
@@ -74,9 +74,9 @@ jobs:
     # theirs.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "22"
           cache: npm
@@ -103,9 +103,9 @@ jobs:
     # types rather than a hand-copied stub.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "22"
           cache: npm
@@ -126,9 +126,9 @@ jobs:
     # real file now and this is the job that compiles it.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
 
@@ -146,7 +146,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           # The merge base is not in a shallow clone, and without it the script
           # would see the whole manual as changed on every run.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,10 +34,16 @@ jobs:
             binary: omni.exe
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: dtolnay/rust-toolchain@stable
+      # The toolchain used to be chosen by the ref (`@stable`). Pinning the
+      # action to a SHA means the version has to be named, and naming it is the
+      # honest form anyway: `rust-toolchain.toml` pins 1.97.0 and rustup prefers
+      # that file, so `@stable` fetched a whole toolchain that was then never
+      # used, and the two could drift apart without anything saying so (#179).
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
+          toolchain: "1.97.0"
           targets: ${{ matrix.target }}
 
       - name: Install musl tools (Linux x86_64)
@@ -46,7 +52,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y musl-tools
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           key: ${{ matrix.target }}
 
@@ -56,7 +62,7 @@ jobs:
 
       - name: Build release (Linux)
         if: runner.os == 'Linux'
-        uses: houseabsolute/actions-rust-cross@v1
+        uses: houseabsolute/actions-rust-cross@85826e468eac832e251ac58f6191ba784db237c8 # v1
         with:
           command: build
           target: ${{ matrix.target }}
@@ -81,7 +87,7 @@ jobs:
           fi
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: omni-${{ matrix.target }}
           path: dist/omni-${{ github.ref_name }}-${{ matrix.target }}.*
@@ -90,11 +96,20 @@ jobs:
     name: Create Release
     needs: build
     runs-on: ubuntu-latest
+    # `id-token` and `attestations` are what let this job sign a statement that
+    # these bytes came from this workflow at this commit. `SHA256SUMS` only says
+    # a file has not changed since it was published; it cannot say who published
+    # it, which is the question that matters for a binary sitting in the hook
+    # path of every command a developer runs (#632).
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: artifacts
 
@@ -112,8 +127,15 @@ jobs:
           echo "=== SHA256SUMS ==="
           cat SHA256SUMS
 
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4
+        with:
+          subject-path: |
+            release/*.tar.gz
+            release/*.zip
+
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           generate_release_notes: true
           files: |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,28 +2,29 @@
 
 ## Supported Versions
 
-Security updates are applied to the latest release on the `main` branch.
+Fixes go into the next release off `main`. Only the current minor line gets them.
 
 | Version | Supported          |
 | ------- | ------------------ |
-| v0.5.x  | :white_check_mark: |
-| v0.4.x  | :x:                |
-| v0.3.x  | :x:                |
-| v0.2.x  | :x:                |
+| 0.7.x   | :white_check_mark: |
+| 0.6.x   | :x:                |
+| 0.5.x   | :x:                |
 
 ## Reporting a Vulnerability
 
-We take the security of OMNI seriously. If you discover a vulnerability, you can report it to us through one of the following channels:
+**Do not open a public issue.** OMNI runs in the hook path of every command a
+developer types, so a report needs an embargo until there is a release to upgrade
+to.
 
-1. **GitHub Issues (Recommended)**: Create an issue at [https://github.com/fajarhide/omni/issues](https://github.com/fajarhide/omni/issues). *(If the vulnerability is critical, you can also use GitHub's private vulnerability reporting feature if enabled on the repository).*
-2. **Email us**: Send a detailed report to [security@weekndlabs.com](mailto:security@weekndlabs.com).
+1. **[Report a vulnerability privately](https://github.com/fajarhide/omni/security/advisories/new)**.
+   GitHub's private reporting is enabled on this repository, and the thread stays
+   between you and the maintainer.
+2. **Email** [security@weekndlabs.com](mailto:security@weekndlabs.com) if you would
+   rather not use GitHub.
 
-For either method, please include:
-- A description of the issue.
-- Steps to reproduce.
-- Potential impact.
+Please include a description, steps to reproduce, and what an attacker gets.
 
-We will acknowledge your report within 48 hours and provide a timeline for a fix.
+You will get an acknowledgement within 48 hours and a timeline with it.
 
 ## Security Considerations
 
@@ -31,6 +32,18 @@ We will acknowledge your report within 48 hours and provide a timeline for a fix
 - **Local SQLite Persistence**: Usage stats and archived contexts are stored locally in the SQLite database `~/.omni/omni.db`. **No data ever leaves your machine.**
 - **MCP Server**: The MCP server runs locally via `stdio` transport and does not expose any network ports.
 - **`omni update`**: Only reads the public GitHub Releases API (no authentication required) to download the latest binary. No data is uploaded.
+
+## Verifying a Release
+
+Every release archive carries a signed statement of which workflow built it and
+from which commit. `SHA256SUMS` only proves a file has not changed since it was
+published; provenance is what says who published it.
+
+```bash
+gh attestation verify omni-v0.7.7-aarch64-apple-darwin.tar.gz --repo fajarhide/omni
+```
+
+Releases from 0.7.7 onward are attested. Anything older has `SHA256SUMS` only.
 
 ---
 

--- a/changelog.d/632.fixed.md
+++ b/changelog.d/632.fixed.md
@@ -1,0 +1,26 @@
+**Every workflow action was pinned to a mutable ref, so a compromise upstream
+would have been published under our name.** `dtolnay/rust-toolchain@master` is a
+branch, and a tag like `actions/checkout@v7` can be repointed at will. That is the
+`tj-actions/changed-files` shape, and `release.yml` is what builds the binaries
+Homebrew then distributes. All 22 `uses:` lines across the workflows are full
+commit SHAs now, with the version in a trailing comment so Dependabot still opens
+the bump PRs.
+
+Pinning `dtolnay/rust-toolchain` is not a pure rename: that action chooses the
+toolchain from its own ref, and at the pinned commit `toolchain` is a **required
+input**, so a SHA with no input fails the build outright. Every call names
+`1.97.0` now, which is what `rust-toolchain.toml` pins anyway. `release.yml` used
+to ask for `stable` and then have rustup switch to the pinned channel underneath
+it, which is the mismatch that produced no binaries at all for v0.6.2 (#179).
+
+**Releases carry build provenance.** `SHA256SUMS` proves a file has not changed
+since publication and says nothing about who published it, which is the question
+that matters for a binary in the hook path of every command. The release job
+attests its archives, and `SECURITY.md` documents the one-line
+`gh attestation verify` a user runs. Releases from 0.7.7 onward are attested.
+
+**`SECURITY.md` told reporters to open a public issue**, listed as "Recommended",
+and claimed 0.5.x was the supported line while 0.7.6 was out. A reader taking it
+at its word would publish a working exploit against a tool sitting in front of
+every shell command, with no embargo and no release to upgrade to. Private
+reporting is first and the public-issue route is gone; the table names 0.7.x.


### PR DESCRIPTION
Three defects in how OMNI reaches users and how problems reach OMNI, all in `.github/` and `SECURITY.md`.

## Pinning

All 22 `uses:` lines are full commit SHAs, version kept in a trailing comment so Dependabot still opens the bump PRs.

```
$ grep -rn "uses: " .github/workflows/ | grep -vc "@[0-9a-f]\{40\}"
0
```

`dtolnay/rust-toolchain` was not a rename. That action picks the toolchain from its own ref, and at the pinned commit the input is required:

```
$ curl -sL .../6c977a6/action.yml | sed -n '36,38p'
        if [[ -z $toolchain ]]; then
          echo "'toolchain' is a required input" >&2
```

So a bare SHA would have failed the release build. Every call names `1.97.0`, which `rust-toolchain.toml` pins anyway. `release.yml` previously asked for `stable` and let rustup switch to the pinned channel underneath it, which is the mismatch that produced no binaries at all for v0.6.2 (#179).

## Provenance

The release job gets `id-token: write` and `attestations: write` and attests its archives before publishing them. `SHA256SUMS` proves a file has not changed since publication; it cannot say who published it, and that is the question for a binary in the hook path of every command.

`SECURITY.md` documents the check a user runs:

```bash
gh attestation verify omni-v0.7.7-aarch64-apple-darwin.tar.gz --repo fajarhide/omni
```

## Disclosure

`SECURITY.md` listed **GitHub Issues (Recommended)** first, which asks for full public disclosure with no embargo, and its table said 0.5.x was supported while 0.7.6 was out. A reader following it would publish a working exploit against a tool sitting in front of every shell command, and might not report at all after reading that their version is unsupported.

Private reporting is first and links straight to the advisory form, the public-issue route is gone, and the table names 0.7.x. Private vulnerability reporting is already enabled on the repository, checked rather than assumed:

```
$ gh api repos/fajarhide/omni/private-vulnerability-reporting
{"enabled":true}
```

## Verification

The issue's own three checks: zero unpinned `uses:`, provenance present, `SECURITY.md` head rewritten.

All three workflows parsed rather than eyeballed, and every toolchain step asserted to name its version, since that is the one that fails a release and not CI:

```
ci.yml/ci:            toolchain="1.97.0"
ci.yml/test-matrix:   toolchain="1.97.0"
release.yml/build:    toolchain="1.97.0"
```

The provenance step itself cannot be verified before a tag exists. First attested release is 0.7.7, and `SECURITY.md` says so rather than implying older ones carry it.

Closes #632


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR hardens CI and release workflows by pinning third-party actions, aligning Rust toolchain selection, and adding provenance attestations. It also updates the security policy to direct vulnerability reports through private channels and accurately document supported and attested releases.
- Pins every workflow action reference to a full commit SHA.
- Explicitly configures Rust 1.97.0 throughout CI and release builds.
- Attests release archives before publishing them.
- Updates supported-version, private-disclosure, and release-verification guidance.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or non-blocking defects identified in the changed paths.

The pinned workflow references and explicit toolchain inputs align with repository configuration, release archives reach the attestation step under the documented names, and the security guidance matches the configured release flow and current version line.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Pins all CI actions to immutable SHAs and consistently selects the repository’s Rust 1.97.0 toolchain. |
| .github/workflows/release.yml | Pins release actions, aligns cross-platform builds with Rust 1.97.0, and attests collected archives before publication. |
| SECURITY.md | Updates the supported release line, prioritizes private vulnerability reporting, and documents provenance verification beginning with 0.7.7. |
| changelog.d/632.fixed.md | Accurately records the workflow supply-chain, provenance, and disclosure-policy changes. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Tag as Tag push
    participant Build as Matrix build jobs
    participant Artifacts as GitHub artifacts
    participant Release as Release job
    participant Attest as Provenance attestation
    participant GH as GitHub Release
    Tag->>Build: "Trigger v* workflow"
    Build->>Build: Build and package archives
    Build->>Artifacts: Upload archives and checksums
    Artifacts->>Release: Download all artifacts
    Release->>Release: Collect files and generate SHA256SUMS
    Release->>Attest: Attest tar.gz and zip archives
    Attest-->>Release: Signed provenance
    Release->>GH: Publish archives and SHA256SUMS
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci,docs): pin every action to a SHA,..."](https://github.com/fajarhide/omni/commit/a61317bd9fb8227b6b43fe0ee6822bb36bb8f9d1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55956895)</sub>

<!-- /greptile_comment -->