### PR TITLE
fix(cli): make --flag=value mean what it says, in every command

### DIFF
--- a/changelog.d/646.fixed.md
+++ b/changelog.d/646.fixed.md
@@ -1,0 +1,38 @@
+**`--flag=value` was accepted and then ignored, in every command.** `check_flags`
+validates that form on the flag name alone, and all sixty call sites compared the
+whole argument, so the flag passed validation and the command behaved as if it
+were absent.
+
+For a boolean flag that means the wrong mode: `omni version --json=1` printed the
+human banner, and `omni init --openclaw=1` exited 0 having installed nothing.
+
+For a flag that takes a value it is worse, because the command succeeds and
+answers about something else:
+
+```
+$ omni dashboard --port=18877
+  OMNI dashboard http://127.0.0.1:7717     # before
+  OMNI dashboard http://127.0.0.1:18877    # after
+```
+
+`omni patterns --tool=bash` filtered on nothing the same way.
+
+Two helpers now hold the rule, `has_flag` and `flag_value`, and every command uses
+them. `flag_value` reads both `--port 8080` and `--port=8080`, and splits on the
+first `=` only, so a value containing one survives.
+
+A test scans `src/cli/` and fails on any argument compared to a flag directly.
+Sixty sites across twelve commands is what it took to notice, and each was correct
+on its own and wrong against `check_flags`, so the guard is that nobody writes the
+raw form again. It found one leftover while being written.
+
+Review found two the first pass missed, both now covered. `stats` kept its own
+matcher for the windows that grew alternative spellings (`--day` / `--today`), and
+because it compared against a parameter rather than a flag literal the source scan
+could not see it, so `--hour=1` still selected the default overview. That copy is
+deleted and the shared `has_any` replaces it.
+
+And routing the positional word `help` through `has_flag` widened it: `help=x`
+started triggering the help page. `help` is now matched exactly and only as a
+subcommand's first argument, which also fixes something older than this change,
+`omni query how do i get help` printed the help page instead of answering.

--- a/src/cli/dashboard.rs
+++ b/src/cli/dashboard.rs
@@ -38,16 +38,15 @@ fn print_help() {
 }
 
 pub fn run(args: &[String], store: &Store) -> Result<()> {
-    if args.iter().any(|a| a == "--help" || a == "-h") {
+    if super::has_flag(args, "--help") || super::has_flag(args, "-h") {
         print_help();
         return Ok(());
     }
     super::check_flags("dashboard", args, FLAGS)?;
 
-    let port = args
-        .iter()
-        .position(|a| a == "--port")
-        .and_then(|i| args.get(i + 1))
+    // `--port=8080` used to bind `DEFAULT_PORT` and say nothing: `check_flags`
+    // accepted the argument and the lookup below never matched it (#646).
+    let port = super::flag_value(args, "--port")
         .and_then(|v| v.parse::<u16>().ok())
         .unwrap_or(DEFAULT_PORT);
 

--- a/src/cli/diff.rs
+++ b/src/cli/diff.rs
@@ -12,10 +12,7 @@ fn print_help() {
 }
 
 pub fn run_diff(args: &[String]) -> Result<()> {
-    if args
-        .iter()
-        .any(|a| a == "--help" || a == "-h" || a == "help")
-    {
+    if super::wants_help(args) {
         print_help();
         return Ok(());
     }

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -117,7 +117,7 @@ pub(crate) fn mcp_tool_line(agent_id: &str, keep_everything: bool) -> String {
 }
 
 fn run_json(args: &[String]) -> anyhow::Result<()> {
-    let fix_mode = args.iter().any(|a| a == "--fix");
+    let fix_mode = super::has_flag(args, "--fix");
     let mut checks = Vec::new();
     let mut all_ok = true;
     let mut fix_available = false;
@@ -302,21 +302,18 @@ fn condense_agent_report(report: &str, tier: &str, detail: bool) -> String {
 }
 
 pub fn run(args: &[String]) -> anyhow::Result<()> {
-    if args
-        .iter()
-        .any(|a| a == "--help" || a == "-h" || a == "help")
-    {
+    if super::wants_help(args) {
         print_help();
         return Ok(());
     }
     super::check_flags("doctor", args, FLAGS)?;
 
-    if args.iter().any(|a| a == "--json") {
+    if super::has_flag(args, "--json") {
         return run_json(args);
     }
 
-    let fix_mode = args.iter().any(|a| a == "--fix");
-    let detail = args.iter().any(|a| a == "--detail");
+    let fix_mode = super::has_flag(args, "--fix");
+    let detail = super::has_flag(args, "--detail");
 
     let mut all_ok = true;
     let mut warnings: Vec<String> = Vec::new();

--- a/src/cli/engram.rs
+++ b/src/cli/engram.rs
@@ -27,10 +27,7 @@ pub struct EngramJson {
 const FLAGS: super::Flags = &[("--json", "Machine-readable JSON output")];
 
 pub fn run_engram(args: &[String], store: Arc<Store>) -> anyhow::Result<()> {
-    if args
-        .iter()
-        .any(|a| a == "--help" || a == "-h" || a == "help")
-    {
+    if super::wants_help(args) {
         println!("\nomni engram: View engrams (subtask digests)\n");
         println!("USAGE:\n  omni engram [list] [FLAGS]\n");
         super::print_flags(FLAGS);
@@ -38,8 +35,8 @@ pub fn run_engram(args: &[String], store: Arc<Store>) -> anyhow::Result<()> {
     }
     super::check_flags("engram", args, FLAGS)?;
 
-    let is_json = args.iter().any(|a| a == "--json");
-    let is_list = args.iter().any(|a| a == "list");
+    let is_json = super::has_flag(args, "--json");
+    let is_list = super::has_flag(args, "list");
 
     if is_json && is_list {
         let state = match store.find_latest_session() {

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -128,35 +128,32 @@ fn non_interactive_host() -> anyhow::Result<&'static str> {
 }
 
 pub fn run_init(args: &[String]) -> anyhow::Result<()> {
-    if args
-        .iter()
-        .any(|a| a == "--help" || a == "-h" || a == "help")
-    {
+    if super::wants_help(args) {
         print_help();
         return Ok(());
     }
     super::check_flags("init", args, FLAGS)?;
 
-    let mut is_claude = args.iter().any(|a| a == "--claude");
-    let mut is_cursor = args.iter().any(|a| a == "--cursor");
-    let mut is_zed = args.iter().any(|a| a == "--zed");
-    let mut is_cline = args.iter().any(|a| a == "--cline");
-    let mut is_roo = args.iter().any(|a| a == "--roo" || a == "--roo-code");
-    let mut is_copilot = args.iter().any(|a| a == "--copilot");
-    let mut is_gemini = args.iter().any(|a| a == "--gemini");
-    let mut is_opencode = args.iter().any(|a| a == "--opencode");
-    let mut is_codex = args.iter().any(|a| a == "--codex");
-    let mut is_openclaw = args.iter().any(|a| a == "--openclaw");
-    let mut is_antigravity = args.iter().any(|a| a == "--antigravity");
-    let mut is_hermes = args.iter().any(|a| a == "--hermes");
-    let mut is_vscode = args.iter().any(|a| a == "--vscode");
-    let mut is_pi = args.iter().any(|a| a == "--pi");
+    let mut is_claude = super::has_flag(args, "--claude");
+    let mut is_cursor = super::has_flag(args, "--cursor");
+    let mut is_zed = super::has_flag(args, "--zed");
+    let mut is_cline = super::has_flag(args, "--cline");
+    let mut is_roo = super::has_flag(args, "--roo") || super::has_flag(args, "--roo-code");
+    let mut is_copilot = super::has_flag(args, "--copilot");
+    let mut is_gemini = super::has_flag(args, "--gemini");
+    let mut is_opencode = super::has_flag(args, "--opencode");
+    let mut is_codex = super::has_flag(args, "--codex");
+    let mut is_openclaw = super::has_flag(args, "--openclaw");
+    let mut is_antigravity = super::has_flag(args, "--antigravity");
+    let mut is_hermes = super::has_flag(args, "--hermes");
+    let mut is_vscode = super::has_flag(args, "--vscode");
+    let mut is_pi = super::has_flag(args, "--pi");
 
-    let mut is_hook = args.iter().any(|a| a == "--hook");
-    let mut is_mcp = args.iter().any(|a| a == "--mcp");
-    let is_all = args.iter().any(|a| a == "--all");
-    let is_status = args.iter().any(|a| a == "--status");
-    let is_uninstall = args.iter().any(|a| a == "--uninstall");
+    let mut is_hook = super::has_flag(args, "--hook");
+    let mut is_mcp = super::has_flag(args, "--mcp");
+    let is_all = super::has_flag(args, "--all");
+    let is_status = super::has_flag(args, "--status");
+    let is_uninstall = super::has_flag(args, "--uninstall");
 
     if is_all {
         is_claude = true;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -112,6 +112,61 @@ pub fn flag_name(arg: &str) -> &str {
     arg.split('=').next().unwrap_or(arg)
 }
 
+/// Is this flag present, in either accepted spelling?
+///
+/// `check_flags` validates `--flag=value` on the name alone, so a caller
+/// comparing the whole argument accepts the input and then behaves as if the
+/// flag were absent. Every command in this CLI had that shape: `omni reset
+/// --openclaw=1` dropped into the interactive menu with the plugin installed,
+/// and `omni init --openclaw=1` exited 0 having installed nothing (#646).
+///
+/// Use this rather than `args.iter().any(|a| a == "--flag")`. There is a test in
+/// this module that fails on the raw form, because sixty of them is what it took
+/// to notice.
+pub fn has_flag(args: &[String], flag: &str) -> bool {
+    args.iter().any(|a| flag_name(a) == flag)
+}
+
+/// Is any of these spellings present? For a flag that grew alternatives.
+///
+/// `stats` had its own copy of this comparing whole arguments, which is how
+/// `--hour=1` survived the first pass of #646: the source scan below looks for a
+/// flag literal, and a helper comparing against a `&[&str]` parameter has none.
+/// Deleting that copy is the fix, not widening the scan.
+pub fn has_any(args: &[String], flags: &[&str]) -> bool {
+    flags.iter().any(|f| has_flag(args, f))
+}
+
+/// Did the caller ask for help?
+///
+/// `--help`, `-h`, or `help` as the **first argument to the subcommand**. Every
+/// command used to test `help` anywhere in argv, so `omni query how do i get
+/// help` printed the help page instead of answering, and routing that word
+/// through `has_flag` made `help=notes.txt` do it too. Position is what separates
+/// the subcommand from its payload.
+pub fn wants_help(args: &[String]) -> bool {
+    has_flag(args, "--help") || has_flag(args, "-h") || args.get(2).is_some_and(|a| a == "help")
+}
+
+/// The value given to a flag, as `--flag value` or `--flag=value`.
+///
+/// The `=` form used to be accepted by `check_flags` and then never found, so
+/// `omni dashboard --port=8080` bound the default port and said nothing, and
+/// `omni patterns --tool=bash` filtered on nothing. Silently doing something
+/// other than what the argument said is worse here than for a boolean flag: the
+/// command succeeds and the answer is about something else.
+pub fn flag_value<'a>(args: &'a [String], flag: &str) -> Option<&'a str> {
+    args.iter().enumerate().find_map(|(i, a)| {
+        if flag_name(a) != flag {
+            return None;
+        }
+        match a.split_once('=') {
+            Some((_, v)) => Some(v),
+            None => args.get(i + 1).map(String::as_str),
+        }
+    })
+}
+
 pub fn check_flags(command: &str, args: &[String], flags: Flags) -> Result<()> {
     let has_shorts = flags
         .iter()
@@ -253,5 +308,156 @@ mod tests {
     #[test]
     fn never_rejects_help() {
         assert!(check_flags("stats", &args(&["omni", "stats", "--help"]), FLAGS).is_ok());
+    }
+}
+
+#[cfg(test)]
+mod flag_tests {
+    use super::{flag_name, flag_value, has_flag};
+
+    fn argv(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| s.to_string()).collect()
+    }
+
+    /// #646. `check_flags` validates `--flag=value` on the name alone, so every
+    /// caller that compared the whole argument accepted the input and then acted
+    /// as if the flag were absent.
+    #[test]
+    fn a_flag_is_found_in_either_spelling() {
+        assert!(has_flag(&argv(&["--json"]), "--json"));
+        assert!(has_flag(&argv(&["--json=1"]), "--json"));
+        assert!(has_flag(&argv(&["--json=true"]), "--json"));
+        assert!(!has_flag(&argv(&["--jsonx"]), "--json"));
+        assert!(!has_flag(&argv(&["--json-lines"]), "--json"));
+    }
+
+    /// The `=` form on a value flag was worse than on a boolean one: the command
+    /// succeeded and answered about something else. `--port=8080` bound the
+    /// default port; `--tool=bash` filtered on nothing.
+    #[test]
+    fn a_value_is_read_from_either_form() {
+        assert_eq!(
+            flag_value(&argv(&["--port", "8080"]), "--port"),
+            Some("8080")
+        );
+        assert_eq!(flag_value(&argv(&["--port=8080"]), "--port"), Some("8080"));
+        assert_eq!(flag_value(&argv(&["--port="]), "--port"), Some(""));
+        assert_eq!(flag_value(&argv(&["--port"]), "--port"), None);
+        assert_eq!(flag_value(&argv(&["--other", "8080"]), "--port"), None);
+    }
+
+    /// A value that itself contains `=` must survive whole.
+    #[test]
+    fn only_the_first_equals_separates_a_value() {
+        assert_eq!(
+            flag_value(&argv(&["--filter=key=value"]), "--filter"),
+            Some("key=value")
+        );
+        assert_eq!(flag_name("--filter=key=value"), "--filter");
+    }
+
+    /// What the scan below looks for, as its own function so it can be tested on
+    /// lines that are not in the tree. Any leading dash, not just `--`: `-h` is a
+    /// flag too and the first pass of this only caught the long form, which no
+    /// current line would have shown.
+    fn compares_an_argument_to_a_flag(line: &str) -> bool {
+        line.contains("== \"-")
+    }
+
+    #[test]
+    fn the_scan_catches_both_flag_spellings_and_leaves_positionals_alone() {
+        for bad in [
+            r#"let is_json = args.iter().any(|a| a == "--json");"#,
+            r#"if args.iter().any(|a| a == "-h") {"#,
+            r#".position(|a| a == "--port")"#,
+        ] {
+            assert!(compares_an_argument_to_a_flag(bad), "missed: {bad}");
+        }
+        for ok in [
+            r#"super::has_flag(args, "--json")"#,
+            r#"args.get(2).is_some_and(|a| a == "help")"#,
+            r#"if name == "help" {"#,
+        ] {
+            assert!(!compares_an_argument_to_a_flag(ok), "false positive: {ok}");
+        }
+    }
+
+    /// `stats` grew `--today` beside `--day` and kept its own matcher for the
+    /// three spellings (#428). That copy compared whole arguments, so `--hour=1`
+    /// selected the default overview, and the source scan could not see it: it
+    /// looks for a flag literal and that helper compared against a parameter.
+    #[test]
+    fn an_alternative_spelling_is_found_in_either_form() {
+        use super::has_any;
+        let names = ["--day", "--today", "-d"];
+        for spelling in ["--day", "--today=1", "-d"] {
+            assert!(
+                has_any(&argv(&[spelling]), &names),
+                "{spelling} did not select the window"
+            );
+        }
+        assert!(!has_any(&argv(&["--week"]), &names));
+    }
+
+    /// `help` is a positional word, not a flag, so it is matched exactly and only
+    /// where a subcommand's first argument sits. Routing it through `has_flag`
+    /// made `help=notes.txt` trigger it, and testing it anywhere in argv made
+    /// `omni query how do i get help` print the help page instead of answering.
+    #[test]
+    fn help_is_positional_and_query_text_does_not_trigger_it() {
+        use super::wants_help;
+        assert!(wants_help(&argv(&["omni", "query", "help"])));
+        assert!(wants_help(&argv(&["omni", "query", "--help"])));
+        assert!(wants_help(&argv(&["omni", "query", "-h"])));
+        assert!(wants_help(&argv(&["omni", "query", "--help=1"])));
+
+        assert!(
+            !wants_help(&argv(&["omni", "query", "how", "do", "i", "get", "help"])),
+            "a query that mentions help is not a request for the help page"
+        );
+        assert!(!wants_help(&argv(&["omni", "query", "help=notes.txt"])));
+        assert!(!wants_help(&argv(&["omni", "query"])));
+    }
+
+    /// The guard, and the reason it is a source scan rather than a lint: sixty
+    /// call sites carried this bug across twelve commands, each one correct in
+    /// isolation and wrong against `check_flags`. Nothing in the type system
+    /// separates "compare an argument" from "test for a flag", so the check is
+    /// that nobody writes the raw form again.
+    #[test]
+    fn no_command_compares_an_argument_to_a_flag_directly() {
+        let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/cli");
+        let mut offenders = Vec::new();
+
+        for entry in std::fs::read_dir(&dir).expect("src/cli is readable") {
+            let path = entry.expect("dir entry").path();
+            if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+                continue;
+            }
+            // `check_flags` and these tests are where the rule is defined, so
+            // they are the two places allowed to spell it out.
+            if path.file_name().and_then(|n| n.to_str()) == Some("mod.rs") {
+                continue;
+            }
+            let src = std::fs::read_to_string(&path).expect("readable");
+            for (n, line) in src.lines().enumerate() {
+                if compares_an_argument_to_a_flag(line) {
+                    offenders.push(format!(
+                        "{}:{}: {}",
+                        path.file_name().unwrap().to_string_lossy(),
+                        n + 1,
+                        line.trim()
+                    ));
+                }
+            }
+        }
+
+        assert!(
+            offenders.is_empty(),
+            "these compare an argument to a flag directly, so `--flag=value` is \
+             accepted by check_flags and then ignored. Use `has_flag` or \
+             `flag_value`:\n{}",
+            offenders.join("\n")
+        );
     }
 }

--- a/src/cli/patterns.rs
+++ b/src/cli/patterns.rs
@@ -6,25 +6,15 @@ use colored::*;
 const FLAGS: super::Flags = &[("--tool", "Scope to one tool family")];
 
 pub fn run_patterns(args: &[String], store: &Store) -> Result<()> {
-    if args
-        .iter()
-        .any(|a| a == "--help" || a == "-h" || a == "help")
-    {
+    if super::wants_help(args) {
         print_help();
         return Ok(());
     }
     super::check_flags("patterns", args, FLAGS)?;
 
-    let mut tool_family = None;
-    let mut i = 2;
-    while i < args.len() {
-        if args[i] == "--tool" && i + 1 < args.len() {
-            tool_family = Some(args[i + 1].as_str());
-            i += 2;
-        } else {
-            i += 1;
-        }
-    }
+    // `--tool=bash` used to filter on nothing, since the scan compared the whole
+    // argument while `check_flags` had already accepted it (#646).
+    let tool_family = super::flag_value(args, "--tool");
 
     let patterns = store.get_patterns(tool_family, 20);
 

--- a/src/cli/query.rs
+++ b/src/cli/query.rs
@@ -4,10 +4,7 @@ use anyhow::Result;
 use colored::*;
 
 pub fn run_query(args: &[String], store: &Store) -> Result<()> {
-    if args
-        .iter()
-        .any(|a| a == "--help" || a == "-h" || a == "help")
-    {
+    if super::wants_help(args) {
         print_help();
         return Ok(());
     }
@@ -20,7 +17,7 @@ pub fn run_query(args: &[String], store: &Store) -> Result<()> {
         return Ok(());
     };
 
-    let json_mode = args.iter().any(|a| a == "--json");
+    let json_mode = super::has_flag(args, "--json");
 
     match store.execute_omni_query(&raw_query) {
         Ok(result) => {

--- a/src/cli/reset.rs
+++ b/src/cli/reset.rs
@@ -57,7 +57,7 @@ fn targets_from_args(args: &[String]) -> Vec<&'static str> {
         .filter(|(flags, _)| {
             flags
                 .split(',')
-                .any(|alias| args.iter().any(|a| super::flag_name(a) == alias.trim()))
+                .any(|alias| super::has_flag(args, alias.trim()))
         })
         .map(|(flags, _)| target_of(flags))
         .collect()
@@ -81,7 +81,7 @@ fn print_help() {
 pub fn handle_reset() -> anyhow::Result<()> {
     let args: Vec<String> = env::args().collect();
 
-    if args.iter().any(|a| a == "--help" || a == "-h") {
+    if super::has_flag(&args, "--help") || super::has_flag(&args, "-h") {
         print_help();
         return Ok(());
     }
@@ -91,7 +91,7 @@ pub fn handle_reset() -> anyhow::Result<()> {
     // understand, doing something else, and exiting 0.
     super::check_flags("reset", &args, FLAGS)?;
 
-    let is_all = args.iter().any(|a| super::flag_name(a) == "--all");
+    let is_all = super::has_flag(&args, "--all");
     let mut target_ids = targets_from_args(&args);
 
     if target_ids.is_empty() && !is_all {

--- a/src/cli/retrieve.rs
+++ b/src/cli/retrieve.rs
@@ -62,7 +62,7 @@ fn frame(handle: &str, content: &str, whole_len: usize) -> String {
 }
 
 pub fn run(args: &[String], store: &Store) -> Result<()> {
-    if args.iter().any(|a| a == "--help" || a == "-h") {
+    if super::has_flag(args, "--help") || super::has_flag(args, "-h") {
         print_help();
         return Ok(());
     }

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -52,24 +52,21 @@ fn print_help() {
 }
 
 pub fn run_session(args: &[String], store: Arc<Store>) -> anyhow::Result<()> {
-    if args
-        .iter()
-        .any(|a| a == "--help" || a == "-h" || a == "help")
-    {
+    if super::wants_help(args) {
         print_help();
         return Ok(());
     }
     super::check_flags("session", args, FLAGS)?;
 
-    let is_history = args.iter().any(|a| a == "--history");
-    let is_clear = args.iter().any(|a| a == "--clear");
-    let is_continue = args.iter().any(|a| a == "--continue");
-    let is_status = args.iter().any(|a| a == "--status");
-    let is_inject = args.iter().any(|a| a == "--inject");
-    let is_resume = args.iter().any(|a| a == "--resume");
-    let is_transcript = args.iter().any(|a| a == "--transcript");
-    let is_health = args.iter().any(|a| a == "--health");
-    let is_json = args.iter().any(|a| a == "--json");
+    let is_history = super::has_flag(args, "--history");
+    let is_clear = super::has_flag(args, "--clear");
+    let is_continue = super::has_flag(args, "--continue");
+    let is_status = super::has_flag(args, "--status");
+    let is_inject = super::has_flag(args, "--inject");
+    let is_resume = super::has_flag(args, "--resume");
+    let is_transcript = super::has_flag(args, "--transcript");
+    let is_health = super::has_flag(args, "--health");
+    let is_json = super::has_flag(args, "--json");
 
     // If no flags, show help
     if !is_history

--- a/src/cli/stats.rs
+++ b/src/cli/stats.rs
@@ -283,23 +283,17 @@ const FLAGS: super::Flags = &[
 /// being the fall-through in one of them, and silently ignored in the other.
 fn scope(args: &[String]) -> (&'static str, i64) {
     let now = chrono::Utc::now().timestamp();
-    if has(args, &["--hour", "-H"]) {
+    if super::has_any(args, &["--hour", "-H"]) {
         ("last hour", now - 3600)
-    } else if has(args, &["--day", "--today", "-d"]) {
+    } else if super::has_any(args, &["--day", "--today", "-d"]) {
         // Calendar day, not a rolling 24h: "today" means since midnight.
         ("today", now - (now % 86400))
-    } else if has(args, &["--week", "-w"]) {
+    } else if super::has_any(args, &["--week", "-w"]) {
         ("last 7 days", now - 7 * 86400)
     } else {
         // `--month` / `-m` and the no-flag default are the same window.
         ("last 30 days", now - 30 * 86400)
     }
-}
-
-/// A slice rather than a `(long, short)` pair, because `--today` gained a
-/// `--day` spelling and the pair could not carry a third name (#428).
-fn has(args: &[String], names: &[&str]) -> bool {
-    args.iter().any(|a| names.iter().any(|n| a == n))
 }
 
 fn print_help() {
@@ -332,27 +326,24 @@ fn print_help() {
 // ─── Main Entry ─────────────────────────────────────────
 
 pub fn run(args: &[String], store: &Store) -> Result<()> {
-    if args
-        .iter()
-        .any(|a| a == "--help" || a == "-h" || a == "help")
-    {
+    if super::wants_help(args) {
         print_help();
         return Ok(());
     }
     super::check_flags("stats", args, FLAGS)?;
 
-    let detail_flag = args.iter().any(|a| a == "--detail");
-    let json_flag = args.iter().any(|a| a == "--json");
-    let share_flag = args.iter().any(|a| a == "--share");
-    let card_flag = args.iter().any(|a| a == "--card");
-    let project_flag = args.iter().any(|a| a == "--project");
-    let context_flag = args.iter().any(|a| a == "--context");
-    let rerun_flag = args.iter().any(|a| a == "--rerun");
-    let filter_flag = has(args, &["--hour", "-H"])
-        || has(args, &["--day", "--today", "-d"])
-        || has(args, &["--week", "-w"])
-        || has(args, &["--month", "-m"])
-        || args.iter().any(|a| a == "--all-commands");
+    let detail_flag = super::has_flag(args, "--detail");
+    let json_flag = super::has_flag(args, "--json");
+    let share_flag = super::has_flag(args, "--share");
+    let card_flag = super::has_flag(args, "--card");
+    let project_flag = super::has_flag(args, "--project");
+    let context_flag = super::has_flag(args, "--context");
+    let rerun_flag = super::has_flag(args, "--rerun");
+    let filter_flag = super::has_any(args, &["--hour", "-H"])
+        || super::has_any(args, &["--day", "--today", "-d"])
+        || super::has_any(args, &["--week", "-w"])
+        || super::has_any(args, &["--month", "-m"])
+        || super::has_flag(args, "--all-commands");
 
     let mode = if card_flag {
         "card"
@@ -1152,7 +1143,7 @@ fn run_detail(args: &[String], store: &Store) -> Result<()> {
 
     // By Command, top 10 (or all if requested), filter 0% savings
     let raw_filters = store.filter_breakdown(since)?;
-    let all_flag = args.iter().any(|a| a == "--all-commands");
+    let all_flag = super::has_flag(args, "--all-commands");
     let grouped_filters = group_and_calculate_stats(raw_filters, 0);
 
     let display_filters: Vec<_> = if all_flag {

--- a/src/cli/update.rs
+++ b/src/cli/update.rs
@@ -23,10 +23,7 @@ pub fn print_help() {
 const FLAGS: super::Flags = &[];
 
 pub fn run(args: &[String]) -> Result<(), String> {
-    if args
-        .iter()
-        .any(|a| a == "--help" || a == "-h" || a == "help")
-    {
+    if super::wants_help(args) {
         print_help();
         return Ok(());
     }

--- a/src/cli/version.rs
+++ b/src/cli/version.rs
@@ -12,10 +12,7 @@ pub struct VersionJson {
 const FLAGS: super::Flags = &[("--json", "Machine-readable JSON output")];
 
 pub fn run_version(args: &[String]) {
-    if args
-        .iter()
-        .any(|a| a == "--help" || a == "-h" || a == "help")
-    {
+    if super::wants_help(args) {
         println!("\nomni version: Build and feature information\n");
         println!("USAGE:\n  omni version [FLAGS]\n");
         crate::cli::print_flags(FLAGS);
@@ -28,7 +25,7 @@ pub fn run_version(args: &[String]) {
         std::process::exit(1);
     }
 
-    let json_flag = args.iter().any(|a| a == "--json");
+    let json_flag = super::has_flag(args, "--json");
     let version_str = env!("CARGO_PKG_VERSION").to_string();
 
     if json_flag {


### PR DESCRIPTION
`check_flags` validates `--flag=value` on the flag name alone. All sixty call sites compared the whole argument, so the flag passed validation and the command then behaved as if it were absent.

For a boolean flag that is the wrong mode:

```
$ omni version --json=1
OMNI v0.7.6          # before, the human banner
{                    # after
  "version": "0.7.6",
```

For a flag that takes a value it is worse, because the command succeeds and answers about something else:

```
$ omni dashboard --port=18877
  OMNI dashboard http://127.0.0.1:7717     # before, the default port
  OMNI dashboard http://127.0.0.1:18877    # after
```

`omni patterns --tool=bash` filtered on nothing the same way, and `omni init --openclaw=1` exited 0 having installed nothing.

## The change

Two helpers in `cli/mod.rs` hold the rule and every command uses them:

- `has_flag(args, "--json")` for a boolean flag.
- `flag_value(args, "--port")` for one that takes a value, reading both `--port 8080` and `--port=8080`, splitting on the first `=` only so a value containing one survives.

`--port` and `--tool` were the two flags that took values, and both had hand-rolled scans that only knew the space-separated form.

## The guard

A test walks `src/cli/` and fails on any argument compared to a flag directly, printing the offending file, line and text.

Sixty sites across twelve commands is what it took to notice this, and every one of them was correct in isolation and wrong against `check_flags`. Nothing in the type system separates "compare an argument" from "test for a flag", so the check has to be that nobody writes the raw form again. It earned itself immediately by catching a leftover in `reset.rs` from #645.

## Verification

Both behaviours proved against a binary built from before the change, not asserted from the diff:

```
CONTROL  http://127.0.0.1:7717
FIXED    http://127.0.0.1:18877
```

Four break directions, each red: stop normalising in `has_flag`, stop reading the `=` form in `flag_value`, take the name half as the value, and reintroduce one raw comparison in `version.rs`.

`make ci` green.

Closes #646




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR centralizes CLI flag detection so accepted `--flag=value` arguments are consistently honored, including valued flags and stats window aliases.
- Adds shared helpers for normalized flag presence, aliases, values, and help routing.
- Migrates command implementations away from direct raw-argument comparisons.
- Adds regression coverage and a source-level guard against reintroducing direct flag comparisons.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/cli/mod.rs | Adds the shared normalized flag helpers, focused regression tests, and a source guard against direct flag comparisons. |
| src/cli/stats.rs | Replaces the residual local exact matcher so equals-form window flags now affect both routing and report scope. |
| src/cli/query.rs | Uses position-aware help routing so ordinary query text containing `help` no longer diverts execution. |
| src/cli/dashboard.rs | Reads `--port` through the shared value helper, supporting both separated and equals forms. |
| src/cli/patterns.rs | Reads `--tool` through the shared value helper while preserving the complete value after the first equals sign. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Raw CLI arguments] --> B[check_flags validates normalized names]
  A --> C{Argument usage}
  C -->|Boolean or alias| D[has_flag / has_any]
  C -->|Value-bearing flag| E[flag_value]
  C -->|Help request| F[wants_help]
  D --> G[Command mode selection]
  E --> H[Command value parsing]
  F --> I[Help or command execution]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(cli): make --flag=value mean what it..."](https://github.com/fajarhide/omni/commit/ddd3cd031a53f54d74e1d18935004a37249f1aef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55960220)</sub>

<!-- /greptile_comment -->