### PR TITLE
test(hooks,ledger): guard the two properties that make OMNI cache-safe

### DIFF
--- a/changelog.d/610.changed.md
+++ b/changelog.d/610.changed.md
@@ -1,0 +1,18 @@
+**Two guards for the property that makes OMNI cache-safe.** Prompt caching is
+prefix-matched, so a tool that rewrites anything already in the conversation
+invalidates every token after the edit. OMNI's answer is structural: the only
+thing it can rewrite is the newest tool result.
+
+The post-tool hook may emit exactly three keys and all three name the call it was
+handed. A fourth is somebody having found a way to reach into the prefix, and the
+test now fails the build saying so.
+
+And an identical ledger sequence replayed against identical history has to produce
+identical bytes. The ledger is the only stateful stage, so the same command is
+rewritten differently depending on what earlier commands showed, and a prefix that
+cannot be reproduced cannot be cached. The fixture asserts it reached the fold
+before comparing, because three identical passthroughs would satisfy the
+comparison while testing nothing.
+
+No claim is published yet. The measurement that would support one is not settled;
+see #610.

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -3082,6 +3082,63 @@ src/distillers/system_ops.rs:849:                is_sensitive_key(key),
         }
     }
 
+    /// #610. Prompt caching is prefix-matched, so a tool that rewrites anything
+    /// already in the conversation invalidates every token after the edit. That
+    /// is the standing objection to this whole category of tool, and OMNI's
+    /// answer is structural rather than careful: it can only address the tool
+    /// call it was handed.
+    ///
+    /// This pins the whole set of keys the hook may emit. All three name the
+    /// current call. A fourth appearing here is not a style question, it is
+    /// somebody having found a way to reach back into the prefix, and it should
+    /// fail loudly until that is argued in a PR.
+    #[test]
+    fn the_hook_can_only_address_the_call_it_was_handed() {
+        let noisy: String = (0..400)
+            .map(|i| format!("npm WARN deprecated pkg-{i}@1.0.0: no longer supported\n"))
+            .collect();
+        let input = json!({
+            "tool_name": "Bash",
+            "tool_input": { "command": "npm install" },
+            "tool_response": { "stdout": noisy, "stderr": "", "interrupted": false }
+        });
+
+        let out = process_payload(&input.to_string(), None, None).expect("distills");
+        let v: serde_json::Value = serde_json::from_str(&out).expect("valid JSON");
+
+        let top: Vec<&str> = v
+            .as_object()
+            .expect("object")
+            .keys()
+            .map(String::as_str)
+            .collect();
+        assert_eq!(
+            top,
+            vec!["hookSpecificOutput"],
+            "a key outside the hook envelope"
+        );
+
+        let mut inner: Vec<&str> = v["hookSpecificOutput"]
+            .as_object()
+            .expect("object")
+            .keys()
+            .map(String::as_str)
+            .collect();
+        inner.sort_unstable();
+        for key in &inner {
+            assert!(
+                matches!(
+                    *key,
+                    "hookEventName" | "updatedToolOutput" | "additionalContext"
+                ),
+                "`{key}` is not one of the three keys that address the current \
+                 call. If it edits anything already in the conversation it \
+                 invalidates the prompt cache from that point on, which is the \
+                 failure OMNI exists to avoid (#610): {v}"
+            );
+        }
+    }
+
     #[test]
     fn bash_tool_with_git_diff_output() {
         let diff_str = "diff --git a/test.txt b/test.txt\nindex 123..456 100644\n--- a/test.txt\n+++ b/test.txt\n@@ -1,1 +1,2 @@\n-old\n+new line 1\n+new line 2\n".to_string();

--- a/src/ledger/mod.rs
+++ b/src/ledger/mod.rs
@@ -1085,6 +1085,45 @@ mod tests {
     /// One session's history is not another's. Without this the ledger would
     /// tell a fresh session it had already seen output it never received, which
     /// is the false-claim defect this project is named after.
+    /// #610, the other half. Prompt caching is prefix-matched, so what the model
+    /// already holds has to serialise the same way every time it is replayed. The
+    /// ledger is the only stateful stage here: the same command's output is
+    /// rewritten differently depending on what earlier commands showed, which is
+    /// correct for a new insertion and would be a defect if it were not
+    /// reproducible.
+    ///
+    /// Two stores, same sequence, byte for byte. The fixture asserts the fold
+    /// actually happened first, because three identical passthroughs would
+    /// satisfy the comparison while testing nothing.
+    #[test]
+    fn the_same_sequence_against_the_same_history_replays_byte_for_byte() {
+        fn sequence(store: &Store) -> Vec<Option<String>> {
+            let text = payload();
+            let ledger = Ledger::new(store, "s1").with_project("/repo");
+            (0..3).map(|_| ledger.project(&text)).collect()
+        }
+
+        let (a, _da) = temp_store();
+        let (b, _db) = temp_store();
+        let first = sequence(&a);
+        let second = sequence(&b);
+
+        assert!(
+            first[0].is_none() && first[1].is_some(),
+            "the fixture has to reach the fold: the first sighting stays verbatim \
+             and the repeat folds, got {:?}",
+            first
+                .iter()
+                .map(|t| t.as_ref().map(String::len))
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(
+            first, second,
+            "the same history replayed to different bytes, so what the model holds \
+             is not reproducible and cannot be cached"
+        );
+    }
+
     #[test]
     fn never_claims_another_sessions_history() {
         let (store, _d) = temp_store();


### PR DESCRIPTION
Two guards for the property that makes OMNI cache-safe. **The published claim that this PR originally carried has been removed**, because the measurement behind it did not survive review.

## What ships

Prompt caching is prefix-matched, so a tool that rewrites anything already in the conversation invalidates every token after the edit. OMNI's answer is structural rather than careful: the only thing it may rewrite is the newest tool result.

**The hook can only address the call it was handed.** It emits exactly three keys and all three name the current call. A fourth is somebody having found a way to reach into the prefix:

```
`rewriteEarlierTurn` is not one of the three keys that address the current call.
If it edits anything already in the conversation it invalidates the prompt cache
from that point on, which is the failure OMNI exists to avoid (#610)
```

**An identical sequence replays byte for byte.** The ledger is the only stateful stage, so the same command is rewritten differently depending on history, and a prefix that cannot be reproduced cannot be cached. The fixture asserts it reached the fold before comparing, because three identical passthroughs would satisfy the comparison while testing nothing.

That assertion is not decoration. My first attempt lived at the hook level, where the distiller collapses the payload below the ledger floor, so it compared three identical results and could not be made to fail by any break I tried. Moved to the ledger it goes red two ways.

## What does not ship, and why

The README and manual copy, and the public reproduction script. Step 3 of the issue is gated on step 1 returning clean and it does not.

The first measurement classified a request by whether the preceding user record mentioned `[OMNI` anywhere. That counts ordinary prompt text, and on the machine being measured OMNI is the subject of the conversation. Restricting to `tool_result` blocks reverses the sign:

```
                       first pass     corrected
after an OMNI rewrite      99.20%        99.35%
after a plain result       98.67%        99.56%
delta                       +0.53         -0.21
```

Controlling for delivered size does not settle it either: the two buckets with real n are flat to slightly negative, and the two that favour OMNI have n of 89 and 6. The groups are not comparable, because a turn is in the marked group *because* its payload was large.

The issue already named `OMNI_PASSTHROUGH=1` as the valid control and I skipped it while the observational number was flattering. Full numbers are on #610, which stays open for that A/B.

## Verification

`make ci` green. Break directions, each red: add a fourth hook key, replay against a history that already holds the payload, make one turn answer differently.

Refs #610


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds regression coverage for the two properties underlying OMNI's prompt-cache safety and records the work without publishing the withdrawn measurement claim.
- Restricts the post-tool hook's serialized envelope to fields addressing the current tool call.
- Verifies that identical ledger histories produce byte-identical folded output across independent stores.
- Adds a changelog fragment explaining the cache-safety guarantees and their scope.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/hooks/post_tool.rs | Adds a regression test that rejects hook output fields outside the current-call envelope. |
| src/ledger/mod.rs | Adds a stateful replay test proving identical ledger sequences render identical bytes. |
| changelog.d/610.changed.md | Documents the structural cache-safety guards while explicitly withholding the unsettled measurement claim. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test(hooks,ledger): guard the two proper..."](https://github.com/fajarhide/omni/commit/3f168347f3c1ba60da9c5ca88660dff2353f259a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55967177)</sub>

<!-- /greptile_comment -->