### PR TITLE
fix(semantic): rank a compiler frame's own marker above the context around it

### DIFF
--- a/changelog.d/650.fixed.md
+++ b/changelog.d/650.fixed.md
@@ -1,0 +1,24 @@
+**The distiller dropped the line a bundler marked as the one that threw, and kept
+the unmarked source around it.** In a compiler frame the leading `>` and the `^`
+under it are the entire answer, and they carried no failure signal at all, so they
+tiered as ordinary context while lines 49, 51 and 53 survived. The reader was left
+with five lines of source, none of which is the one that failed, and the
+`12 lines omitted` label gave no hint that the marked line was among them.
+
+Two shapes are Critical now, kept narrow because a leading `>` is also a markdown
+quote and a shell redirection, and tiering those Critical would stop a document
+being distilled at all:
+
+* `> 50 |  throw ...`, which needs the `|` gutter after the marker to tell it
+  apart from quoted prose.
+* `|      ^^^^`, a row of nothing but gutter, carets, tildes and space.
+
+`> Build error occurred` is prose with no colon for the `error:` rule to catch, so
+`build error` joins the generic markers where it belongs.
+
+Same shape as #425 one layer up, where a runner's verdict glyph tiered as context
+and the distiller kept three passing tests while dropping the failing one.
+
+The report's second finding, `omni_explain_savings` answering "No recent
+distillations found in current session", is already fixed on `main` by #625 and
+only waiting on a release: v0.7.6 still carries the old wording.

--- a/src/pipeline/semantic.rs
+++ b/src/pipeline/semantic.rs
@@ -196,6 +196,17 @@ fn is_critical(lower_text: &str, tool_family: Option<&str>) -> bool {
         return true;
     }
 
+    // The line a compiler or bundler marked as the one that threw, and the caret
+    // row pointing at the column. In a frame those two tokens are the entire
+    // answer, and without this they carried no failure signal at all: the
+    // distiller dropped `> 50 | throw ...` and its `^` and kept lines 49, 51 and
+    // 53 around them, leaving five lines of source and not the one that failed
+    // (#650). Same shape as #425 one layer up, where a runner's verdict glyph
+    // tiered as ordinary context.
+    if marks_the_offending_line(lower_text) {
+        return true;
+    }
+
     // Generic critical markers
     lower_text.contains("error:")
         || lower_text.contains("error[")
@@ -204,8 +215,38 @@ fn is_critical(lower_text: &str, tool_family: Option<&str>) -> bool {
         || lower_text.contains("panic:")
         || lower_text.starts_with("error ")
         || lower_text.contains("build failed")
+        // `> Build error occurred` is what the bundler prints above the frame,
+        // and it has no colon for the `error:` rule to catch (#650).
+        || lower_text.contains("build error")
         || lower_text.contains("--- fail")
         || mentions_failure_as_a_verdict(lower_text)
+}
+
+/// Does any line here carry a compiler frame's own pointer?
+///
+/// Deliberately narrow, because a leading `>` is also a markdown quote and a
+/// shell redirection, and tiering those Critical would stop a document being
+/// distilled at all. Two shapes only:
+///
+/// * `> 50 |  throw ...`, the marked source line, which needs the `|` gutter
+///   after the marker to tell it apart from quoted prose.
+/// * `|      ^^^^`, the caret row, which is nothing but gutter, carets, tildes
+///   and space.
+///
+/// `> Build error occurred` is prose and is not matched here; `build error` is a
+/// generic marker below instead, where it belongs.
+fn marks_the_offending_line(text: &str) -> bool {
+    text.lines().any(|line| {
+        let t = line.trim();
+        if let Some(rest) = t.strip_prefix('>') {
+            // `> 50 |` and `>50 |`: a gutter follows, which prose does not have.
+            let rest = rest.trim_start();
+            return rest.split_once('|').is_some_and(|(num, _)| {
+                !num.is_empty() && num.trim().chars().all(|c| c.is_ascii_digit())
+            });
+        }
+        t.contains('^') && t.chars().all(|c| matches!(c, '^' | '~' | '|' | ' '))
+    })
 }
 
 /// The verdict glyphs runners print instead of words.
@@ -463,6 +504,57 @@ mod tests {
             assert!(
                 is_critical(&red.to_lowercase(), Some("cargo")),
                 "real failure not classified Critical: {red}"
+            );
+        }
+    }
+
+    /// #650. A bundler marks the line that threw with a leading `>` and points at
+    /// the column with `^`. Those two tokens are the whole answer in a compiler
+    /// frame, and they carried no failure signal, so the distiller dropped them
+    /// and kept the unmarked context around them. The reader was left with five
+    /// lines of source, none of which is the one that failed.
+    ///
+    /// Same shape as #425, one layer up: there a runner's verdict glyph tiered as
+    /// ordinary context, here the marker that says which line the verdict is
+    /// about.
+    #[test]
+    fn a_compiler_frame_marker_is_the_answer_not_context() {
+        for marked in [
+            "  > 50 |   throw new Error(`invalid configuration: ${keys.join(', ')}`)",
+            "  |         ^",
+            "     ^^^^^^",
+            "> Build error occurred",
+            "  > 12 | const x: string = 1",
+        ] {
+            assert!(
+                is_critical(&marked.to_lowercase(), None),
+                "the marked line of a compiler frame tiered as context: {marked:?}"
+            );
+        }
+
+        // The neighbours it kept while dropping the above. They are context and
+        // must stay context, or the frame has no signal to rank against.
+        for context in [
+            "  49 |   const keys = [...new Set(parsed.error.issues.map((i) => i.path))]",
+            "  51 | }",
+            "  53 | export const env: Env = parsed.data",
+        ] {
+            assert!(
+                !is_critical(&context.to_lowercase(), None),
+                "an unmarked context line tiered Critical: {context:?}"
+            );
+        }
+
+        // Not every `>` is a compiler frame. A quoted line in a README read
+        // through `cat`, and a shell redirection in a transcript, are prose.
+        for prose in [
+            "> a blockquote in some markdown a tool printed",
+            "$ cargo build > build.log 2>&1",
+            "  -> resolved 41 packages",
+        ] {
+            assert!(
+                !is_critical(&prose.to_lowercase(), None),
+                "ordinary text tiered Critical by the frame rule: {prose:?}"
             );
         }
     }


### PR DESCRIPTION
A bundler marks the line that threw with a leading `>` and points at the column with `^`. Neither carried a failure signal, so both tiered as ordinary context and the distiller dropped them while keeping the unmarked source around them.

Tiering the reported block line by line, before and after:

```
before                              after
context     49 | const keys = ...   context     49 | const keys = ...
context   > 50 |   throw new ...    CRITICAL  > 50 |   throw new ...
context     |         ^             CRITICAL    |         ^
context     51 | }                  context     51 | }
context     53 | export const ...   context     53 | export const ...
context   > Build error occurred    CRITICAL  > Build error occurred
```

Five lines of source and not the one that failed, which is the inversion the report describes.

## Kept narrow

A leading `>` is also a markdown quote and a shell redirection, and tiering those Critical would stop a document being distilled at all. So:

- `> 50 |  throw ...` requires the `|` gutter after the marker, with digits between, which prose does not have.
- The caret row must be nothing but gutter, carets, tildes and space.
- `> Build error occurred` is prose with no colon for the `error:` rule to catch, so `build error` joins the generic markers rather than widening the frame rule to cover sentences.

The negative cases are asserted, not assumed: a markdown blockquote, a shell redirection and `-> resolved 41 packages` all stay context.

## Same shape as #425

There a runner's verdict glyph tiered as ordinary context, so three passing tests survived and the failing one was dropped. This is that one layer up: not the verdict, but the marker that says which line the verdict is about.

## The report's second finding

`omni_explain_savings` answering `No recent distillations found in current session` is **already fixed on `main`** by #625 and only waiting on a release. v0.7.6 still carries that wording:

```
$ git show v0.7.6:src/mcp/server.rs | grep "No recent distillations"
950:  return "No recent distillations found in current session.".to_string();
```

Current `main` says `No recent distillations or folds recorded.` and takes the fold route into account. Nothing to do here beyond cutting a release.

## Verification

`make ci` green. Four break directions, each red: remove the frame rule, drop the `build error` marker, stop matching the caret row, and accept any `>` prefix, which fails on the blockquote case with the reason.

Closes #650


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR preserves compiler-frame lines that identify the failing source line and column during semantic distillation.
- Recognizes narrowly shaped `> <line> |` source markers and caret/tilde pointer rows as Critical.
- Adds `build error` as a generic critical marker for bundler verdict text without an `error:` prefix.
- Adds positive and negative regression coverage and documents the fix in the changelog.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness or security failures identified.

The new predicates promote the intended compiler-frame markers while constraining the leading-angle marker to a numeric source gutter and limiting pointer rows to gutter and pointer characters; the added negative cases protect common blockquote, redirection, and arrow output.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/pipeline/semantic.rs | Adds compiler-frame marker recognition, the bundler build-error marker, and focused regression tests without an established actionable defect. |
| changelog.d/650.fixed.md | Accurately documents the semantic-tiering failure, the narrowed matching rules, and the resulting behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(semantic): rank a compiler frame&#39;s o..."](https://github.com/fajarhide/omni/commit/de0f10ccff6f3d7f6374764da29d8088a20d3589) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55970497)</sub>

<!-- /greptile_comment -->