### PR TITLE
fix(repo): stop the blanket *.py ignore swallowing shipped tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@ actual_stdout.txt
 # is compiled into the binary with include_str! and a fresh clone cannot
 # build without it (#628).
 !plugins/**/*.py
+# And `scripts/`, which is shipped tooling a user is told to run. The blanket rule
+# above had already swallowed one announced file whole (#651), and it was about to
+# swallow a reproduction script the README pointed at.
+!scripts/*.py
 __pycache__/
 node_modules/
 # --- Environment & Configuration ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1311,6 +1311,8 @@ what a visitor's agent sees is deleted rather than repaired.
 - **Rewind Management**: Added `omni rewind list` and `omni rewind show <hash>` for local exploration of the RewindStore archive.
 - **Real-time ROI Indicator**: New `[OMNI Active]` terminal status line providing immediate feedback on token reduction and latency.
 - **Marketing Data Seeding**: New `scripts/seed_marketing.py` for generating high-impact, realistic demonstration data.
+  *(Corrected 2026-08-23: this file never reached the repository. A blanket `*.py`
+  ignore rule swallowed it, so no release has ever contained it. See #651.)*
 
 ### Improved
 - **Analytics UI**: Refined `omni stats` with professional English headers, better alignment, and improved financial impact estimation.

--- a/changelog.d/651.fixed.md
+++ b/changelog.d/651.fixed.md
@@ -1,0 +1,23 @@
+**A blanket `*.py` ignore had kept an announced file out of every release.** The
+0.5.2 changelog says `scripts/seed_marketing.py` was added; `.gitignore` ignores
+every Python file outside `plugins/`, so it has never been in the repository and
+no user has ever had it. That changelog line is corrected in place rather than
+quietly dropped.
+
+`scripts/*.py` is exempt now, because that directory is tooling a reader is told
+to run. The same rule was about to swallow a reproduction script the README
+pointed at, which would have shipped an instruction nobody could follow.
+
+The seeder itself is archived rather than committed. It opens `~/.omni/omni.db`,
+runs `DELETE FROM distillations`, and refills it with randomised rows under a
+comment reading "make it look real". That database is where every published figure
+here is measured from, so the script fabricates the evidence this project exists to
+keep honest. It also names a `content_type` column that no longer exists, which is
+the only reason it has not already done the damage.
+
+A test walks README, `CONTRIBUTING.md` and both manuals, and fails on any
+`scripts/...` path that is not in the repository. It also refuses to pass by not
+looking: a manual directory that moved, or a document it cannot read, fails rather
+than being skipped. `CHANGELOG.md` is exempt: history legitimately names files
+that were removed later, which is a different thing from a live instruction naming
+a file that never existed.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -356,6 +356,95 @@ mod flag_tests {
         assert_eq!(flag_name("--filter=key=value"), "--filter");
     }
 
+    /// A script the docs tell you to run has to be in the repository.
+    ///
+    /// #651: the 0.5.2 changelog announced `scripts/seed_marketing.py` and a
+    /// blanket `*.py` ignore meant no release ever contained it. The same rule
+    /// was about to swallow the reproduction script #610's README copy pointed
+    /// at, which would have shipped an instruction nobody could follow.
+    ///
+    /// README and the manual only. `CHANGELOG.md` is history and legitimately
+    /// names files that were removed later, which is a different thing from a
+    /// live instruction naming a file that never existed.
+    #[test]
+    fn every_script_the_docs_name_is_in_the_repository() {
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+        // `CONTRIBUTING.md` is a live guide too and names `scripts/`, which the
+        // first version of this missed.
+        let mut docs = vec![root.join("README.md"), root.join("CONTRIBUTING.md")];
+        for dir in ["docs/website/src", "docs/website/src-id"] {
+            let path = root.join(dir);
+            assert!(
+                path.is_dir(),
+                "{dir} is not a directory, so this guard would scan nothing and \
+                 pass. A check that cannot fail proves nothing."
+            );
+            collect_markdown(&path, &mut docs);
+        }
+        assert!(
+            docs.len() > 10,
+            "only {} documents found, so the traversal is not reaching the manual \
+             and this guard is decorative",
+            docs.len()
+        );
+
+        let mut missing = Vec::new();
+        for doc in &docs {
+            let text = std::fs::read_to_string(doc).unwrap_or_else(|e| {
+                // Skipping an unreadable file would let the guard pass by not
+                // looking, which is the failure mode it is guarding against.
+                panic!("cannot read {}: {e}", doc.display())
+            });
+            for (n, line) in text.lines().enumerate() {
+                // Tokenised rather than sliced. The boundaries here are provable,
+                // but `clippy::string_slice` is denied crate-wide since #619 and
+                // splitting on the characters that delimit a path in prose needs
+                // no indexing at all.
+                for token in
+                    line.split(|c: char| !(c.is_ascii_alphanumeric() || "._-/".contains(c)))
+                {
+                    let path = token.trim_end_matches('.');
+                    if let Some(rest) = path.strip_prefix("scripts/")
+                        && !rest.is_empty()
+                        && !root.join(path).exists()
+                    {
+                        missing.push(format!(
+                            "{}:{}: {path}",
+                            doc.file_name().unwrap_or_default().to_string_lossy(),
+                            n + 1
+                        ));
+                    }
+                }
+            }
+        }
+
+        assert!(
+            missing.is_empty(),
+            "the docs tell a reader to run a script that is not in the repository, \
+             which is what a blanket ignore rule did to `seed_marketing.py` for \
+             every release since 0.5.2 (#651):\n{}",
+            missing.join("\n")
+        );
+    }
+
+    fn collect_markdown(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
+        // Every failure here is loud. Returning quietly on an unreadable
+        // directory would let the guard pass by scanning less than it thinks it
+        // did, at any depth, which is the same hole the top-level check closes.
+        let entries =
+            std::fs::read_dir(dir).unwrap_or_else(|e| panic!("cannot list {}: {e}", dir.display()));
+        for entry in entries {
+            let entry =
+                entry.unwrap_or_else(|e| panic!("cannot read an entry of {}: {e}", dir.display()));
+            let path = entry.path();
+            if path.is_dir() {
+                collect_markdown(&path, out);
+            } else if path.extension().and_then(|e| e.to_str()) == Some("md") {
+                out.push(path);
+            }
+        }
+    }
+
     /// What the scan below looks for, as its own function so it can be tested on
     /// lines that are not in the tree. Any leading dash, not just `--`: `-h` is a
     /// flag too and the first pass of this only caught the long form, which no


### PR DESCRIPTION
The 0.5.2 changelog announced `scripts/seed_marketing.py`. It has never been in the repository:

```
$ git check-ignore -v scripts/seed_marketing.py
.gitignore:5:*.py	scripts/seed_marketing.py
```

A blanket `*.py` with one negation for `plugins/`. No release has ever contained the file, so the entry names something no user has. It is corrected in place rather than quietly dropped.

## The rule

`scripts/*.py` is exempt now, because that directory is tooling a reader is told to run. This is not hypothetical maintenance: the same rule was about to swallow the reproduction script #610's README copy pointed at, which would have published an instruction nobody could follow.

## The file

Archived under `docs/internal/archive/`, not committed. What it does:

```python
cursor.execute("DELETE FROM distillations")
...
# Add some randomness to make it look real
```

It empties the real distillation history out of `~/.omni/omni.db` and refills it with randomised rows. That database is where every figure this project publishes is measured from, so the script fabricates the evidence OMNI exists to keep honest. It also names a `content_type` column that no longer exists, so it raises before doing the damage, which is the only reason it has not already destroyed a history.

`docs/internal/README.md` says `archive/` is dead code with the reason attached, so the reason is at the top of the file.

## The guard

A test walks README and both manuals and fails on any `scripts/...` path not in the repository:

```
README.md:333: scripts/does_not_exist.py
```

`CHANGELOG.md` is exempt on purpose. It names `scripts/legacy/` and `scripts/omni-deploy-edge.sh`, which existed in the pre-Rust era and were removed later. History naming a file that was deleted is a different thing from a live instruction naming one that never existed, and a guard that cannot tell them apart would force the changelog to be rewritten.

## Verification

`make ci` green. Break direction: add a missing `scripts/` path to README, which goes red naming the file and line.

The first version of the guard indexed into the line and tripped `clippy::string_slice`, denied crate-wide since #619. Rewritten to tokenise instead, so there is no allow and no boundary to argue about.

Closes #651






<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR exempts shipped Python tooling under `scripts/` from the blanket ignore rule, corrects the historical changelog entry, and adds a documentation consistency test.
- Scans README, the contributor guide, and both manuals for referenced `scripts/...` paths.
- Fails loudly when expected documentation roots or nested traversal inputs cannot be read.
- Records why the announced marketing seeder was not restored.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .gitignore | Exempts top-level Python tooling in `scripts/` from the repository-wide Python ignore rule. |
| CHANGELOG.md | Corrects the historical claim that the missing marketing seeder shipped. |
| changelog.d/651.fixed.md | Documents the ignore-rule correction, archival decision, and documentation guard. |
| src/cli/mod.rs | Adds a test that scans all identified live documentation and reports missing script references; the previously reported coverage and traversal gaps are fixed. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(repo): stop the blanket \*.py ignore ..."](https://github.com/fajarhide/omni/commit/cbb0e0626681cf6e04c830caaa0ddf8fb8b10e38) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55972858)</sub>

<!-- /greptile_comment -->