### PR TITLE
perf(mcp): drop omni_context from the advertised surface, keep it as a CLI command

### DIFF
--- a/changelog.d/609b.changed.md
+++ b/changelog.d/609b.changed.md
@@ -1,0 +1,30 @@
+**`omni_context` is now `omni context`, and the MCP surface every request carries
+is 8 tools instead of 9.** `mcp::policy::FULL` admits a tool on one stated rule,
+"called at least once in the corpus". Re-measured over 253 recorded sessions,
+`omni_context` was the only advertised tool with **zero** calls ever, and the three
+places OMNI recommended it appear zero times in 10,578 traces, so this is not an
+agent ignoring advice.
+
+It cost 189 B in the prefix of every request on a Full-tier host. Measured through
+the real server over stdio: **2,296 B to 2,098 B**.
+
+Nothing is removed. `omni context <file>` prints the same report, costs nothing per
+request, and an agent that wants it still has `omni_run("omni context <file>")`.
+The two Guard strings that used to recommend the tool now name the command.
+
+The surface gate is ratcheted from 2,500 to 2,200, just above what measures today,
+because a bound with room in it does not notice a regression: the old 3,000 gate
+stayed green through the whole 7,912 B era.
+
+This still does not settle what #609 was filed for. 86% of sessions carry a surface
+they never call, and that is a question about advertising 2,098 B rather than about
+any one tool.
+
+Review found two more while checking this. `omni context ./src/x.rs` and `omni
+context src/x.rs` were two different keys: `normalize_path_string` only swapped
+backslashes, so the graph answered "imports: none detected" for one spelling and a
+hot-file lookup keyed on its result said "no" for a file the session had touched.
+That was true for as long as the MCP tool existed and is fixed at the normaliser,
+where every caller routes through. And the Guard string that suggests the command
+now quotes the path, since a filename with a space in it was being pasted into
+something a reader would run.

--- a/docs/website/src-id/reference/mcp-tools.md
+++ b/docs/website/src-id/reference/mcp-tools.md
@@ -18,7 +18,7 @@ itu OMNI hanya mengiklankan set yang bisa dipakai oleh tier host Anda:
 
 Yang sembilan itu adalah `omni_retrieve`, `omni_explain_savings`, `omni_remember`,
 `omni_recall`, `omni_run`, `omni_find_noise`, `omni_context_breakdown`, `omni_history`
-dan `omni_context`. Itulah yang benar-benar pernah dipanggil di korpus yang terekam.
+dan `omni_history`. Itulah yang benar-benar pernah dipanggil di korpus yang terekam.
 
 Perkakas lain di halaman ini tetap ada di dalam binary dan hanya berjarak satu setelan.
 `OMNI_MCP_TOOLS=all` mengiklankan seluruh 25 perkakas, dan `omni doctor` menyebutkan set
@@ -83,7 +83,6 @@ angkanya, jangan membentuk kesan.
 | `omni_session` | Keadaan sesi: status, konteks, bersihkan |
 | `omni_search` | Cari di riwayat sesi ini |
 | `omni_query` | Kueri riwayat penyulingan dengan bentuk kueri yang tetap |
-| `omni_context` | Konteks dependensi ringan untuk sebuah berkas |
 | `omni_agents` | Agent lain yang sedang aktif di proyek ini |
 
 ## Penyetelan
@@ -118,3 +117,16 @@ Memanggilnya mengembalikan `-32602 tool not found`.
 Ia pernah salah hitung: `grep` atas kode sumber untuk `"omni_*"` mengembalikan
 27, jadi 27 salah di mana pun ia muncul. Jalankan panggilan `tools/list` di atas
 untuk hitungannya.
+
+## Yang keluar dari permukaan
+
+`omni_context` diiklankan sampai 0.7.7 dan tidak pernah sekali pun dipanggil di 253
+sesi yang terekam, jadi ia memakan 189 byte di prefix setiap request untuk
+kapabilitas yang tidak pernah dijangkau siapa pun. Sekarang ia `omni context
+<file>`, yang tidak memakan biaya per request:
+
+```bash
+omni context src/ledger/mod.rs
+```
+
+Agen tetap bisa menjangkaunya lewat `omni_run`.

--- a/docs/website/src/reference/mcp-tools.md
+++ b/docs/website/src/reference/mcp-tools.md
@@ -18,7 +18,7 @@ host's tier can use:
 
 The nine are `omni_retrieve`, `omni_explain_savings`, `omni_remember`, `omni_recall`,
 `omni_run`, `omni_find_noise`, `omni_context_breakdown`, `omni_history` and
-`omni_context`. They are the ones that were actually called across the recorded corpus.
+`omni_history`. They are the ones that were actually called across the recorded corpus.
 
 Every other tool on this page is still in the binary and one setting away.
 `OMNI_MCP_TOOLS=all` advertises all 25, and `omni doctor` says which set is in force and
@@ -82,7 +82,6 @@ than forming an impression.
 | `omni_session` | Session state: status, context, clear |
 | `omni_search` | Search this session's history |
 | `omni_query` | Query distillation history with the fixed query forms |
-| `omni_context` | Lightweight dependency context for a file |
 | `omni_agents` | Other agents currently active on this project |
 
 ## Tuning
@@ -115,3 +114,16 @@ a filter name passed to the TOML generator. Calling it returns `-32602 tool not 
 
 It has been miscounted before: a source grep for `"omni_*"` returns 27, and 27 is
 therefore wrong wherever it appears. Run the `tools/list` call above for the count.
+
+## What left the surface
+
+`omni_context` was advertised until 0.7.7 and had never been called once across
+253 recorded sessions, so it cost 189 bytes in the prefix of every request for a
+capability nobody reached for. It is `omni context <file>` now, which costs nothing
+per request:
+
+```bash
+omni context src/ledger/mod.rs
+```
+
+An agent can still reach it through `omni_run`.

--- a/src/cli/context.rs
+++ b/src/cli/context.rs
@@ -1,0 +1,127 @@
+//! `omni context <file>`: which files this one imports, and which import it.
+//!
+//! Was an MCP tool and nothing else. It sat in the prefix of every request on a
+//! Full-tier host at 189 bytes, and `mcp::policy::FULL` admits a tool on one
+//! stated rule, "called at least once in the corpus": across 253 recorded
+//! sessions `omni_context` is the only advertised tool with **zero** calls ever,
+//! and the three places OMNI recommended it appear zero times in 10,578 traces
+//! (#609).
+//!
+//! Moving it here rather than deleting it keeps the capability and stops charging
+//! for it. A CLI subcommand costs nothing per request, and an agent that wants it
+//! still has `omni_run("omni context <file>")`.
+
+use crate::graph;
+use crate::pipeline::SessionState;
+use anyhow::Result;
+use colored::*;
+
+/// Read by both `print_help` and `super::check_flags` (#151).
+const FLAGS: super::Flags = &[];
+
+pub fn run_context(args: &[String], session: Option<&SessionState>) -> Result<()> {
+    if super::wants_help(args) {
+        print_help();
+        return Ok(());
+    }
+    super::check_flags("context", args, FLAGS)?;
+
+    let Some(file_path) = args.iter().skip(2).find(|a| !a.starts_with('-')) else {
+        print_help();
+        return Ok(());
+    };
+
+    let cwd = std::env::current_dir()?;
+    println!("{}", report(&cwd, file_path, session)?);
+    Ok(())
+}
+
+/// The report itself, so the CLI and any future caller cannot render it two ways.
+///
+/// The session is read here rather than by the caller because the hot-file lookup
+/// has to use the path the graph resolved, not the one that was typed. `omni
+/// context ./src/main.rs` and `omni context src/main.rs` name the same file, and
+/// looking up the raw argument answers "Hot in session: no" for one of them.
+pub fn report(
+    cwd: &std::path::Path,
+    file_path: &str,
+    session: Option<&SessionState>,
+) -> Result<String> {
+    let graph = graph::indexer::build_graph(cwd)?;
+    let ctx = graph.context_for(file_path);
+    let hot_count = session
+        .and_then(|s| s.hot_files.get(&ctx.file_path).copied())
+        .unwrap_or(0);
+
+    let list = |items: &[String]| {
+        if items.is_empty() {
+            "none detected".to_string()
+        } else {
+            items.iter().take(8).cloned().collect::<Vec<_>>().join(", ")
+        }
+    };
+
+    Ok(format!(
+        "OMNI Context for {}\nImports: {}\nImported by: {}\nHot in session: {}\n",
+        ctx.file_path,
+        list(&ctx.imports),
+        list(&ctx.imported_by),
+        if hot_count > 0 {
+            format!("yes ({hot_count}x)")
+        } else {
+            "no".to_string()
+        }
+    ))
+}
+
+fn print_help() {
+    println!(
+        "\n{} {}: Dependency context for one file",
+        "omni".bold().cyan(),
+        "context".bold().yellow()
+    );
+    println!(
+        "Which files it imports, which import it, and whether this session keeps touching it."
+    );
+    println!();
+    println!("Usage: omni context <file>");
+    println!();
+    super::print_flags(FLAGS);
+    println!();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::report;
+    use crate::pipeline::SessionState;
+
+    /// Greptile on #609. The graph resolves `./src/x.rs` and `src/x.rs` to one
+    /// path; looking the session up by the argument as typed answers "Hot in
+    /// session: no" for one spelling of the same file.
+    #[test]
+    fn the_hot_lookup_uses_the_path_the_graph_resolved() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let src = dir.path().join("src");
+        std::fs::create_dir_all(&src).expect("mkdir");
+        std::fs::write(src.join("thing.rs"), "// nothing to import\n").expect("write");
+
+        let mut session = SessionState::new();
+        // Recorded the way the tracker records it, resolved rather than as typed.
+        let resolved = report(dir.path(), "src/thing.rs", None).expect("report");
+        let name = resolved
+            .lines()
+            .next()
+            .and_then(|l| l.strip_prefix("OMNI Context for "))
+            .expect("the first line names the file")
+            .to_string();
+        session.hot_files.insert(name, 4);
+
+        for spelling in ["src/thing.rs", "./src/thing.rs"] {
+            let out = report(dir.path(), spelling, Some(&session)).expect("report");
+            assert!(
+                out.contains("Hot in session: yes (4x)"),
+                "{spelling} reported the wrong hot status:\n{out}"
+            );
+        }
+    }
+}

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -696,7 +696,7 @@ mod tests {
         let line = super::mcp_tool_line("claude_code", false);
         assert_eq!(
             line,
-            "  MCP tools:      9 of 25 advertised to claude_code \
+            "  MCP tools:      8 of 25 advertised to claude_code \
              (OMNI_MCP_TOOLS=all restores the rest)"
         );
     }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,3 +1,4 @@
+pub mod context;
 pub mod dashboard;
 pub mod diff;
 pub mod doctor;

--- a/src/distillers/readfile.rs
+++ b/src/distillers/readfile.rs
@@ -13,7 +13,7 @@ fn distill_readfile(content: &str, filepath: &str) -> Option<String> {
 const MIN_DISTILL_TOKENS: usize = 2000;
 
 /// `imported_by_count`: number of files that import this file (from graph).
-/// When > 3, append a factual warning suggesting omni_context.
+/// When > 3, append a factual warning suggesting `omni context` (#609).
 /// `imported_by` is a closure, not a number, because computing it walks the
 /// repository. It is consulted at one place, the dependents guard below, and
 /// only after two earlier gates have already decided there is something to
@@ -83,7 +83,7 @@ pub fn distill_readfile_with_context(
         let imported_by_count = imported_by();
         if imported_by_count > 3 {
             out.push_str(&format!(
-                "\n[OMNI Guard: {} is imported by {} files, changes here may have wide impact. Call omni_context(\"{}\") for full dependency map.]",
+                "\n[OMNI Guard: {} is imported by {} files, changes here may have wide impact. Run `omni context '{}'` for the full dependency map.]",
                 filepath, imported_by_count, filepath
             ));
         }
@@ -466,6 +466,33 @@ fn distill_log_file(content: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+
+    /// The guard suggests a command a reader will paste into a shell, so the path
+    /// has to survive being a filename rather than becoming shell syntax. Flagged
+    /// on #609 when the suggestion changed from an MCP call, where the argument
+    /// was already quoted by JSON, to a command line where it is not.
+    #[test]
+    fn the_suggested_command_quotes_the_path() {
+        // Same shape as `the_dependents_guard_still_fires_when_it_is_reached`,
+        // which is the fixture already proven to clear both gates: the token
+        // floor and the 20% compression the guard sits behind.
+        let mut content = String::new();
+        for i in 0..400 {
+            content.push_str(&format!(
+                "// comment line {i} explaining a thing at some length for bulk\n"
+            ));
+            content.push_str(&format!("fn helper_{i}(x: usize) -> usize {{ x + {i} }}\n"));
+        }
+
+        let out = super::distill_readfile_with_context(&content, "src/my file.rs", || 9)
+            .expect("a file this size distils");
+
+        assert!(
+            out.contains("omni context 'src/my file.rs'"),
+            "a path with a space was pasted into a command unquoted, so the \
+             reader is told to run something that means two arguments:\n{out}"
+        );
+    }
 
     /// #320: `hooks::post_tool` built the whole import graph before calling this,
     /// so every hooked `Read` paid 48 ms on this repository, most of them for a

--- a/src/graph/indexer.rs
+++ b/src/graph/indexer.rs
@@ -229,15 +229,57 @@ fn normalize_relative(root: &Path, path: &Path) -> String {
         .replace('\\', "/")
 }
 
+/// One spelling per file, so the graph and anything keyed off it agree.
+///
+/// This only swapped backslashes for slashes, so `./src/x.rs` and `src/x.rs` were
+/// two different keys: the graph answered "imports: none detected" for one of
+/// them, and a hot-file lookup keyed on the result said "no" for a file the
+/// session had touched four times. Found by review on #609 when the tool became
+/// `omni context`, and it was there for as long as the MCP tool was.
+///
+/// `..` is kept. Dropping it would change which file is named, and this function
+/// decides a key rather than resolving a path against the filesystem.
 fn normalize_path_string(path: &str) -> String {
-    let p = PathBuf::from(path);
-    p.to_string_lossy().replace('\\', "/")
+    use std::path::Component;
+
+    let slashed = path.replace('\\', "/");
+    let mut out = PathBuf::new();
+    for component in PathBuf::from(&slashed).components() {
+        match component {
+            Component::CurDir => {}
+            other => out.push(other.as_os_str()),
+        }
+    }
+    let normalized = out.to_string_lossy().replace('\\', "/");
+    if normalized.is_empty() {
+        slashed
+    } else {
+        normalized
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use tempfile::tempdir;
+
+    /// #609. Two spellings of one file were two keys, so the graph and every
+    /// lookup keyed off its answer disagreed with each other.
+    #[test]
+    fn one_file_has_one_spelling() {
+        for (given, want) in [
+            ("./src/x.rs", "src/x.rs"),
+            ("src/x.rs", "src/x.rs"),
+            ("./src/./x.rs", "src/x.rs"),
+            ("src\\x.rs", "src/x.rs"),
+        ] {
+            assert_eq!(normalize_path_string(given), want, "{given}");
+        }
+        // `..` names a different file, so it survives.
+        assert_eq!(normalize_path_string("../src/x.rs"), "../src/x.rs");
+        // And nothing becomes empty.
+        assert_eq!(normalize_path_string("."), ".");
+    }
 
     #[test]
     fn extracts_rust_imports() {

--- a/src/hooks/pre_tool.rs
+++ b/src/hooks/pre_tool.rs
@@ -221,7 +221,7 @@ fn process_payload(
             if hot_count > 2 {
                 let updated_input = parsed.tool_input.clone();
                 let reason = format!(
-                    "OMNI Guard: {} is a hot file (accessed {}x this session). Mutating it may have wide impact. Consider reviewing dependents via omni_context.",
+                    "OMNI Guard: {} is a hot file (accessed {}x this session). Mutating it may have wide impact. Consider reviewing dependents with `omni context <file>`.",
                     target_file, hot_count
                 );
                 let output = PreHookOutput {

--- a/src/main.rs
+++ b/src/main.rs
@@ -133,6 +133,11 @@ const COMMANDS: &[(&str, &str, &str)] = &[
     ),
     ("TUNE IT", "query", "Search past distillations (OmniQL)"),
     ("TUNE IT", "patterns", "Errors that keep coming back"),
+    (
+        "TUNE IT",
+        "context",
+        "Which files import this one, and which it imports",
+    ),
     ("MEMORY", "remember", "Save a fact for future sessions"),
     ("MEMORY", "engram", "Digests of finished subtasks"),
     (
@@ -437,6 +442,17 @@ fn main() {
                         std::process::exit(1);
                     }
                 },
+                "context" => {
+                    // #609 moved this off the MCP surface, where it cost 189 B in
+                    // the prefix of every request and was never once called. The
+                    // session is best effort: it only decides the "hot in session"
+                    // line, so a store that will not open still gives an answer.
+                    let session = Store::open().ok().and_then(|s| s.find_latest_session());
+                    if let Err(e) = cli::context::run_context(&args, session.as_ref()) {
+                        eprintln!("[omni] Context error: {}", e);
+                        std::process::exit(1);
+                    }
+                }
                 "patterns" => match Store::open() {
                     Ok(store) => {
                         if let Err(e) = cli::patterns::run_patterns(&args, &store) {

--- a/src/mcp/policy.rs
+++ b/src/mcp/policy.rs
@@ -24,8 +24,13 @@ pub const FULL: &[&str] = &[
     "omni_find_noise",
     "omni_context_breakdown",
     "omni_history",
-    "omni_context",
 ];
+// `omni_context` was here and failed the rule above. Across 253 recorded sessions
+// it is the only advertised tool with zero calls ever, and the three places OMNI
+// recommended it appear zero times in 10,578 traces. It cost 189 B in the prefix
+// of every request on this tier. The capability moved to `omni context <file>`,
+// which costs nothing per request and is still reachable from an agent through
+// `omni_run` (#609).
 
 /// Same list today, kept separate so a future edit to `FULL` cannot silently
 /// drop `omni_run` from the one tier that has nothing else. The test is what
@@ -155,14 +160,15 @@ mod tests {
     }
 
     /// Measured 2026-08-15: nine tools were called across 228 sessions and the
-    /// other sixteen never were. If this list grows without the probe being
-    /// re-run, the design's own justification has stopped being true.
+    /// other sixteen never were. Re-measured 2026-08-23 over 253 sessions, and
+    /// `omni_context` had still never been called once, so it left too (#609).
+    /// If this list grows without the probe being re-run, the design's own
+    /// justification has stopped being true.
     #[test]
-    fn the_full_set_is_the_nine_that_were_actually_called() {
+    fn the_full_set_is_the_ones_that_were_actually_called() {
         let mut got = active_tools("claude_code").to_vec();
         got.sort_unstable();
         let mut want = vec![
-            "omni_context",
             "omni_context_breakdown",
             "omni_explain_savings",
             "omni_find_noise",

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1845,6 +1845,11 @@ mod tests {
     /// `$schema` and `title` keys `schemars` stamps on every parameter struct.
     /// The old 3,000 gate stayed green through that whole regression, which is
     /// what a bound set far above the measurement buys you.
+    ///
+    /// Ratcheted again to 2,200 when `omni_context` left the surface: it was the
+    /// only advertised tool never called once in 253 sessions, and it cost 189 B
+    /// of every request. Kept just above the 2,098 that measures today, for the
+    /// same reason: a gate with room in it does not notice a regression.
     #[test]
     fn the_advertised_surface_is_smaller_than_it_was() {
         let router = OmniServer::router_from("claude_code", false);
@@ -1856,13 +1861,13 @@ mod tests {
 
         assert_eq!(
             listed.len(),
-            9,
-            "advertised {} tools, expected the nine",
+            8,
+            "advertised {} tools, expected eight",
             listed.len()
         );
         assert!(
-            bytes <= 2_500,
-            "advertised surface is {bytes} B, gate is 2500 (it measured 2,286 on #609)"
+            bytes <= 2_200,
+            "advertised surface is {bytes} B, gate is 2200 (it measured 2,098 on #609)"
         );
     }
 

--- a/tests/smoke_test.sh
+++ b/tests/smoke_test.sh
@@ -100,7 +100,7 @@ check "doctor shows binary" "$DOCTOR_OUT" "Binary"
 # combination has reddened CI here before. A subprocess has its own environment, so the
 # escape hatch is verified across the boundary that can actually be wrong.
 LEAN_OUT=$(OMNI_AGENT_ID=claude_code "$OMNI" doctor 2>&1 || true)
-check "doctor reports the lean MCP surface" "$LEAN_OUT" "9 of 25"
+check "doctor reports the lean MCP surface" "$LEAN_OUT" "8 of 25"
 ALL_OUT=$(OMNI_AGENT_ID=claude_code OMNI_MCP_TOOLS=all "$OMNI" doctor 2>&1 || true)
 check "OMNI_MCP_TOOLS=all restores every tool" "$ALL_OUT" "25 of 25"
 


### PR DESCRIPTION
`mcp::policy::FULL` admits a tool on one stated rule, written in its own doc comment: **"called at least once in the corpus"**. `omni_context` fails it.

Re-measured over 253 recorded sessions:

```
     104  omni_retrieve
      29  omni_explain_savings
       3  omni_run
       2  omni_context_breakdown
       2  omni_find_noise
       2  omni_recall
       1  omni_history
       1  omni_remember
```

Every advertised tool has at least one call. `omni_context` is not in the list, because it has never been called once. The three places OMNI recommends it (`distillers/readfile.rs:86`, `hooks/pre_tool.rs:224`) appear zero times in 10,578 traces, so this is not an agent ignoring advice.

## What it cost, measured through the real server

```
before  9 tools  2,296 B
after   8 tools  2,098 B
```

189 B in the prefix of every request, on every session, whether the tool is wanted or not.

## Nothing is removed

The issue's option was to drop the tool. Checking first found there is **no CLI equivalent**, so dropping it would have deleted the capability rather than stopping the charge for it. It is `omni context <file>` now:

```
$ omni context src/ledger/mod.rs
OMNI Context for src/ledger/mod.rs
Imports: src/guard/limits.rs
Imported by: none detected
Hot in session: no
```

A subcommand costs nothing per request, and an agent still reaches it through `omni_run("omni context <file>")`, verified with the built binary on PATH. Both Guard strings name the command now instead of the tool.

## The gate

Ratcheted from 2,500 to 2,200, just above the 2,098 that measures today. A bound with room in it does not notice a regression: the old 3,000 gate stayed green through the entire 7,912 B era, which is the point #609 makes about itself.

## What this does not settle

86% of sessions carry a surface they never call. That is a question about advertising 2,098 B at all, not about any one tool, and it is the lever the issue was filed for. #609 stays open.

## Verification

`make ci` green, including the smoke test, which caught the `9 of 25` assertion in `doctor` that a CLI-surface change had to update.

Break directions, each red: put `omni_context` back on the surface, and grow a description so the bytes cross the gate with the tool count unchanged. Loosening the gate is not a break test, since a looser bound can never fail.

Refs #609




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR removes `omni_context` from the default MCP surface while preserving dependency-context reporting as `omni context <file>`.
- Adds and wires the new CLI context command.
- Updates MCP policy, surface-size gates, doctor output, documentation, and Guard recommendations.
- Normalizes current-directory path components for graph context lookups.
</details>


<details open><summary><h3>Confidence Score: 2/5</h3></summary>

The PR is not yet safe to merge because its replacement shell recommendation can expose quote-containing filenames as command syntax, while another Guard path still recommends the removed MCP route.

The Read Guard inserts an unchanged filename between literal single quotes before directing agents toward a route backed by `sh -c`, and the pre-tool fallback continues to name `omni_context` after that route was removed from the default advertised surface.

**Files Needing Attention:** src/distillers/readfile.rs and src/hooks/pre_tool.rs
</details>


<details open><summary><h3>Security Review</h3></summary>

The new Read Guard shell recommendation does not safely encode filenames containing single quotes. Such paths reach the recommendation unchanged, and following it through `omni_run` can expose additional filename content as shell syntax.

**How this was verified:** The unchanged Read path is interpolated inside literal single quotes and the documented `omni_run` route executes the resulting command through `sh -c`.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/cli/context.rs | Adds the CLI replacement and resolves equivalent current-directory spellings through the graph key before checking session heat. |
| src/distillers/readfile.rs | Changes the dependency recommendation to a shell command, but its single-quote wrapping does not safely represent every legal filename. |
| src/hooks/pre_tool.rs | Updates the hot-file recommendation while leaving a reachable generic recommendation pointing to the removed MCP route. |
| src/mcp/policy.rs | Removes `omni_context` from the default Full and Handoff advertised sets while retaining the all-tools override. |
| src/mcp/server.rs | Ratchets the advertised-surface count and byte-size regression test to the new eight-tool surface. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Read tool path] --> B[Read distiller]
  B --> C[Guard recommends omni context]
  C --> D[Agent calls omni_run]
  D --> E[sh -c executes command]
  F[MCP Full policy] -->|omni_context removed| G[Eight advertised tools]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20fajarhide%2Fomni%20PR%20%23654%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=fajarhide%2Fomni&pr=654&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fdistillers%2Freadfile.rs%3A86-88%0A**Single%20quotes%20break%20path%20escaping**%0A%0AWhen%20a%20sufficiently%20large%20distilled%20file%20with%20more%20than%20three%20importers%20has%20a%20single%20quote%20in%20its%20filename%2C%20this%20interpolation%20closes%20the%20quoted%20argument%20early.%20Following%20the%20recommendation%20through%20%60omni_run%60%20exposes%20the%20remaining%20filename%20as%20shell%20syntax%2C%20causing%20the%20command%20to%20fail%2C%20split%20into%20unintended%20arguments%2C%20or%20execute%20injected%20commands.%0A%0A**How%20this%20was%20verified%3A**%20The%20unchanged%20Read%20path%20is%20interpolated%20inside%20literal%20single%20quotes%2C%20and%20the%20documented%20%60omni_run%60%20route%20executes%20the%20resulting%20command%20through%20%60sh%20-c%60.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni&pr=654&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fajarhide%2Fomni%22%20on%20the%20existing%20branch%20%22fix%2F609-drop-omni-context%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F609-drop-omni-context%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fdistillers%2Freadfile.rs%3A86-88%0A**Single%20quotes%20break%20path%20escaping**%0A%0AWhen%20a%20sufficiently%20large%20distilled%20file%20with%20more%20than%20three%20importers%20has%20a%20single%20quote%20in%20its%20filename%2C%20this%20interpolation%20closes%20the%20quoted%20argument%20early.%20Following%20the%20recommendation%20through%20%60omni_run%60%20exposes%20the%20remaining%20filename%20as%20shell%20syntax%2C%20causing%20the%20command%20to%20fail%2C%20split%20into%20unintended%20arguments%2C%20or%20execute%20injected%20commands.%0A%0A**How%20this%20was%20verified%3A**%20The%20unchanged%20Read%20path%20is%20interpolated%20inside%20literal%20single%20quotes%2C%20and%20the%20documented%20%60omni_run%60%20route%20executes%20the%20resulting%20command%20through%20%60sh%20-c%60.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni&pr=654&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Asrc%2Fdistillers%2Freadfile.rs%3A86-88%0A**Single%20quotes%20break%20path%20escaping**%0A%0AWhen%20a%20sufficiently%20large%20distilled%20file%20with%20more%20than%20three%20importers%20has%20a%20single%20quote%20in%20its%20filename%2C%20this%20interpolation%20closes%20the%20quoted%20argument%20early.%20Following%20the%20recommendation%20through%20%60omni_run%60%20exposes%20the%20remaining%20filename%20as%20shell%20syntax%2C%20causing%20the%20command%20to%20fail%2C%20split%20into%20unintended%20arguments%2C%20or%20execute%20injected%20commands.%0A%0A**How%20this%20was%20verified%3A**%20The%20unchanged%20Read%20path%20is%20interpolated%20inside%20literal%20single%20quotes%2C%20and%20the%20documented%20%60omni_run%60%20route%20executes%20the%20resulting%20command%20through%20%60sh%20-c%60.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=654&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fajarhide%2Fomni%22%20on%20the%20existing%20branch%20%22fix%2F609-drop-omni-context%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F609-drop-omni-context%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fdistillers%2Freadfile.rs%3A86-88%0A**Single%20quotes%20break%20path%20escaping**%0A%0AWhen%20a%20sufficiently%20large%20distilled%20file%20with%20more%20than%20three%20importers%20has%20a%20single%20quote%20in%20its%20filename%2C%20this%20interpolation%20closes%20the%20quoted%20argument%20early.%20Following%20the%20recommendation%20through%20%60omni_run%60%20exposes%20the%20remaining%20filename%20as%20shell%20syntax%2C%20causing%20the%20command%20to%20fail%2C%20split%20into%20unintended%20arguments%2C%20or%20execute%20injected%20commands.%0A%0A**How%20this%20was%20verified%3A**%20The%20unchanged%20Read%20path%20is%20interpolated%20inside%20literal%20single%20quotes%2C%20and%20the%20documented%20%60omni_run%60%20route%20executes%20the%20resulting%20command%20through%20%60sh%20-c%60.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/distillers/readfile.rs:86-88
**Single quotes break path escaping**

When a sufficiently large distilled file with more than three importers has a single quote in its filename, this interpolation closes the quoted argument early. Following the recommendation through `omni_run` exposes the remaining filename as shell syntax, causing the command to fail, split into unintended arguments, or execute injected commands.

**How this was verified:** The unchanged Read path is interpolated inside literal single quotes, and the documented `omni_run` route executes the resulting command through `sh -c`.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["perf(mcp): drop omni\_context from the ad..."](https://github.com/fajarhide/omni/commit/f1ca347aacb9cdcfe0a8f4944fe052566d00d7ea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55978134)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->