### PR TITLE
fix(semantic): read a log's severity level, not just a colon after the word

### DIFF
--- a/changelog.d/655.fixed.md
+++ b/changelog.d/655.fixed.md
@@ -1,0 +1,40 @@
+**A log's failure lines were tiered as ordinary context and dropped, while a
+hundred routine lines were kept.** `is_critical` matched `error:` and a line
+starting `error `, which is how a tool writes a one-line message and not how a log
+writes anything. A timestamped line, a bracketed level and logfmt were all missed,
+so `GenericDistiller` selected the routine lines first and discarded the failures
+with the tail.
+
+Driven through the hook against a build of `main`, on 300 routine lines followed
+by two `ERROR` and one `FATAL`:
+
+```
+                            before              after
+zzunknowncommand --flag     5993 B, 0 of 3      5991 B, 3 of 3
+sort -u app.log             1824 B, 0 of 3       246 B, 3 of 3
+LOG_LEVEL=debug ./run.sh    5993 B, 0 of 3      5991 B, 3 of 3
+```
+
+`sort` gets seven times smaller *and* keeps the answer, because the lines that
+matter are now the ones selected.
+
+The rule reads position, not presence. Two earlier drafts matched the bare word
+anywhere and both were caught by their own tests: `Compiling error-chain v0.12.4`
+is cargo naming a crate, and `const keys = [...new Set(parsed.error.issues)]` is
+source code. A log puts its level in the first few tokens, so only those are read.
+`no errors detected` is excluded, but only when the negated word is the matched
+one: `ERROR: no error handler registered` is a failure whose message happens to
+contain the phrase, and an exclusion that read the whole line threw it away. A
+count of exactly zero is the same statement in digits, so `0 errors found` is
+excluded too, which is the rule `mentions` already carries for `failed` (#210).
+
+Third instance of one shape, after #425 (a runner's verdict glyph) and #650 (a
+compiler frame's own marker): the predicate that decides what is worth keeping did
+not recognise how the tool actually says it failed.
+
+Measured for regression over 150 recorded payloads through the real hook path:
+identical bytes delivered before and after, so nothing that was being distilled
+changed.
+
+`LOG_LEVEL=debug ./run.sh` is in the table because an env-var prefix defeats
+profile routing (#339), and #605 measures that shape at 16.5% of recorded rows.

--- a/src/pipeline/semantic.rs
+++ b/src/pipeline/semantic.rs
@@ -220,6 +220,7 @@ fn is_critical(lower_text: &str, tool_family: Option<&str>) -> bool {
         || lower_text.contains("build error")
         || lower_text.contains("--- fail")
         || mentions_failure_as_a_verdict(lower_text)
+        || states_a_severity(lower_text)
 }
 
 /// Does any line here carry a compiler frame's own pointer?
@@ -264,6 +265,62 @@ const PASS_GLYPHS: &[char] = &['✓', '✔', '✅'];
 fn has_fail_glyph(text: &str) -> bool {
     text.lines()
         .any(|l| l.trim_start().starts_with(FAIL_GLYPHS))
+}
+
+/// Whether a line announces a failure the way a log does, with a level.
+///
+/// The generic markers above match `error:` and a line starting `error `, which
+/// is how a tool writes a one-line message and not how a log writes anything. A
+/// timestamped line, a bracketed level and logfmt were all missed, so a log's
+/// failure lines tiered as context and `GenericDistiller` discarded them with the
+/// tail while keeping a hundred routine ones (#655).
+///
+/// **Position, not presence.** Matching the bare word anywhere is what two
+/// earlier drafts of this did, and both were wrong in a way tests caught:
+/// `Compiling error-chain v0.12.4` is cargo naming a crate, and
+/// `const keys = [...new Set(parsed.error.issues...)]` is source code. A log puts
+/// the level at the front, so only the first few tokens are read, and that is
+/// what separates a report from a mention.
+///
+/// Per line rather than over the block, because a block is mostly routine and the
+/// one line that matters sits inside it.
+fn states_a_severity(lower_text: &str) -> bool {
+    const LEVELS: [&str; 3] = ["error", "errors", "fatal"];
+    // `2026-08-10T00:05:00Z  ERROR upstream ...` puts it third once the two
+    // timestamp halves are counted, and logfmt puts it after a date and a time.
+    const LOOK: usize = 4;
+
+    lower_text.lines().any(|line| {
+        if line.trim_start().starts_with(PASS_GLYPHS) {
+            return false;
+        }
+
+        let mut previous = "";
+        for token in line.split_whitespace().take(LOOK) {
+            let bare = token.trim_matches(|c: char| !c.is_alphanumeric());
+            let is_level = LEVELS.contains(&bare)
+                || token.rsplit_once('=').is_some_and(|(_, value)| {
+                    LEVELS.contains(&value.trim_matches(|c: char| !c.is_alphanumeric()))
+                });
+
+            // The word this token negates is itself, not the line. `no errors
+            // detected` reports an absence, and it is the string a fabricated
+            // summary used in #105, so reading it as a failure would be that
+            // defect answering itself. But `ERROR: no error handler registered`
+            // is a failure whose *message* happens to contain the phrase, and an
+            // exclusion that reads the whole line throws it away.
+            // A count of exactly zero is the same statement in digits, and it is
+            // what every green summary prints: `0 errors found`. `mentions`
+            // carries this rule for the word `failed` for the same reason (#210).
+            let negated =
+                matches!(previous, "no" | "without" | "zero") || previous.parse::<u64>() == Ok(0);
+            if is_level && !negated {
+                return true;
+            }
+            previous = bare;
+        }
+        false
+    })
 }
 
 /// `mentions_failure`, but never for a line that has already announced a pass.
@@ -555,6 +612,58 @@ mod tests {
             assert!(
                 !is_critical(&prose.to_lowercase(), None),
                 "ordinary text tiered Critical by the frame rule: {prose:?}"
+            );
+        }
+    }
+
+    /// #655. `is_critical` matched `error:` and a line starting `error `, which is
+    /// how a one-line message is written and not how a log is. A timestamped
+    /// line, a bracketed level and logfmt were all missed, so the failure lines
+    /// tiered as context and `GenericDistiller` discarded them with the tail
+    /// while keeping a hundred routine ones.
+    ///
+    /// Third instance of one shape, after #425 (a verdict glyph) and #650 (a
+    /// compiler frame's marker): the predicate deciding what is worth keeping did
+    /// not recognise how the tool actually says it failed.
+    #[test]
+    fn a_severity_word_is_a_failure_however_the_log_frames_it() {
+        for line in [
+            "2026-08-10T00:05:00Z  ERROR upstream timed out after 30s",
+            "2026-08-10T00:05:02Z  FATAL giving up after 3 retries",
+            "[ERROR] something broke",
+            "2026-08-10 level=error msg=\"upstream timed out\"",
+            "  2 errors found",
+            "error: something broke",
+            // A failure whose message mentions the absence of something. The
+            // level at the front decides it, not a phrase further along.
+            "ERROR: no error handler registered for /foo",
+            "2026-08-10T00:05:00Z  FATAL exited without errors reported upstream",
+        ] {
+            assert!(
+                is_critical(&line.to_lowercase(), None),
+                "a line stating a failure tiered as context: {line:?}"
+            );
+        }
+
+        // The other direction, which is what makes the word dangerous. Each of
+        // these has cost this project a wrong tier before.
+        for line in [
+            "test error_handling ... ok",
+            "test result: ok. 479 passed; 0 errors",
+            "docker logs: 323 lines, no errors detected",
+            // The same phrasing where position alone would not save it: the word
+            // sits second, well inside the window the rule reads.
+            "no errors detected",
+            "completed without errors",
+            "zero errors",
+            "0 errors found",
+            "check complete: 0 errors, 0 warnings",
+            "2026-08-10T00:00:00Z  worker 1 handled request 1 in 12ms",
+            "Compiling error-chain v0.12.4",
+        ] {
+            assert!(
+                !is_critical(&line.to_lowercase(), None),
+                "ordinary output tiered Critical by the severity rule: {line:?}"
             );
         }
     }


### PR DESCRIPTION
`is_critical` matched `error:` and a line starting `error `. That is how a tool writes a one-line message, not how a log writes anything, so a log's failure lines tiered as ordinary context and `GenericDistiller` selected the routine ones first and discarded the failures with the tail.

Driven through the hook against a build of `main`. 300 routine lines, then two `ERROR` and one `FATAL`:

```
                            before              after
zzunknowncommand --flag     5993 B, 0 of 3      5991 B, 3 of 3
sort -u app.log             1824 B, 0 of 3       246 B, 3 of 3
LOG_LEVEL=debug ./run.sh    5993 B, 0 of 3      5991 B, 3 of 3
```

`sort` gets seven times smaller **and** keeps the answer, because the lines that matter are now the ones selected rather than the ones dropped.

## Position, not presence

Two earlier drafts matched the bare word anywhere in the line. Both were wrong and both were caught by their own negative cases:

- `Compiling error-chain v0.12.4` is cargo naming a crate.
- `const keys = [...new Set(parsed.error.issues.map(...))]` is source code, and it is a line from #650's own fixture.

A log puts its level in the first few tokens, so only those are read. `no errors detected` and `completed without errors` are excluded explicitly, because that phrasing sits inside the window and reads as a report of absence. It is also the exact string a fabricated summary used in #105, so treating it as a failure would be that defect answering itself.

## Third instance of one shape

After #425, where a runner's verdict glyph tiered as context and three passing tests survived while the failing one was dropped, and #650, where a compiler frame's own `>` marker tiered as context. Each time the predicate that decides what is worth keeping did not recognise how that tool says it failed.

## Regression

150 recorded payloads from `execution_traces` replayed through the real hook path, before and after:

```
payloads 150  rewritten 7  in 648805 B  delivered 637462 B
```

Byte-identical both ways, so nothing already being distilled changed.

Worth stating how that number was nearly wrong. My first two attempts called `distill_with_command(&[], ...)` with an empty segment slice, which leaves the distiller nothing to select from, so both sides measured the same thing and I read it as "no regression". Only replaying through `process_payload`, which segments the payload the way the hook does, measures anything.

## How it was found

Measuring #641, which claimed the opposite: that routing to a named arm saved less than the fallback. Over 400 payloads the fallback did produce a smaller output on 378 of them, and this is why. It was not saving more, it was dropping more. #641 is closed as inverted, with the evidence on the issue.

## Verification

`make ci` green. Four break directions, each red: remove the rule, read the whole line instead of its first tokens, stop excluding the absence phrasing, and stop reading logfmt.

The third of those was green on the first attempt, because the negative case I had written was rejected by position anyway. Two shorter phrasings were added so the exclusion carries its own weight.

Closes #655






<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR extends semantic failure detection to recognize severity levels near the beginning of log lines while distinguishing actual failures from negated or zero-count summaries.
- Recognizes `error`, `errors`, and `fatal` in common timestamped, bracketed, and logfmt forms.
- Limits matching to the first four tokens to avoid treating incidental words in source and build output as severity levels.
- Resolves the prior absence and numeric-zero findings by checking whether the matched level token is immediately preceded by a negation or zero count.
- Adds focused positive and negative regression coverage plus a changelog entry.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/pipeline/semantic.rs | Adds position-sensitive severity recognition and regression tests; the previously reported negation and numeric-zero cases are now handled. |
| changelog.d/655.fixed.md | Documents the corrected log-severity classification, its scope, and regression evidence. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(semantic): read a log&#39;s severity lev..."](https://github.com/fajarhide/omni/commit/2b7f57bb0290e20bbdb71539f9c9d205df910a9c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55983248)</sub>

<!-- /greptile_comment -->