### PR TITLE
fix(ledger): stop booking a Read fold the pipeline then refuses

### DIFF
--- a/changelog.d/657.fixed.md
+++ b/changelog.d/657.fixed.md
@@ -1,0 +1,21 @@
+**A `Read` fold the pipeline refuses is no longer recorded as a saving.** The ledger
+wrote its fold into `ledger_folds` while building the view, and the `Read` path decides
+afterwards whether it can use that view at all: survivors sitting in two blocks cannot
+be renumbered from one `startLine`, so the view is dropped and the host keeps its own
+bytes (#557). The row stayed. `omni_explain_savings` reads that table, so the tool that
+answers "did this route pay for itself" was quoting folds that were reverted.
+
+Measured on `97a8da2` by reading 17 markdown files twice with no edit between the reads:
+13 delivered a fold, 4 delivered nothing and recorded one anyway. `CHANGELOG.md`
+recorded 78.4% of 434,639 bytes, `CONTRIBUTING.md` 95.9% of 15,340, and the agent
+received both in full.
+
+The ledger is now told when the caller's host renumbers what it is handed, so the
+refusal happens before the view is built and the books never see it. `ledger_record` is
+untouched and now reads the situation correctly on this path as a side effect: with no
+view to deliver, every line counts as delivered, which is what the agent received.
+Before, a refused view recorded only the survivors, so those lines stayed foldable for a
+later read that had already been shown them.
+
+Why those four payloads refuse the fold in the first place is a separate defect (#658);
+this change is only about the accounting.

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -434,6 +434,10 @@ fn fold_cross_turn(
         // another's (#622). For a `Read` this is the path, for Bash the command.
         .from(normalized.command.as_str())
         .by(crate::hooks::normalize::stats_agent_id(&normalized.agent))
+        // Only `Read` hands its payload back as numbered content, so only `Read`
+        // refuses a view it cannot renumber. Saying so here keeps the refusal and
+        // the bookkeeping in one place (#657).
+        .renumbered(normalized.tool_name == "Read")
         .project_reporting_shift(&text);
 
     // #557. A `Read` payload is handed back as `file.content` and the host
@@ -3356,6 +3360,61 @@ src/distillers/system_ops.rs:849:                is_sensitive_key(key),
             file["startLine"],
             100 + 30 - above,
             "the middle block keeps numbers it is no longer at: {out}"
+        );
+    }
+
+    /// #657. A `Read` whose survivors sit in two blocks cannot be renumbered, so
+    /// the view is dropped and the host keeps its own bytes. The fold was recorded
+    /// before that decision was taken, so `ledger_folds` kept a row for bytes the
+    /// agent received in full, and `omni_explain_savings` reads that table.
+    ///
+    /// Measured before the fix: 4 of 17 markdown files read twice unchanged
+    /// delivered nothing and recorded 78% to 97% as saved, `CHANGELOG.md` among
+    /// them at 341 KB.
+    #[test]
+    fn a_refused_read_fold_records_nothing() {
+        let line = |i: usize| format!("    let unique_marker_{i:03} = \"quokka-{i:03}-xyzzy\";\n");
+        let range = |from: usize, to: usize| (from..to).map(line).collect::<String>();
+        let seen = range(100, 200);
+        // Two new lines with a folded run between them: the survivors are in two
+        // blocks, and one starting number cannot describe both.
+        let split = format!(
+            "{}{}{}{}{}",
+            range(100, 130),
+            "    let fresh_one = \"added since the first read\";\n",
+            range(130, 170),
+            "    let fresh_two = \"added since the first read too\";\n",
+            range(170, 200)
+        );
+        let payload = |content: &str| {
+            json!({
+                "session_id": "host-657-split",
+                "tool_name": "Read",
+                "tool_input": {"path": "probe.rs"},
+                "tool_response": {"file": {
+                    "filePath": "probe.rs",
+                    "content": content,
+                    "startLine": 100,
+                    "numLines": content.lines().count(),
+                    "totalLines": 400,
+                }},
+            })
+            .to_string()
+        };
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Arc::new(Store::open_path(&dir.path().join("omni.db")).expect("store"));
+        let _ = process_payload(&payload(&seen), Some(store.clone()), None);
+        let out = process_payload(&payload(&split), Some(store.clone()), None);
+
+        assert!(
+            out.is_none(),
+            "split survivors cannot be renumbered, so nothing may be rewritten: {out:?}"
+        );
+        let folds = store.get_recent_ledger_folds(None, 10);
+        assert!(
+            folds.is_empty(),
+            "the fold was refused, so the books must not carry it: {folds:?}"
         );
     }
 

--- a/src/ledger/mod.rs
+++ b/src/ledger/mod.rs
@@ -306,6 +306,11 @@ pub struct Ledger<'a> {
     /// replacing came from a different one (#622). Empty means the caller could
     /// not name one, which suppresses the clause rather than guessing.
     source: String,
+    /// Whether the caller's host numbers the lines it is handed, counting from a
+    /// start line the caller controls. A host that does cannot take a view whose
+    /// survivors sit in two blocks, so that view is never built and never booked
+    /// (#657).
+    renumbered: bool,
     /// Who is being shown these lines, recorded and read by nothing (#509).
     ///
     /// The project scope is keyed on the directory alone, so two agents in one
@@ -348,6 +353,7 @@ impl<'a> Ledger<'a> {
             scope: scope.into(),
             project: None,
             source: String::new(),
+            renumbered: false,
             agent: "unknown".to_string(),
         }
     }
@@ -362,6 +368,18 @@ impl<'a> Ledger<'a> {
     /// before claiming a different source in its marker.
     pub fn from(mut self, source: impl Into<String>) -> Self {
         self.source = source.into();
+        self
+    }
+
+    /// Says the host will renumber whatever lines it is handed, which decides
+    /// whether a split view is worth building at all.
+    ///
+    /// Only `Read` does: its payload goes back as `file.content` and the host
+    /// renders it with `cat -n` from `startLine`. One starting number cannot
+    /// describe survivors sitting at two different offsets, so the caller drops
+    /// such a view, and a fold nobody delivers must not reach the books.
+    pub fn renumbered(mut self, yes: bool) -> Self {
+        self.renumbered = yes;
         self
     }
 
@@ -484,6 +502,16 @@ impl<'a> Ledger<'a> {
             .substitute(&lines, &hashes, &origin_of)
             .filter(|(view, _, _)| view.len() < text.len());
 
+        // What the fold did to the numbering below it (#557), read from the folded
+        // indices where the answer is known. Decided here rather than after the
+        // recording below, because a host that renumbers will drop a split view and
+        // the books must not carry a fold the agent never received (#657).
+        let shifts = projected
+            .as_ref()
+            .map(|(_, folded, above)| FoldShift::of(folded, lines.len(), *above))
+            .unwrap_or(FoldShift::None);
+        let projected = projected.filter(|_| !(self.renumbered && shifts == FoldShift::Interior));
+
         // Record what the agent was handed, which is not always what it was
         // given (#465). A run replaced by a marker never reached the context, so
         // recording it here would let the *next* occurrence in this session read
@@ -570,12 +598,6 @@ impl<'a> Ledger<'a> {
                 .ledger_record(p, &delivered, &self.agent, &self.source);
         }
 
-        // What the fold did to the numbering below it (#557). Read from the
-        // folded indices, where the answer is known.
-        let shifts = projected
-            .as_ref()
-            .map(|(_, folded, above)| FoldShift::of(folded, lines.len(), *above))
-            .unwrap_or(FoldShift::None);
         projected.map(|(view, _, _)| (view, shifts))
     }
 


### PR DESCRIPTION
`ledger_folds` was written while the view was still being built, and the `Read` path
decides only afterwards whether it can use that view: survivors sitting in two blocks
cannot be renumbered from one `startLine`, so the view is dropped and the host keeps its
own bytes (#557). The row stayed behind, and `omni_explain_savings` reads that table.

The ledger is now told when the caller's host renumbers what it is handed, so the shift
is decided before anything is recorded and a refused fold never reaches the books.

Measured by reading 17 markdown files twice with no edit between the reads, same binary
before and after:

```
before:  13 files folded, 4 delivered 0% and recorded 78.4% to 96.8% as saved
after:   13 files folded (byte-identical), 0 recorded a fold that was never delivered
```

`CHANGELOG.md` accounted for 341 KB of that on a payload the agent received whole.

`a_refused_read_fold_records_nothing` was driven red from both sides: `.renumbered(false)`
at the call site, and removing the filter in `project_inner`. Both breaks were confirmed
applied by diff before the run.

`make ci`: 1,870 tests, clippy clean, security checks passed, smoke test 46/46.

Why those four payloads refuse the fold at all is #658, not this PR.

Closes #657


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR prevents refused `Read` folds from being recorded as delivered savings by moving the renumbering decision into ledger projection before accounting occurs.
- Adds a `renumbered` ledger option for callers whose hosts number returned lines.
- Rejects interior folds before recording fold statistics or delivered-line history.
- Adds a regression test confirming a refused `Read` fold leaves no fold record.
- Documents the corrected accounting behavior in the changelog.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable correctness or security issues identified.

The renumbering flag and downstream Read handling use the same normalized tool identity, and refused interior projections are now discarded before either fold statistics or delivered-line history is recorded.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/hooks/post_tool.rs | Marks normalized `Read` responses as host-renumbered and adds an end-to-end regression test for refused-fold accounting. |
| src/ledger/mod.rs | Rejects interior projections for renumbering hosts before fold and delivered-line records are written. |
| changelog.d/657.fixed.md | Accurately documents the phantom-savings defect, its impact, and the new accounting behavior. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Read tool response] --> B[Ledger projection]
    B --> C[Calculate survivor layout]
    C -->|Contiguous or no survivors| D[Build and record folded view]
    C -->|Interior split and host renumbers| E[Reject projection before accounting]
    D --> F[Return folded content and line-number shift]
    E --> G[Record all original lines as delivered]
    G --> H[Host retains original response]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ledger): stop booking a Read fold th..."](https://github.com/fajarhide/omni/commit/74afc0bfed42da7c03692e0d480e35e039593a69) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55987947)</sub>

<!-- /greptile_comment -->