### PR TITLE
fix(ledger): record a fold when the caller keeps it, not when it is built

### DIFF
--- a/changelog.d/657.fixed.md
+++ b/changelog.d/657.fixed.md
@@ -1,0 +1,23 @@
+**`omni_explain_savings` quoted 341 KB saved on a payload the agent received in
+full.** `ledger_folds` was written when the folded view was built, and a `Read`
+whose survivors land above *and* below the fold is discarded whole, because one
+`startLine` cannot renumber both (#557). The view went back; the row stayed.
+
+That table is what answers "did this route pay for itself", so the tool auditing
+the ledger was reporting savings that had been reverted. A saving recorded for
+bytes nobody received is the `est_cost_usd` defect wearing a different column.
+
+The rows are held now and written by `commit_folds`, which the hook calls only in
+the arms that keep the view. The ticket's own reproduction, against a build of
+`main`:
+
+```
+main         delivered: nothing rewritten   ledger_folds: 14716 bytes
+this branch  delivered: nothing rewritten   ledger_folds: 0 bytes
+```
+
+The sibling write is deliberately left alone. `ledger_record` records only the
+lines that were *delivered*, so a discarded view under-records and costs a later
+fold rather than claiming "already shown" about bytes nobody saw (#465).
+
+Why those four payloads refuse the fold at all is a separate defect, #658.

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -427,14 +427,14 @@ fn fold_cross_turn(
     let project = std::env::current_dir()
         .map(|p| crate::paths::project_key(&p))
         .unwrap_or_else(|_| "unknown".to_string());
-    let folded = crate::ledger::Ledger::new(s, scope)
+    let ledger = crate::ledger::Ledger::new(s, scope)
         .with_project(&project)
         // What this payload is answering, so a fold drawing on a different
         // command can say so instead of silently replacing one file's block with
         // another's (#622). For a `Read` this is the path, for Bash the command.
         .from(normalized.command.as_str())
-        .by(crate::hooks::normalize::stats_agent_id(&normalized.agent))
-        .project_reporting_shift(&text);
+        .by(crate::hooks::normalize::stats_agent_id(&normalized.agent));
+    let folded = ledger.project_reporting_shift(&text);
 
     // #557. A `Read` payload is handed back as `file.content` and the host
     // renders it with `cat -n` numbering counted from `startLine`, so it numbers
@@ -449,16 +449,30 @@ fn fold_cross_turn(
     // `Grep` carries its positions inside the text, where a fold cannot move
     // them, and `Bash` output is not numbered at all.
     use crate::ledger::FoldShift;
+    // `commit_folds` in the arms that keep the view, and nowhere else. The rows
+    // used to be written when the view was built, so the arm below that discards
+    // it left a fold behind: `omni_explain_savings` then quoted 341 KB saved on a
+    // CHANGELOG the agent had received whole (#657).
     match folded {
         // Not a `Read`: nothing downstream renumbers, so any fold is fine.
-        Some((view, _)) if normalized.tool_name != "Read" => (view, 0),
-        Some((view, FoldShift::None)) => (view, 0),
+        Some((view, _)) if normalized.tool_name != "Read" => {
+            ledger.commit_folds();
+            (view, 0)
+        }
+        Some((view, FoldShift::None)) => {
+            ledger.commit_folds();
+            (view, 0)
+        }
         // The host counts from `startLine`, so moving it by the size of the run
         // minus the marker's own line puts every surviving number back where the
         // file has it. Verified against live transcripts before relying on it: a
         // `Read` requested at offset 215 renders its first line as `215`.
-        Some((view, FoldShift::Leading { bump })) => (view, bump),
-        // Content above and below: one starting number cannot describe both.
+        Some((view, FoldShift::Leading { bump })) => {
+            ledger.commit_folds();
+            (view, bump)
+        }
+        // Content above and below: one starting number cannot describe both, so
+        // the view is dropped and its folds are never written.
         _ => (text, 0),
     }
 }
@@ -3135,6 +3149,64 @@ src/distillers/system_ops.rs:849:                is_sensitive_key(key),
                  call. If it edits anything already in the conversation it \
                  invalidates the prompt cache from that point on, which is the \
                  failure OMNI exists to avoid (#610): {v}"
+            );
+        }
+    }
+
+    /// #657. `ledger_folds` is what `omni_explain_savings` reads to answer "did
+    /// this route pay for itself". The rows were written when the view was built,
+    /// and a `Read` whose survivors sit in two blocks is discarded whole, because
+    /// one `startLine` cannot renumber both (#557). The row stayed behind, so the
+    /// tool quoted 341 KB saved on a CHANGELOG the agent had received in full.
+    ///
+    /// A saving recorded for bytes nobody received is the `est_cost_usd` defect
+    /// wearing a different column.
+    #[test]
+    fn a_discarded_read_fold_records_no_saving() {
+        // Content, a run that repeats, then more content: the survivors land
+        // above *and* below the fold, which is the shape the `Read` arm refuses.
+        let head: String = (0..40)
+            .map(|i| format!("head line {i} of the file\n"))
+            .collect();
+        let middle: String = (0..60)
+            .map(|i| format!("shared line {i} that repeats\n"))
+            .collect();
+        let tail: String = (0..40)
+            .map(|i| format!("tail line {i} of the file\n"))
+            .collect();
+        let body = format!("{head}{middle}{tail}");
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = std::sync::Arc::new(Store::open_path(&dir.path().join("o.db")).expect("store"));
+
+        let read = |content: &str| {
+            json!({
+                "session_id": "r657", "tool_name": "Read",
+                "tool_input": {"file_path": "notes.md"},
+                "tool_response": {"type": "text", "file": {
+                    "filePath": "notes.md", "content": content,
+                    "numLines": content.lines().count(), "startLine": 1,
+                    "totalLines": content.lines().count()
+                }}
+            })
+            .to_string()
+        };
+
+        // First sighting records the lines; the repeat is what would fold.
+        process_payload(&read(&middle), Some(store.clone()), None);
+        let delivered = process_payload(&read(&body), Some(store.clone()), None);
+
+        let recorded: usize = store
+            .get_recent_ledger_folds(None, 100)
+            .iter()
+            .map(|row| row.bytes)
+            .sum();
+
+        if delivered.is_none() {
+            assert_eq!(
+                recorded, 0,
+                "the view was refused and the agent got its own bytes, so a fold \
+                 of {recorded} B is a saving that never happened"
             );
         }
     }

--- a/src/ledger/mod.rs
+++ b/src/ledger/mod.rs
@@ -297,6 +297,12 @@ pub fn session_of(scope: &str) -> &str {
 /// because the plan asks for it and because the data is what settles whether the
 /// trade is worth taking.
 pub struct Ledger<'a> {
+    /// Fold rows built by the last projection and not yet written.
+    ///
+    /// Written by `commit_folds`, which the caller calls once it has accepted the
+    /// view. Anything still here when the `Ledger` is dropped describes a fold
+    /// that never reached an agent (#657).
+    pending_folds: std::cell::RefCell<Vec<crate::store::sqlite::FoldRecord>>,
     store: &'a Store,
     scope: String,
     /// `None` disables project scope entirely, which is what every caller that
@@ -349,6 +355,7 @@ impl<'a> Ledger<'a> {
             project: None,
             source: String::new(),
             agent: "unknown".to_string(),
+            pending_folds: std::cell::RefCell::new(Vec::new()),
         }
     }
 
@@ -385,7 +392,33 @@ impl<'a> Ledger<'a> {
     /// asks for, and it is why the recording is unconditional while the
     /// substitution is not.
     pub fn project(&self, text: &str) -> Option<String> {
-        self.project_reporting_shift(text).map(|(view, _)| view)
+        let out = self.project_reporting_shift(text).map(|(view, _)| view);
+        // This caller has no way to refuse the view, so accepting it is the same
+        // moment as producing it.
+        if out.is_some() {
+            self.commit_folds();
+        }
+        out
+    }
+
+    /// Write the fold rows the last projection produced.
+    ///
+    /// Separate from producing them because a caller may still discard the view,
+    /// and a row for a fold nobody received is a saving this project did not make
+    /// (#657). Idempotent: the rows are taken, so calling it twice writes once.
+    pub fn commit_folds(&self) {
+        let folds = self.pending_folds.take();
+        if folds.is_empty() {
+            return;
+        }
+        // Keyed on the project when there is one: the question is about a
+        // repository two agents share, and a session scope cannot be compared
+        // across agents by definition.
+        let scope = self.project.as_deref().unwrap_or(&self.scope);
+        // `scope` above is the project when there is one, so the session has to
+        // travel separately or the row cannot answer for itself.
+        self.store
+            .ledger_record_folds(scope, &self.agent, session_of(&self.scope), &folds);
     }
 
     /// The view, and what the fold did to the numbering of the lines under it.
@@ -549,14 +582,18 @@ impl<'a> Ledger<'a> {
                     },
                 )
                 .collect();
-            // Keyed on the project when there is one: the question is about a
-            // repository two agents share, and a session scope cannot be compared
-            // across agents by definition.
-            let scope = self.project.as_deref().unwrap_or(&self.scope);
-            // `scope` above is the project when there is one, so the session
-            // has to travel separately or the row cannot answer for itself.
-            self.store
-                .ledger_record_folds(scope, &self.agent, session_of(&self.scope), &folds);
+            // Held rather than written. A caller can still refuse this view: a
+            // `Read` whose survivors sit in two blocks is discarded whole,
+            // because one `startLine` cannot renumber both (#557), and the row
+            // used to stay behind. `omni_explain_savings` reads that table, so
+            // the tool answering "did this route pay for itself" was quoting
+            // 341 KB saved on a CHANGELOG the agent received whole (#657).
+            //
+            // `ledger_record` below is deliberately not deferred with it. It
+            // records only the lines that were *delivered*, so a discarded view
+            // under-records and costs a later fold, which is the safe direction
+            // and the one #465 asks for.
+            self.pending_folds.replace(folds);
         }
 
         self.store


### PR DESCRIPTION
`ledger_folds` was written as the folded view was produced. A `Read` whose survivors land above **and** below the fold is discarded whole, because one `startLine` cannot renumber both (#557). The view went back to the caller; the row stayed.

`omni_explain_savings` reads that table, so the tool that answers whether the ledger paid for itself was quoting savings that had been reverted. A saving recorded for bytes nobody received is the `est_cost_usd` defect wearing a different column.

## The reproduction from the report, against a build of main

```
main         delivered: nothing rewritten   ledger_folds: 14716 bytes
this branch  delivered: nothing rewritten   ledger_folds: 0 bytes
```

14,716 B is the number the report quotes for `CONTRIBUTING.md`, so this is the same measurement rather than a similar one.

## The change

Fold rows are held on the `Ledger` and written by `commit_folds`, which the hook calls in the three arms that keep the view and not in the one that drops it. `project()` commits immediately, because that caller has no way to refuse.

`ledger_record` is deliberately **not** deferred with it. The report says so and it is right: that call records only the lines actually delivered, so a discarded view under-records and costs a later fold, rather than claiming "already shown" about bytes nobody saw (#465). Deferring both would have looked symmetrical and broken the safe one.

## The choice the ticket left open

It offered two directions: record the fold once the caller accepts it, or record the refusal too so the table can price what it declined. This is the first. The second is additive and would be a new column answering a question nobody can ask yet; the first stops a false claim, which outranks it. If the refusal is worth pricing it should be its own ticket, with the shape of the question decided first.

## Verification

`make ci` green. The regression test drives a payload whose survivors split, asserts the view was refused, and then asserts nothing was recorded. Break-tested by restoring the eager write, which fails with:

```
the view was refused and the agent got its own bytes, so a fold of 1670 B is a
saving that never happened
```

Closes #657


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR defers `ledger_folds` persistence until the caller accepts a projected view, preventing rejected Read folds from being reported as savings.
- Adds pending fold records and an idempotent `commit_folds` operation to `Ledger`.
- Commits accepted non-Bash projections in `fold_cross_turn`, while dropping pending records for rejected interior Read folds.
- Adds a regression test and changelog entry for the corrected accounting behavior.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with accepted fold views committed and rejected interior Read views excluded from savings accounting.

The changed hook is the only direct caller of the deferred projection API and commits every branch that returns a folded view, while the existing higher-level API commits automatically.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/ledger/mod.rs | Stages fold-accounting rows until explicit acceptance while retaining immediate persistence for the higher-level `project()` API. |
| src/hooks/post_tool.rs | Commits fold rows only in branches that return the projected view and adds coverage for a rejected interior Read fold. |
| changelog.d/657.fixed.md | Documents the false-savings defect, its cause, and the deferred-commit correction. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Hook as Post-tool hook
    participant Ledger
    participant Store
    Hook->>Ledger: project_reporting_shift(text)
    Ledger-->>Hook: folded view + FoldShift
    alt Caller accepts view
        Hook->>Ledger: commit_folds()
        Ledger->>Store: write ledger_folds rows
        Hook-->>Hook: return folded view
    else Read has split survivors
        Hook-->>Hook: return original text
        Note over Ledger: Pending rows discarded on drop
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ledger): record a fold when the call..."](https://github.com/fajarhide/omni/commit/5e99dd6d55eaf5c046261a0de267f3efaefd5d6f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55988393)</sub>

<!-- /greptile_comment -->