### PR TITLE
docs(semantic): record the false positives states_a_severity is known to have

### DIFF
--- a/src/pipeline/semantic.rs
+++ b/src/pipeline/semantic.rs
@@ -284,6 +284,28 @@ fn has_fail_glyph(text: &str) -> bool {
 ///
 /// Per line rather than over the block, because a block is mostly routine and the
 /// one line that matters sits inside it.
+///
+/// **Known imprecision, measured rather than guessed.** Reading the first tokens
+/// still matches four shapes that are not reports, found by probing this function
+/// after it shipped:
+///
+/// ```text
+/// {"error": null}                            a JSON object
+///   "error": null,                           a JSON field
+/// fn handle_error(e: Error) -> Result<()> {  `Error)` is the third token
+/// // error handling lives here               a comment
+/// ```
+///
+/// All four cost bytes rather than correctness: a false positive here *keeps* a
+/// line, so nothing is deleted and nothing is invented. Priced before deciding to
+/// leave them: 25 Rust source files, 315 KB through the `Read` path, and 150
+/// recorded payloads through the Bash path, both byte-identical before and after
+/// this function existed. A tightening with no measured effect is not worth the
+/// risk of a new false negative, which would cost the answer instead of bytes.
+///
+/// If that changes, the shape to reach for is what precedes the token, not more
+/// words: a log level is preceded by a timestamp, a bracket or nothing, and none
+/// of the four above is.
 fn states_a_severity(lower_text: &str) -> bool {
     const LEVELS: [&str; 3] = ["error", "errors", "fatal"];
     // `2026-08-10T00:05:00Z  ERROR upstream ...` puts it third once the two


### PR DESCRIPTION
Probed `states_a_severity` after #656 shipped it, with shapes I had not tested. Four matches that are not reports:

```
{"error": null}                            a JSON object
  "error": null,                           a JSON field
fn handle_error(e: Error) -> Result<()> {  `Error)` is the third token
// error handling lives here               a comment
```

No code change. Each one **keeps** a line rather than dropping it, so nothing is deleted and nothing is invented, and the cost was measured before deciding to leave them:

```
BEFORE #655    25 files  in 314958 B  delivered 46961 B  saved 85.1%
AFTER #655     25 files  in 314958 B  delivered 46961 B  saved 85.1%
```

Byte-identical through the `Read` path on real Rust source, and byte-identical through the Bash path on 150 recorded payloads. Tightening something with no measured effect risks a false negative, which costs the answer rather than bytes.

The comment names the shape to reach for if that ever changes: what precedes the token, not more words. A log level is preceded by a timestamp, a bracket or nothing, and none of the four above is.

Recorded in the code rather than as an issue, because a tracker item nobody can act on is noise and the next person to touch this function will be reading it here.

Refs #655

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds documentation for known false-positive inputs recognized by `states_a_severity`, explaining why the behavior remains unchanged.
- Records four non-report input shapes that retain lines.
- Documents measured impact and suggests a safer discriminator for future refinement.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because it changes documentation only and introduces no functional behavior.

The added comments describe existing behavior without modifying executable code, public contracts, generated data, or security boundaries.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/pipeline/semantic.rs | Documentation-only change accurately records known imprecision and introduces no runtime behavior changes. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(semantic): record the false positiv..."](https://github.com/fajarhide/omni/commit/68cac7d7447931b08bfa342fe72e7e728bed712e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55990108)</sub>

<!-- /greptile_comment -->