### PR TITLE
fix(ledger): fold a split Read down to its first survivor instead of nothing

### DIFF
--- a/changelog.d/658.fixed.md
+++ b/changelog.d/658.fixed.md
@@ -1,0 +1,28 @@
+**A `Read` whose survivors split now folds its head instead of nothing.** The fold was
+all or nothing: survivors sitting in two blocks cannot be renumbered from one `startLine`,
+so the whole view was dropped and the agent paid for every byte again (#557). Two things
+split the survivors far more often than an edit does. A second change anywhere is one, and
+a line stating a failure is the other, since it is marked unseen so it never folds (#458)
+and that splits the run around it. Six such lines are scattered through this repo's own
+`CONTRIBUTING.md`, which is why an unchanged re-read of it saved nothing at all.
+
+Folding down to the first line that survives leaves everything below it contiguous, so the
+existing `startLine` bump still describes all of it and no number moves. Runs are now
+planned before any of them is emitted, which is what makes the shape of the survivors
+knowable in advance; only the store can still turn a planned fold back into a verbatim run,
+and that direction is the safe one.
+
+Priced over 18 markdown files read twice with no edit between the reads, 611 KB:
+
+| | before | after |
+| --- | --- | --- |
+| corpus | 23.9% | 27.3% |
+| `CHANGELOG.md`, 434 KB | 0.0% | 4.4% |
+| `CONTRIBUTING.md` | 0.0% | 8.3% |
+| `docs/website/src/develop/index.md` | 0.0% | 7.8% |
+| files that already folded | 95.4% to 99.6% | unchanged |
+
+The ceiling is structural rather than a tuning choice: while the line count has to survive,
+only a fold at an edge can keep the numbering true, so the head is all there is to take. A
+fold that preserves the line count prices at 82.8% on the same corpus and was refused for
+now, because it inserts lines the file does not contain.

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -3363,26 +3363,27 @@ src/distillers/system_ops.rs:849:                is_sensitive_key(key),
         );
     }
 
-    /// #657. A `Read` whose survivors sit in two blocks cannot be renumbered, so
-    /// the view is dropped and the host keeps its own bytes. The fold was recorded
-    /// before that decision was taken, so `ledger_folds` kept a row for bytes the
-    /// agent received in full, and `omni_explain_savings` reads that table.
+    /// #657, narrowed by #658. A `Read` whose survivors split now folds its head
+    /// and stops there, so the case that still delivers nothing is the one with no
+    /// head to fold: a payload whose first line is new and whose survivors split
+    /// below it. The books must be empty for it, because the agent received every
+    /// byte.
     ///
-    /// Measured before the fix: 4 of 17 markdown files read twice unchanged
-    /// delivered nothing and recorded 78% to 97% as saved, `CHANGELOG.md` among
-    /// them at 341 KB.
+    /// Measured before #657: 4 of 17 markdown files read twice unchanged delivered
+    /// nothing and recorded 78% to 97% as saved, `CHANGELOG.md` among them at
+    /// 341 KB.
     #[test]
     fn a_refused_read_fold_records_nothing() {
         let line = |i: usize| format!("    let unique_marker_{i:03} = \"quokka-{i:03}-xyzzy\";\n");
         let range = |from: usize, to: usize| (from..to).map(line).collect::<String>();
         let seen = range(100, 200);
-        // Two new lines with a folded run between them: the survivors are in two
-        // blocks, and one starting number cannot describe both.
+        // The payload opens on a new line, so there is no head to fold, and a
+        // second new line further down splits what is left. Nothing can be
+        // folded here at all, which is the case that must still record nothing.
         let split = format!(
-            "{}{}{}{}{}",
-            range(100, 130),
+            "{}{}{}{}",
             "    let fresh_one = \"added since the first read\";\n",
-            range(130, 170),
+            range(100, 170),
             "    let fresh_two = \"added since the first read too\";\n",
             range(170, 200)
         );
@@ -3415,6 +3416,175 @@ src/distillers/system_ops.rs:849:                is_sensitive_key(key),
         assert!(
             folds.is_empty(),
             "the fold was refused, so the books must not carry it: {folds:?}"
+        );
+    }
+
+    /// #658. Refusing the whole view when the survivors split gave up the bytes
+    /// above the first split too: an unchanged re-read of `CONTRIBUTING.md` saved
+    /// nothing, because six lines stating a failure are never folded (#458) and
+    /// each one splits the run around it.
+    ///
+    /// Folding down to the first surviving line leaves everything below it
+    /// contiguous, so `startLine` still describes all of it. Priced over 18
+    /// markdown files read twice: the corpus goes from 23.9% to 27.3%, and
+    /// `CHANGELOG.md` from nothing to 4.4%. The ceiling is structural, since a
+    /// fold that keeps the line count is the only way past it.
+    #[test]
+    fn a_split_read_folds_its_head_and_stops_there() {
+        let line = |i: usize| format!("    let unique_marker_{i:03} = \"quokka-{i:03}-xyzzy\";\n");
+        let range = |from: usize, to: usize| (from..to).map(line).collect::<String>();
+        let seen = range(100, 200);
+        let split = format!(
+            "{}{}{}{}{}",
+            range(100, 130),
+            "    let fresh_one = \"added since the first read\";\n",
+            range(130, 170),
+            "    let fresh_two = \"added since the first read too\";\n",
+            range(170, 200)
+        );
+        let payload = |content: &str| {
+            json!({
+                "session_id": "host-658-head",
+                "tool_name": "Read",
+                "tool_input": {"path": "probe.rs"},
+                "tool_response": {"file": {
+                    "filePath": "probe.rs",
+                    "content": content,
+                    "startLine": 100,
+                    "numLines": content.lines().count(),
+                    "totalLines": 400,
+                }},
+            })
+            .to_string()
+        };
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Arc::new(Store::open_path(&dir.path().join("omni.db")).expect("store"));
+        let _ = process_payload(&payload(&seen), Some(store.clone()), None);
+        let out = process_payload(&payload(&split), Some(store.clone()), None)
+            .expect("the head repeats, so it folds");
+
+        let v: serde_json::Value = serde_json::from_str(&out).expect("hook json");
+        let file = &v["hookSpecificOutput"]["updatedToolOutput"]["file"];
+        let content = file["content"].as_str().expect("content");
+
+        // One marker, at the head, and nothing folded below the first survivor.
+        assert_eq!(
+            content.matches("[OMNI:").count(),
+            1,
+            "only the head may fold, or the survivors split again: {content}"
+        );
+        assert!(
+            content.starts_with("[OMNI:"),
+            "the fold has to be the head for one start line to describe the rest: {content}"
+        );
+        assert!(
+            content.contains("let fresh_two") && content.contains("unique_marker_169"),
+            "everything below the first survivor is delivered verbatim: {content}"
+        );
+        // Thirty lines became one marker, so the survivors sit 29 lines higher.
+        assert_eq!(
+            file["startLine"], 129,
+            "the survivors keep numbers they are no longer at: {out}"
+        );
+        // #657: the books say what was delivered, which is the head and only it.
+        let folds = store.get_recent_ledger_folds(None, 10);
+        assert_eq!(
+            folds.iter().map(|f| f.lines).sum::<usize>(),
+            30,
+            "the fold recorded is not the fold delivered: {folds:?}"
+        );
+    }
+
+    /// #657's guard, on the one path #658 leaves it standing. The head is planned
+    /// as two runs of different origin, and a run whose handle was just pulled has
+    /// to be delivered verbatim (#581). The second run still folds, so the emitted
+    /// survivors are the first run and everything below the fold: two blocks
+    /// again, and the view is dropped. Nothing may be recorded for it.
+    ///
+    /// The planner cannot see this coming, because only the store knows a delivery
+    /// is owed. That is the fail-open direction and this is what keeps it honest.
+    #[test]
+    fn a_fold_undone_by_an_owed_delivery_records_nothing() {
+        let line = |i: usize| format!("    let unique_marker_{i:03} = \"quokka-{i:03}-xyzzy\";\n");
+        let range = |from: usize, to: usize| (from..to).map(line).collect::<String>();
+        let body = |content: String, from: usize| {
+            json!({
+                "session_id": "current",
+                "tool_name": "Read",
+                "tool_input": {"path": "probe.rs"},
+                "tool_response": {"file": {
+                    "filePath": "probe.rs",
+                    "content": content,
+                    "startLine": from,
+                    "numLines": 100,
+                    "totalLines": 400,
+                }},
+            })
+            .to_string()
+        };
+        let payload = |sid: &str, from: usize, to: usize| {
+            json!({
+                "session_id": sid,
+                "tool_name": "Read",
+                "tool_input": {"path": "probe.rs"},
+                "tool_response": {"file": {
+                    "filePath": "probe.rs",
+                    "content": range(from, to),
+                    "startLine": from,
+                    "numLines": to - from,
+                    "totalLines": 400,
+                }},
+            })
+            .to_string()
+        };
+        // A new line under the head keeps the survivors split, so the question
+        // stays about the head rather than becoming a whole-output fold.
+        let split = |fresh: &str| {
+            format!(
+                "{}    let {fresh} = \"added since\";\n{}",
+                range(100, 130),
+                range(130, 200)
+            )
+        };
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Arc::new(Store::open_path(&dir.path().join("omni.db")).expect("store"));
+        let _ = process_payload(&payload("earlier", 100, 115), Some(store.clone()), None);
+        let _ = process_payload(&payload("current", 115, 130), Some(store.clone()), None);
+        let out = process_payload(&body(split("fresh_one"), 100), Some(store.clone()), None)
+            .expect("the whole head repeats, so this folds");
+        let content = serde_json::from_str::<serde_json::Value>(&out).expect("hook json")
+            ["hookSpecificOutput"]["updatedToolOutput"]["file"]["content"]
+            .as_str()
+            .expect("content")
+            .to_string();
+        assert_eq!(
+            content.matches("[OMNI:").count(),
+            2,
+            "the head has to fold as two runs for this to test anything: {content}"
+        );
+
+        // The agent pulled the first marker's handle, so that run owes it a
+        // verbatim delivery and cannot fold again.
+        let handle = content
+            .split("omni retrieve ")
+            .nth(1)
+            .and_then(|rest| rest.split(']').next())
+            .expect("a handle in the first marker")
+            .to_string();
+        store.record_rewind_pull(&handle);
+
+        let before = store.get_recent_ledger_folds(None, 50).len();
+        let out = process_payload(&body(split("fresh_two"), 100), Some(store.clone()), None);
+        assert!(
+            out.is_none(),
+            "the first run came back verbatim, so the survivors split again: {out:?}"
+        );
+        assert_eq!(
+            store.get_recent_ledger_folds(None, 50).len(),
+            before,
+            "a view nobody received was booked anyway"
         );
     }
 

--- a/src/ledger/mod.rs
+++ b/src/ledger/mod.rs
@@ -601,6 +601,22 @@ impl<'a> Ledger<'a> {
         projected.map(|(view, _, _)| (view, shifts))
     }
 
+    /// The marker one run would be replaced by, rendered rather than estimated
+    /// so the test that weighs it and the string that is sent cannot drift (#450).
+    ///
+    /// A run covering every line means the reply is this marker and nothing else,
+    /// which needs different wording (#519), and that wording is longer: an
+    /// earlier draft weighed the short one and emitted the long one.
+    fn marker_for(&self, run: &Run, seen: &Seen, total: usize, handle: &str) -> String {
+        let src = seen.source.as_deref();
+        let lines = run.end - run.start;
+        if run.start == 0 && run.end == total {
+            seen.origin.whole_output_marker(lines, handle, src)
+        } else {
+            seen.origin.marker(lines, handle, src)
+        }
+    }
+
     /// The view, and the indices of the lines it replaced with a marker.
     ///
     /// The caller needs the second half to record only what it delivered (#465);
@@ -654,6 +670,45 @@ impl<'a> Ledger<'a> {
             return None;
         }
 
+        // What every run would do on its own, decided before any of them is
+        // emitted so the shape of the survivors is known in advance. Only the
+        // store can still turn a planned fold back into a verbatim run below,
+        // and that direction is safe: the caller then refuses the view exactly
+        // as it did before any of this existed.
+        let planned: Vec<bool> = runs
+            .iter()
+            .map(|run| {
+                run.seen.as_ref().is_some_and(|seen| {
+                    let marker = self
+                        .marker_for(run, seen, lines.len(), &"0".repeat(HANDLE_LEN))
+                        .len();
+                    lines[run.start..run.end]
+                        .iter()
+                        .map(|l| l.len())
+                        .sum::<usize>()
+                        >= marker + seen.origin.min_gain()
+                })
+            })
+            .collect();
+
+        // #658. A host that renumbers what it is handed cannot take survivors
+        // sitting in two blocks, and refusing the whole view gave up the bytes
+        // above the first split as well. Folding only down to the first run that
+        // survives leaves the rest contiguous, so the head still folds and one
+        // `startLine` still describes everything under it. `markers_above` is
+        // irrelevant to that question, so the plan asks it with zero: the bump is
+        // counted for real during the emit below.
+        let planned_folds: HashSet<usize> = runs
+            .iter()
+            .zip(&planned)
+            .filter(|(_, fold)| **fold)
+            .flat_map(|(run, _)| run.start..run.end)
+            .collect();
+        let cutoff = (self.renumbered
+            && FoldShift::of(&planned_folds, lines.len(), 0) == FoldShift::Interior)
+            .then(|| planned.iter().position(|fold| !fold))
+            .flatten();
+
         let mut out = String::with_capacity(payload_bytes);
         let mut folded: HashSet<usize> = HashSet::new();
         let mut replaced_any = false;
@@ -663,7 +718,7 @@ impl<'a> Ledger<'a> {
         // runs. Every attempt to infer it downstream was wrong (#573).
         let mut markers_above = 0usize;
         let mut still_above = true;
-        for run in runs {
+        for (i, run) in runs.iter().enumerate() {
             let body = lines[run.start..run.end].concat();
             // The only question that decides a fold: does this run save more
             // than the marker replacing it costs. The marker is rendered rather
@@ -676,16 +731,8 @@ impl<'a> Ledger<'a> {
             // longer, and the first draft of this weighed the short one and
             // emitted the long one, which is the drift the rest of this comment
             // exists to prevent.
-            let covers_everything = run.start == 0 && run.end == lines.len();
-            let render = |seen: &Seen, handle: &str| {
-                let src = seen.source.as_deref();
-                if covers_everything {
-                    seen.origin
-                        .whole_output_marker(run.end - run.start, handle, src)
-                } else {
-                    seen.origin.marker(run.end - run.start, handle, src)
-                }
-            };
+            let render =
+                |seen: &Seen, handle: &str| self.marker_for(run, seen, lines.len(), handle);
 
             // Two questions, not one. The first is whether the run outgrows the
             // marker replacing it, which is what every floor here has ever asked.
@@ -700,10 +747,7 @@ impl<'a> Ledger<'a> {
             // payload above: does this run save more than the marker replacing
             // it costs. The marker is rendered rather than estimated, so the
             // test cannot drift from the string it is weighing (#450).
-            let long_enough = run.seen.as_ref().is_some_and(|seen| {
-                let marker = render(seen, &"0".repeat(HANDLE_LEN)).len();
-                body.len() >= marker + seen.origin.min_gain()
-            });
+            let long_enough = planned[i] && cutoff.is_none_or(|c| i < c);
 
             // A handle is only offered for content that is provably retrievable.
             // `store_rewind` returns `None` when the row did not land, and the


### PR DESCRIPTION
The fold was all or nothing. Survivors sitting in two blocks cannot be renumbered from one
`startLine`, so the whole view was dropped and the agent paid for every byte again (#557).
An edit is not what usually splits them: a line stating a failure is marked unseen so it
never folds (#458), and that splits the run around it. Six of those are scattered through
this repo's own `CONTRIBUTING.md`, which is why an unchanged re-read of it saved nothing.

Folding down to the first line that survives leaves everything below it contiguous, so the
bump #573 already computes still describes all of it. Runs are planned before any is
emitted, which is what makes the survivor layout knowable in advance.

18 markdown files read twice with no edit between the reads, 611 KB:

| | before | after |
| --- | --- | --- |
| corpus | 23.9% | 27.3% |
| `CHANGELOG.md`, 434 KB | 0.0% | 4.4% |
| `CONTRIBUTING.md` | 0.0% | 8.3% |
| `develop/index.md` | 0.0% | 7.8% |
| files that already folded | 95.4% to 99.6% | unchanged |

The ceiling is structural, not a tuning choice: while the line count has to survive, only a
fold at an edge keeps the numbering true. A fold that preserves the line count prices at
82.8% on the same corpus and is not in this PR, because it inserts lines the file does not
contain. That call belongs to the maintainer, not to a bug fix.

Three tests, each driven red on purpose before it was kept: the head fold dies without the
cutoff and again when the cutoff folds two runs too far, and #657's guard dies on the one
path this change leaves it standing, a run whose handle was just pulled coming back
verbatim (#581) and splitting the survivors after the plan was made.

`make ci`: 1,876 tests, clippy clean, security checks passed, smoke test 46/46.

Closes #658


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR changes renumbered `Read` folding so a split survivor layout can retain a safe leading fold instead of discarding the entire compacted view.

- Plans profitable runs before emission and stops folding at the first surviving run when the planned layout would otherwise be interior.
- Reuses one marker-rendering helper for profitability checks and emitted markers.
- Adds regression coverage for split reads, line-number adjustment, fold accounting, and owed-delivery fallback.
- Documents the behavior and measured savings in the changelog.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness, security, or maintainability issues identified.

The new cutoff preserves a contiguous survivor suffix, while existing post-emission validation recomputes shifts from actual folds and rejects any layout made unsafe by store-side fold vetoes; accounting likewise uses only the folds actually delivered.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/ledger/mod.rs | Adds pre-emission fold planning and a safe head-fold cutoff while retaining post-emission validation and actual-fold accounting. |
| src/hooks/post_tool.rs | Adds regression tests for split survivor layouts, adjusted start lines, ledger accounting, and owed-delivery fallback. |
| changelog.d/658.fixed.md | Documents the corrected split-read folding behavior, structural limitation, and measured savings. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Group content into runs] --> B[Plan profitable folds]
    B --> C{Renumbered layout is interior?}
    C -- No --> D[Emit planned folds]
    C -- Yes --> E[Set cutoff at first surviving run]
    E --> F[Fold only runs before cutoff]
    D --> G[Recompute actual survivor layout]
    F --> G
    G --> H{Actual layout remains interior?}
    H -- Yes --> I[Return original view and record no folds]
    H -- No --> J[Apply leading line-number shift]
    J --> K[Record actual delivered and folded lines]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ledger): fold a split Read down to i..."](https://github.com/fajarhide/omni/commit/e4f93fe160169e5aad80b0663a5a94f9f8ec88e4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55990543)</sub>

<!-- /greptile_comment -->