### PR TITLE
fix(stats,mcp): stop reporting an estimate as an actual count

### DIFF
--- a/changelog.d/663.fixed.md
+++ b/changelog.d/663.fixed.md
@@ -1,0 +1,24 @@
+**`omni stats --json` and the MCP session surface called an estimate an actual
+count, on every row ever written.** `measurement_method` exists to tell a reader
+how far to trust the number beside it, and the branch deciding it tested
+`raw_tokens > 0`. That column has exactly one writer:
+
+```rust
+// src/hooks/post_tool.rs
+// Reporting columns, so the calibrated central estimate.
+let raw_tokens = estimate_tokens(content.len(), ContentHint::Mixed);
+```
+
+So the branch was never false. 16,405 of 16,405 recorded rows reported `actual`
+for bytes divided by 3.6, a constant calibrated against `cl100k_base`, which is
+GPT's vocabulary rather than Claude's. A field whose whole job is to qualify the
+figure was answering the question wrongly, which is worse than not answering it.
+
+Both surfaces say `estimated` now, and a test scans them and fails on the literal.
+
+`format_exact_tokens` is `format_compact`. Neither half of the old name was true:
+it rounds to `12K`, and since #589 its callers pass bytes as often as tokens,
+because the share card's unit is chosen by the caller.
+
+This is the half of #584 that needed no calibration run and no API key. The other
+half, a divisor measured against Claude's tokenizer, is still open there.

--- a/src/cli/dashboard.rs
+++ b/src/cli/dashboard.rs
@@ -143,8 +143,8 @@ fn page(store: &Store) -> String {
         rows.push_str(&format!(
             "<tr><td>{}</td><td class=\"n\">{calls}</td><td class=\"n\">{}</td><td class=\"n\">{}</td><td class=\"n\">{pct:.1}%</td></tr>",
             escape(label),
-            super::stats::format_exact_tokens(*raw_tokens),
-            super::stats::format_exact_tokens(*filtered_tokens)
+            super::stats::format_compact(*raw_tokens),
+            super::stats::format_compact(*filtered_tokens)
         ));
     }
 

--- a/src/cli/stats.rs
+++ b/src/cli/stats.rs
@@ -19,13 +19,16 @@ pub fn format_bytes(n: u64) -> String {
     }
 }
 
-pub fn format_exact_tokens(tokens: u64) -> String {
-    if tokens < 1000 {
-        format!("{}", tokens)
-    } else if tokens < 1_000_000 {
-        format!("{:.0}K", tokens as f64 / 1_000.0)
+/// Rounds a count to `12K` or `1.2M`. Named `format_exact_tokens` until #663,
+/// and neither half was true: it rounds, and since #589 half its callers hand it
+/// bytes. The unit belongs to the caller, which is why none is printed here.
+pub fn format_compact(count: u64) -> String {
+    if count < 1000 {
+        format!("{}", count)
+    } else if count < 1_000_000 {
+        format!("{:.0}K", count as f64 / 1_000.0)
     } else {
-        format!("{:.1}M", tokens as f64 / 1_000_000.0)
+        format!("{:.1}M", count as f64 / 1_000_000.0)
     }
 }
 
@@ -73,7 +76,7 @@ struct PeriodRow<'a> {
 
 /// Lays out the overview period rows, padding every numeric column to the widest
 /// value present. The widths have to come from the rows: `format_number` grows a
-/// separator every three digits and `format_exact_tokens` widens as it crosses
+/// separator every three digits and `format_compact` widens as it crosses
 /// into K and M, so any hardcoded width is wrong for some future row and shifts
 /// every column to its right (#209).
 fn format_period_rows(rows: &[PeriodRow<'_>]) -> Vec<String> {
@@ -528,7 +531,7 @@ fn run_share(store: &Store) -> Result<()> {
     // number than `6,253` and this card exists to show the real one.
     println!(
         "OMNI saved me {} {unit} ({pct:.1}%) across {} commands.",
-        format_exact_tokens(saved),
+        format_compact(saved),
         format_number(calls)
     );
     if !top.is_empty() {
@@ -624,7 +627,7 @@ fn card_svg(f: &ShareFigures, w: u32, h: u32) -> String {
         x = pad.round(),
         y = y.round(),
         fs = px(120.0).round(),
-        saved = xml_escape(&format_exact_tokens(f.saved))
+        saved = xml_escape(&format_compact(f.saved))
     ));
     y += px(70.0);
     s.push_str(&format!(
@@ -1487,11 +1490,12 @@ fn run_json(store: &Store) -> Result<()> {
                     input_tokens: *raw_tokens,
                     output_tokens: *filtered_tokens,
                     savings_pct,
-                    measurement_method: if *raw_tokens > 0 {
-                        "actual".to_string()
-                    } else {
-                        "estimated".to_string()
-                    },
+                    // #663. Always an estimate. The branch that stood here
+                    // tested `raw_tokens > 0`, and that column has one writer,
+                    // `estimate_tokens`, so it was never false: 16,405 of
+                    // 16,405 recorded rows called bytes over 3.6 an actual
+                    // count, against GPT's vocabulary rather than Claude's.
+                    measurement_method: "estimated".to_string(),
                 }
             },
         )
@@ -1758,7 +1762,7 @@ mod tests {
 
     /// #589, the last of it. The context breakdown accumulated `size_bytes / 4`
     /// and was labelled a rough estimate because of it. It counts the sizes now,
-    /// so `format_exact_tokens` must not come back to this block: a file length
+    /// so `format_compact` must not come back to this block: a file length
     /// is measured, and dividing it by four to call the result tokens is the
     /// defect this issue is named for.
     #[test]
@@ -1775,7 +1779,7 @@ mod tests {
         assert_eq!(format_bytes(turn.tool_output_bytes), "72.3 KB");
         assert_ne!(
             format_bytes(turn.file_read_bytes),
-            format_exact_tokens(turn.file_read_bytes / 4),
+            format_compact(turn.file_read_bytes / 4),
             "the breakdown went back to a quarter of a file's size called tokens"
         );
     }
@@ -1995,5 +1999,44 @@ mod tests {
         assert!(json_str.contains("\"generated_at\":1234567890"));
         assert!(json_str.contains("\"savings_pct\":90.0"));
         assert!(json_str.contains("\"avg_latency_ms\":15.5"));
+    }
+
+    /// #663. `measurement_method` exists to tell a reader how far to trust the
+    /// number beside it, and it said `actual` for every row ever written:
+    /// `raw_tokens` has exactly one writer, `estimate_tokens`, so the branch
+    /// testing `> 0` was never false. 16,405 of 16,405 recorded rows.
+    ///
+    /// A source scan rather than a constructed struct. Building a `StatsPeriod`
+    /// with `"estimated"` typed in and asserting on it cannot see the caller
+    /// that stops setting it, which is the failure the field itself had.
+    #[test]
+    fn no_reporting_surface_calls_an_estimate_an_actual_count() {
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+        let mut offenders = Vec::new();
+
+        for rel in [
+            "src/cli/stats.rs",
+            "src/mcp/server.rs",
+            "src/cli/dashboard.rs",
+        ] {
+            let path = root.join(rel);
+            let text =
+                std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("cannot read {rel}: {e}"));
+            for (n, line) in text.lines().enumerate() {
+                // The quoted literal only. An `is_actual` flag names which figure
+                // to display and says nothing to a reader of the output.
+                if line.contains("\"actual\"") {
+                    offenders.push(format!("{rel}:{}: {}", n + 1, line.trim()));
+                }
+            }
+        }
+
+        assert!(
+            offenders.is_empty(),
+            "a reporting surface labels a figure `actual`. Every token figure \
+             here is `estimate_tokens` over a divisor calibrated against GPT's \
+             vocabulary, so `estimated` is the only honest label (#663):\n{}",
+            offenders.join("\n")
+        );
     }
 }

--- a/src/cli/stats.rs
+++ b/src/cli/stats.rs
@@ -2023,8 +2023,13 @@ mod tests {
             let text =
                 std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("cannot read {rel}: {e}"));
             for (n, line) in text.lines().enumerate() {
-                // The quoted literal only. An `is_actual` flag names which figure
-                // to display and says nothing to a reader of the output.
+                // The quoted literal in code only. An `is_actual` flag names
+                // which figure to display and says nothing to a reader of the
+                // output, and prose about this defect has to be able to quote
+                // the word it is about.
+                if line.trim_start().starts_with("//") {
+                    continue;
+                }
                 if line.contains("\"actual\"") {
                     offenders.push(format!("{rel}:{}: {}", n + 1, line.trim()));
                 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1105,8 +1105,11 @@ impl OmniServer {
             0.0
         };
 
+        // `raw_tokens` is `estimate_tokens` output and nothing else, so this was
+        // reporting `actual` for every row ever written (#663). The flag still
+        // decides which figure to show; only the label was a claim.
         let is_actual = raw_tokens > 0;
-        let method = if is_actual { "actual" } else { "estimated" };
+        let method = "estimated";
 
         // Fallback for legacy
         let display_raw = if is_actual {


### PR DESCRIPTION
`measurement_method` exists to tell a reader how far to trust the number printed
beside it. It chose between `actual` and `estimated` on `raw_tokens > 0`, and that
column has exactly one writer:

```rust
// src/hooks/post_tool.rs:979
let raw_tokens = estimate_tokens(content.len(), ContentHint::Mixed);
```

So the branch was never false.

```
sqlite> SELECT COUNT(*), SUM(raw_tokens > 0) FROM distillations;
16405|16405
```

Every row ever recorded reported `actual` for bytes divided by 3.6, a constant
calibrated against `cl100k_base`, which is GPT's vocabulary rather than Claude's.
Both surfaces say `estimated` now.

The guard is a source scan over the three reporting files that fails on the quoted
literal. A test that builds a `StatsPeriod` with `"estimated"` typed into it and
asserts on what it just wrote cannot see the caller that stops setting it, which is
the failure the field itself had. Driven red twice, once per surface:

```
src/cli/stats.rs:1498: measurement_method: "actual".to_string(),
src/mcp/server.rs:1112: let method = if is_actual { "actual" } else { "estimated" };
```

`format_exact_tokens` is `format_compact`. It rounds to `12K`, and since #589 its
callers pass bytes as often as tokens.

This is the half of #584 that needs no calibration run and no API key. The divisor
measured against Claude's tokenizer is still open there.

`make ci` green, 46/46 smoke.

Closes #663
Refs #584




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR corrects token-count metadata so estimated values are no longer presented as actual measurements and renames the compact number formatter to reflect its behavior.
- Reports `measurement_method` as `estimated` in CLI JSON and MCP session output.
- Renames `format_exact_tokens` to `format_compact` and updates its callers.
- Adds changelog documentation and a regression guard.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/cli/stats.rs | Renames the compact formatter, corrects CLI measurement metadata, and adds the regression guard. |
| src/mcp/server.rs | Changes the MCP measurement label to `estimated` while retaining the legacy display-value selection. |
| src/cli/dashboard.rs | Updates dashboard callers to use the renamed compact formatter. |
| changelog.d/663.fixed.md | Documents the corrected measurement label and formatter naming. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(stats): let the guard read prose abo..."](https://github.com/fajarhide/omni/commit/c1b7f80478800fd194ae2ec878c2b9b982861cc7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55994739)</sub>

<!-- /greptile_comment -->