### PR TITLE
feat(stats): report both engines, each against its own base

### DIFF
--- a/changelog.d/665.changed.md
+++ b/changelog.d/665.changed.md
@@ -1,0 +1,50 @@
+**`omni stats` reads both engines now, each percentage against its own base.**
+
+The report computed everything from `distillations` and never read `ledger_folds`,
+so the engine that removed the most bytes was absent. On the maintainer's machine,
+over one week:
+
+```
+distiller   309,429 B removed   the whole of what the report showed
+ledger      501,385 B removed   not mentioned on any line
+```
+
+The ledger took out 1.6 times what the distiller did and the report said 4.5%,
+because that 4.5% was the distiller's saving divided by 15,718 calls OMNI had
+deliberately declined. The default view now leads with the bytes and gives each
+engine its own row:
+
+```
+    5.1 MB  never reached your model
+
+    folded      1.7 MB   41% of what it folded         906 folds
+    distilled   3.4 MB   48% of what it distilled    1,056 calls
+    left alone       0   by design                  15,718 calls
+```
+
+The two percentages come from different populations and are never added: bytes are
+summed, ratios are not. `left alone` reads `0` rather than the 31 MB that passed
+through, because those bytes are neither a win nor a loss.
+
+The fold figures count fold operations rather than `ledger_folds` rows: one fold
+writes a row per (origin, source agent) pair and repeats the payload size on each,
+so summing rows divided by the same payload several times and reported 31% where
+the real figure is 41%.
+
+`ledger_folds` gains a `fold_id` for this, because nothing in the table said which
+rows belonged together and every way of inferring it merges some pair of folds.
+Rows written before the column are backfilled from (second, session, agent, scope,
+payload size), which is the best the surviving data supports, so a count over
+history is a lower bound and its ratio a slight overstatement. Anything written
+since is exact. It is taken over the folds that record a payload at
+all, and says how many that was. `payload_bytes` arrived in a migration defaulting
+to zero, so the rest carry a saving with no base to divide it by; where none do,
+no percentage is printed at all.
+
+`--json` gains an `engines` object naming the two separately, so nothing downstream
+can average them.
+
+Session lifetime, the per-period table, top commands and the agent split moved to
+`--detail`, which also names why each call was declined out of `passthrough_events`.
+That column has been recorded since #533 and nothing printed it, which left a 94%
+passthrough share looking like an accusation instead of an explanation.

--- a/docs/website/src-id/use/seeing-savings.md
+++ b/docs/website/src-id/use/seeing-savings.md
@@ -18,10 +18,38 @@ omni stats --project       # dipecah per jalur proyek
 omni stats --json          # bisa dibaca mesin
 ```
 
-Ia memimpin dengan **umur sesi**: berapa perintah yang dibawa sebuah sesi sebelum
-host menutupnya. Itu meteran yang benar-benar diperhatikan pengguna. Persentase
-penyulingan di bawahnya adalah alat diagnosis untuk pipeline satu host, bukan
-klaim produk.
+Ia memimpin dengan byte yang tidak pernah sampai ke model Anda, lalu satu baris
+per mesin:
+
+```
+    5.1 MB  never reached your model
+
+    folded      1.7 MB   41% of what it folded         906 folds
+    distilled   3.4 MB   48% of what it distilled    1,056 calls
+    left alone       0   by design                  15,718 calls
+```
+
+**Kedua persentase itu berasal dari populasi yang berbeda dan tidak boleh
+dijumlahkan atau dirata-ratakan.** Penyuling memangkas 48% dari panggilan yang ia
+suling; ledger memangkas 41% dari muatan yang ia lipat. Total byte boleh dijumlahkan,
+dan itulah yang dilakukan baris utamanya. Sampai 0.7.7 laporan ini hanya membaca
+`distillations` dan tidak pernah membaca ledger sama sekali, jadi mesin yang paling
+banyak membuang byte justru hilang dari laporan, dan satu-satunya persentase yang
+tercetak adalah penyuling dibagi 15.718 panggilan yang sengaja ia lewatkan.
+
+**`left alone` tertulis `0`, bukan 31 MB yang lewat begitu saja.** Byte itu bukan
+kemenangan dan bukan kerugian, dan menaruhnya di kolom penghematan membuat pembaca
+mengira ada yang hilang.
+
+**Persentase lipatan hanya mencakup lipatan yang mencatat muatan asalnya.**
+`payload_bytes` datang lewat migrasi dengan nilai bawaan nol, jadi baris lama membawa
+penghematan tanpa basis. Laporannya menyebut berapa lipatan yang ia bagi, dan tidak
+mencetak persentase sama sekali kalau tidak ada satu pun yang mencatatnya.
+
+Umur sesi, tabel per periode, perintah teratas dan pemecahan per agent semuanya pindah
+ke `--detail`. `--detail` juga menyebut alasan tiap panggilan dilewatkan, dari
+`passthrough_events`, yang mengubah angka passthrough 94% dari tuduhan menjadi
+penjelasan.
 
 ## Angkanya dihitung dalam satuan apa
 

--- a/docs/website/src/use/seeing-savings.md
+++ b/docs/website/src/use/seeing-savings.md
@@ -18,9 +18,35 @@ omni stats --project       # broken down per project path
 omni stats --json          # machine readable
 ```
 
-It leads with **session lifetime**: how many commands a session carries before the
-host closes it. That is the meter a user actually watches. The distillation
-percentage below it is a diagnostic for one host's pipeline, not a product claim.
+It leads with the bytes that never reached your model, then one line per engine:
+
+```
+    5.1 MB  never reached your model
+
+    folded      1.7 MB   41% of what it folded         906 folds
+    distilled   3.4 MB   48% of what it distilled    1,056 calls
+    left alone       0   by design                  15,718 calls
+```
+
+**The two percentages come from different populations and may never be added or
+averaged.** The distiller took 48% off the calls it distilled; the ledger took 41%
+off the payloads it folded. Byte totals may be summed, which is what the headline
+does. Until 0.7.7 the report read `distillations` alone and never read the ledger at
+all, so the engine removing the most bytes was missing and the one percentage printed
+was the distiller divided by 15,718 calls it had deliberately declined.
+
+**`left alone` reads `0`, not the 31 MB that passed through.** Those bytes are neither
+a win nor a loss, and putting them in the savings column makes a reader think something
+went missing.
+
+**The fold percentage covers the folds that record the payload they came out of.**
+`payload_bytes` arrived in a migration defaulting to zero, so older rows carry a saving
+with no base. The report says how many of the folds it divided, and prints no percentage
+at all when none of them do.
+
+Session lifetime, the per-period table, top commands and the agent split all moved to
+`--detail`. `--detail` also names why each call was declined, out of `passthrough_events`,
+which is what turns a 94% passthrough share from an accusation into an explanation.
 
 ## What the numbers are counted in
 

--- a/src/cli/stats.rs
+++ b/src/cli/stats.rs
@@ -1,6 +1,6 @@
 // Safety: String slicing uses ASCII delimiter positions or boundary-checked safe utilities.
 
-use crate::store::sqlite::Store;
+use crate::store::sqlite::{EngineTotals, Store};
 use anyhow::{Context, Result};
 use colored::*;
 use std::collections::HashMap;
@@ -39,14 +39,6 @@ pub fn format_bar(pct: f64, width: usize) -> String {
     let filled = ((pct / 100.0) * width as f64).round() as usize;
     let filled = filled.min(width);
     "█".repeat(filled)
-}
-
-fn format_bar_with_empty(pct: f64) -> String {
-    let width = 20;
-    let filled = ((pct / 100.0) * width as f64).round() as usize;
-    let filled = filled.min(width);
-    let empty = width - filled;
-    format!("{}{}", "█".repeat(filled), "░".repeat(empty))
 }
 
 fn format_number(n: u64) -> String {
@@ -376,7 +368,7 @@ pub fn run(args: &[String], store: &Store) -> Result<()> {
         "project" => run_project_stats(args, store),
         "detail" => run_detail(args, store),
         "json" => run_json(store),
-        _ => run_default(store),
+        _ => run_default(args, store),
     }
 }
 
@@ -807,18 +799,131 @@ fn run_card(store: &Store) -> Result<()> {
     Ok(())
 }
 
-fn run_default(store: &Store) -> Result<()> {
-    let periods = store.multi_period_stats()?;
-    let (rewind_stored, rewind_retrieved) = store.rewind_metrics()?;
+/// One line per engine, each percentage against its own base (#665).
+///
+/// Split out from the printing so the arithmetic can be driven directly: the
+/// defect this replaces was a ratio taken over the wrong population, and a test
+/// that has to reach through a terminal to see one cannot check it.
+fn engine_rows(t: &EngineTotals) -> Vec<String> {
+    let rows: [(&str, u64, String, u64, &str); 3] = [
+        (
+            "folded",
+            t.fold_bytes,
+            match t.fold_pct() {
+                Some(p) => format!("{p:.0}% of what it folded"),
+                // No fold in the window records the payload it came out of, so
+                // there is no base. A ratio invented for the column would be a
+                // guess wearing a percent sign.
+                None => "of what it folded".to_string(),
+            },
+            t.folds,
+            "folds",
+        ),
+        (
+            "distilled",
+            t.distilled_saved(),
+            match t.distilled_pct() {
+                Some(p) => format!("{p:.0}% of what it distilled"),
+                None => "of what it distilled".to_string(),
+            },
+            t.distilled_calls,
+            "calls",
+        ),
+        // Declined calls saved nothing and lost nothing. Their 31 MB is not a
+        // number in this column: putting it here reads as bytes that went
+        // missing, and averaging their zero in is what reported a 48% distiller
+        // as 9%.
+        (
+            "left alone",
+            0,
+            "by design".to_string(),
+            t.declined_calls,
+            "calls",
+        ),
+    ];
 
-    let has_data = periods.iter().any(|(_, count, _, _, _, _)| *count > 0);
+    let saved: Vec<String> = rows
+        .iter()
+        .map(|(_, b, ..)| {
+            if *b == 0 {
+                "0".to_string()
+            } else {
+                format_bytes(*b)
+            }
+        })
+        .collect();
+    let counts: Vec<String> = rows
+        .iter()
+        .map(|(_, _, _, n, _)| format_number(*n))
+        .collect();
+
+    let w_label = max_width(rows.iter().map(|(l, ..)| *l));
+    let w_saved = max_width(&saved);
+    let w_base = max_width(rows.iter().map(|(_, _, b, _, _)| b.as_str()));
+    let w_count = max_width(&counts);
+
+    rows.iter()
+        .enumerate()
+        .map(|(i, (label, _, base, _, unit))| {
+            format!(
+                "    {:<w_label$}  {:>w_saved$}   {:<w_base$}   {:>w_count$} {}",
+                label, saved[i], base, counts[i], unit
+            )
+        })
+        .collect()
+}
+
+/// The lines that qualify the numbers above them, empty when nothing needs
+/// qualifying. Every one of them names a population, because both defects this
+/// report has shipped were ratios over a population the reader could not see.
+fn engine_caveats(t: &EngineTotals, since: i64) -> Vec<String> {
+    let mut out = Vec::new();
+
+    if t.folds > 0 {
+        if t.fold_pct().is_none() {
+            out.push(
+                "no fold in this window records the payload it came out of, so the fold column has no percentage"
+                    .to_string(),
+            );
+        } else if t.priced_folds < t.folds {
+            out.push(format!(
+                "fold percentage is measured over the {} of {} folds that record a payload size",
+                format_number(t.priced_folds),
+                format_number(t.folds)
+            ));
+        }
+    }
+
+    // `ledger_folds` is pruned, and it is younger than the distiller table on
+    // every machine that upgraded into it. A window the ledger does not cover is
+    // a window where its bytes are missing rather than zero.
+    if let Some(first) = t.first_fold_ts
+        && first > since
+        && let Some(d) = chrono::DateTime::from_timestamp(first, 0)
+    {
+        out.push(format!(
+            "folds recorded from {}, so this window is longer than the ledger's history",
+            d.format("%Y-%m-%d")
+        ));
+    }
+
+    out
+}
+
+fn run_default(args: &[String], store: &Store) -> Result<()> {
+    let (period_label, since) = scope(args);
+    let t = store.engine_totals(since)?;
 
     println!();
     print_separator();
-    println!(" {}", "OMNI Signal Report".bold().bright_white());
+    println!(
+        " {} {}",
+        "OMNI".bold().bright_white(),
+        format!("· {period_label}").bright_black()
+    );
     print_separator();
 
-    if !has_data {
+    if t.distilled_calls == 0 && t.declined_calls == 0 && t.folds == 0 {
         println!(
             "  {}",
             "No data yet! OMNI tracks savings automatically as you work."
@@ -831,213 +936,25 @@ fn run_default(store: &Store) -> Result<()> {
         return Ok(());
     }
 
-    // #435. The headline is session lifetime, because that is the meter #357
-    // promoted and `CONTRIBUTING.md` calls the number that decides progress. The
-    // distillation percentage below it is a diagnostic for one host's pipeline
-    // and says so, which is the whole of the correction: it was never wrong, it
-    // was presented as the product number after the project stopped treating it
-    // as one.
-    let (sessions, median_cmds, longest, compacted) = store.session_lifetime(0);
-    println!("  {}", "Session lifetime:".bold().bright_white());
-    if sessions == 0 {
-        println!(
-            "  {}",
-            "  not measurable yet: no session has been closed by a host that reports one"
-                .bright_black()
-                .italic()
-        );
-    } else {
-        println!(
-            "  {} commands median, {} longest, across {} closed sessions",
-            median_cmds.to_string().bright_green().bold(),
-            longest.to_string().cyan(),
-            format_number(sessions).cyan()
-        );
-        let compaction_line = if compacted == 0 {
-            "  none ended at a compaction, so this measures sessions, not the window".to_string()
-        } else {
-            format!("  {compacted} of them ended at a compaction, which is what the window costs")
-        };
-        println!("  {}", compaction_line.bright_black().italic());
+    println!();
+    println!(
+        "    {}  {}",
+        format_bytes(t.total_saved()).bold().bright_green(),
+        "never reached your model".bright_white()
+    );
+    println!();
+    for line in engine_rows(&t) {
+        println!("{}", line);
     }
     println!();
     println!(
-        "  {} {}",
-        "Pipeline diagnostic:".bold().bright_white(),
-        "one host's tool output, not a product claim"
+        "    {}",
+        "nothing deleted, nothing invented, no call came back larger"
             .bright_black()
             .italic()
     );
-
-    // Multi-period rows
-    let period_rows: Vec<PeriodRow<'_>> = periods
-        .iter()
-        .filter(|(label, count, ..)| *count > 0 || label == "All Time")
-        .map(
-            |(label, count, input, output, _raw_tokens, _filtered_tokens)| PeriodRow {
-                label,
-                count: *count,
-                raw_bytes: *input,
-                filtered_bytes: *output,
-                reduction_pct: if *input > 0 {
-                    100.0 * (1.0 - *output as f64 / *input as f64)
-                } else {
-                    0.0
-                },
-            },
-        )
-        .collect();
-
-    for line in format_period_rows(&period_rows) {
-        println!("{}", line);
-    }
-
-    // #212: say what the number is a number *of*. It counts only calls whose
-    // result reached a model's context; `omni exec` and pipe output read at a
-    // terminal is compression a human sees, not tokens anyone was billed for,
-    // and folding the two together is what made the all-time headline 66.3%
-    // when the model-facing figure was 29.3%.
-    println!(
-        "  {}",
-        "Counts calls whose result reached a model. Terminal output is excluded:\n  no context holds it."
-            .bright_black()
-            .italic()
-    );
-
-    // #173 asked for a second, cache-discounted figure beside this one, because a
-    // distilled tool result is re-sent on every later turn and OMNI counts the
-    // saving once. `Store::token_savings_with_reuse` computes it and is tested,
-    // and it is deliberately not printed yet.
-    //
-    // Run against the maintainer's database it reports 17.0M at insertion and
-    // 469.3M with re-use, a 27.6x multiplier. The multiplier is wrong, and it is
-    // wrong because of #118 item 1: until #259 every distillation was filed under
-    // a wall-clock id, so one "session" covers 3,739 commands across 16 project
-    // paths and hands its first row a 374x credit. The arithmetic is right and
-    // the input is not.
-    //
-    // Publishing it would be a bigger number that is less true, which is the
-    // defect this tracker exists to fight. It goes in once enough history exists
-    // under real host session ids to make `turns_after` mean what it says.
-
-    let top_commands = get_top_commands(store, 0, 8);
-
-    if !top_commands.is_empty() {
-        println!("\n  {}", "Top Commands:".bold().bright_white());
-        let w_count = max_width(
-            top_commands
-                .iter()
-                .map(|(_, count, _, _)| count.to_string()),
-        );
-        for (cmd, count, pct, bytes_saved) in &top_commands {
-            let short_cmd = shorten_command(cmd, 18);
-            let bar = format_bar_with_empty(*pct);
-            let bar_colored = if *pct > 80.0 {
-                bar.bright_green()
-            } else if *pct > 40.0 {
-                bar.bright_yellow()
-            } else {
-                bar.bright_red()
-            };
-
-            let tokens_str = if *bytes_saved > 0 {
-                format!("(-{})", format_bytes(*bytes_saved)).bright_black()
-            } else {
-                "".bright_black()
-            };
-
-            println!(
-                "    {:<18} {}  {:>5.1}%  ({:>w_count$}x)  {}",
-                short_cmd.bright_cyan(),
-                bar_colored,
-                pct,
-                count,
-                tokens_str,
-            );
-        }
-    }
-
-    // Agent Distribution
-    let agent_data = store.get_agent_breakdown(0).unwrap_or_default();
-
-    // Group by display name
-    let mut grouped_agents: HashMap<String, (u64, u64, u64)> = HashMap::new();
-    for r in &agent_data {
-        if r.agent_id == "unknown" || r.agent_id == "terminal" || r.agent_id.is_empty() {
-            continue;
-        }
-        let name = agent_display_name(&r.agent_id).to_string();
-        let entry = grouped_agents.entry(name).or_insert((0, 0, 0));
-        entry.0 += r.calls;
-        entry.1 += r.input_bytes;
-        entry.2 += r.output_bytes;
-    }
-
-    if !grouped_agents.is_empty() {
-        let total_cmds: u64 = agent_data.iter().map(|r| r.calls).sum();
-        println!("\n  {}", "Agent Distribution:".bold().bright_white());
-
-        let mut sorted_agents: Vec<_> = grouped_agents.into_iter().collect();
-        sorted_agents.sort_by_key(|a| std::cmp::Reverse(a.1.0));
-
-        let w_name = max_width(sorted_agents.iter().map(|(name, _)| name.as_str())).max(18);
-        let w_count = max_width(
-            sorted_agents
-                .iter()
-                .map(|(_, (count, _, _))| count.to_string()),
-        );
-
-        for (name, (count, input, output)) in sorted_agents {
-            let pct = if total_cmds > 0 {
-                count as f64 / total_cmds as f64 * 100.0
-            } else {
-                0.0
-            };
-            let savings = if input > 0 {
-                100.0 * (1.0 - output as f64 / input as f64)
-            } else {
-                0.0
-            };
-            let bar = format_bar_with_empty(pct);
-            println!(
-                "   {:<w_name$} {}  {:>5.1}%  ({:>w_count$}x)  {:>5.1}% saved",
-                name.bright_cyan(),
-                bar.bright_blue(),
-                pct,
-                count,
-                savings,
-            );
-        }
-    }
-
-    // RewindStore
-    println!(
-        "\n  {:<20} {}",
-        "RewindStore:".bright_black(),
-        format!(
-            "{} archived │ {} retrieved",
-            rewind_stored, rewind_retrieved
-        )
-        .bright_magenta()
-    );
-
-    // The fidelity alarm. An expansion request is an agent saying the view it
-    // was given was not enough, so a rising share of archived blocks being
-    // fetched back means the projection is cutting too much. The number was
-    // already being acted on silently: `post_tool` raises the route thresholds
-    // once a command family passes 25%. This makes the same signal visible
-    // rather than only effective.
-    if let Some(rate) = (100 * rewind_retrieved).checked_div(rewind_stored)
-        && rate >= 25
-    {
-        println!(
-            "  {:<20} {}",
-            "Fidelity:".bright_black(),
-            format!(
-                "{rate}% of archived blocks were fetched back, so distillation is cutting too much"
-            )
-            .yellow()
-        );
+    for line in engine_caveats(&t, since) {
+        println!("    {}", line.bright_black().italic());
     }
 
     print_separator();
@@ -1141,6 +1058,95 @@ fn run_detail(args: &[String], store: &Store) -> Result<()> {
                 events
             )
             .bright_green()
+        );
+    }
+
+    // #665 moved these three out of the default view. They answer "what did the
+    // pipeline do", which is a maintainer's question; the default answers "what
+    // did this save me", which is the user's.
+
+    // The fidelity alarm. An expansion request is an agent saying the view it
+    // was given was not enough, so a rising share of archived blocks being
+    // fetched back means the projection is cutting too much. The number was
+    // already being acted on silently: `post_tool` raises the route thresholds
+    // once a command family passes 25%. This makes the same signal visible
+    // rather than only effective.
+    if let Some(rate) = (100 * rewind_retrieved).checked_div(rewind_stored)
+        && rate >= 25
+    {
+        println!(
+            "  {:<20} {}",
+            "Fidelity:".bright_black(),
+            format!(
+                "{rate}% of archived blocks were fetched back, so distillation is cutting too much"
+            )
+            .yellow()
+        );
+    }
+
+    // #435. Session lifetime is the meter `CONTRIBUTING.md` calls the number
+    // that decides progress, and it is all-time by design: a 30 day window over
+    // closed sessions says less than every session ever closed.
+    let (sessions, median_cmds, longest, compacted) = store.session_lifetime(0);
+    println!("\n {}", "Session lifetime:".bold().bright_white());
+    if sessions == 0 {
+        println!(
+            "  {}",
+            "not measurable yet: no session has been closed by a host that reports one"
+                .bright_black()
+                .italic()
+        );
+    } else {
+        println!(
+            "  {} commands median, {} longest, across {} closed sessions",
+            median_cmds.to_string().bright_green().bold(),
+            longest.to_string().cyan(),
+            format_number(sessions).cyan()
+        );
+        let compaction_line = if compacted == 0 {
+            "none ended at a compaction, so this measures sessions, not the window".to_string()
+        } else {
+            format!("{compacted} of them ended at a compaction, which is what the window costs")
+        };
+        println!("  {}", compaction_line.bright_black().italic());
+    }
+
+    // #212: say what the number is a number *of*. It counts only calls whose
+    // result reached a model's context; `omni exec` and pipe output read at a
+    // terminal is compression a human sees, not tokens anyone was billed for,
+    // and folding the two together is what made the all-time headline 66.3%
+    // when the model-facing figure was 29.3%.
+    let periods = store.multi_period_stats()?;
+    let period_rows: Vec<PeriodRow<'_>> = periods
+        .iter()
+        .filter(|(label, count, ..)| *count > 0 || label == "All Time")
+        .map(
+            |(label, count, input, output, _raw_tokens, _filtered_tokens)| PeriodRow {
+                label,
+                count: *count,
+                raw_bytes: *input,
+                filtered_bytes: *output,
+                reduction_pct: if *input > 0 {
+                    100.0 * (1.0 - *output as f64 / *input as f64)
+                } else {
+                    0.0
+                },
+            },
+        )
+        .collect();
+    if !period_rows.is_empty() {
+        println!(
+            "\n {}",
+            "Every recorded call, by period:".bold().bright_white()
+        );
+        for line in format_period_rows(&period_rows) {
+            println!("{}", line);
+        }
+        println!(
+            "  {}",
+            "Declined calls are in this base, which is why it is far under the distiller's own\n  figure above. Counts calls whose result reached a model: terminal output is excluded,\n  no context holds it."
+                .bright_black()
+                .italic()
         );
     }
 
@@ -1299,6 +1305,20 @@ fn run_detail(args: &[String], store: &Store) -> Result<()> {
                 cnt,
                 pct
             );
+
+            // #665. Passthrough is most of the table and was one bucket, which
+            // reads as OMNI doing nothing to 94% of calls. `passthrough_events`
+            // has recorded why since #533; nothing printed it.
+            if route.eq_ignore_ascii_case("passthrough") {
+                for (reason, n) in store.passthrough_reasons(since).iter().take(6) {
+                    println!(
+                        "  {:<17}{}  {}",
+                        "",
+                        format!("{n:>6}").bright_black(),
+                        reason.bright_black()
+                    );
+                }
+            }
         }
     }
 
@@ -1418,6 +1438,53 @@ pub struct StatsJson {
     pub agents: Vec<AgentStat>,
     pub rewind: RewindStat,
     pub avg_latency_ms: f64,
+    /// #665. Both engines, each ratio against its own base and named separately
+    /// so nothing downstream can average them. `periods` above is the distiller
+    /// alone and was the whole of this document while the ledger removed more.
+    pub engines: EngineStats,
+}
+
+/// All time, like the rest of `StatsJson`. `folded.first_fold_ts` is the only
+/// window any of it has, and it is there because the ledger table is younger
+/// than the distiller one and is pruned.
+#[derive(serde::Serialize)]
+pub struct EngineStats {
+    pub bytes_saved: u64,
+    pub distilled: DistilledStat,
+    pub folded: FoldedStat,
+    pub declined: DeclinedStat,
+}
+
+#[derive(serde::Serialize)]
+pub struct DistilledStat {
+    pub calls: u64,
+    pub input_bytes: u64,
+    pub output_bytes: u64,
+    pub bytes_saved: u64,
+    /// Against the bytes this engine was given, not against every recorded call.
+    pub pct_of_own_input: Option<f64>,
+}
+
+#[derive(serde::Serialize)]
+pub struct FoldedStat {
+    pub folds: u64,
+    pub bytes_saved: u64,
+    /// Folds recording the payload they came out of. `pct_of_own_input` covers
+    /// these and only these; the rest carry a saving with no base.
+    pub priced_folds: u64,
+    pub priced_payload_bytes: u64,
+    pub pct_of_own_input: Option<f64>,
+    /// `ledger_folds` is pruned and younger than `distillations` on any machine
+    /// that upgraded into it, so a window can be older than every fold in it.
+    pub first_fold_ts: Option<i64>,
+}
+
+#[derive(serde::Serialize)]
+pub struct DeclinedStat {
+    pub calls: u64,
+    /// Always zero. A declined call is a no-op by design, and the bytes that
+    /// passed through it are neither saved nor lost.
+    pub bytes_saved: u64,
 }
 
 #[derive(serde::Serialize)]
@@ -1461,6 +1528,33 @@ pub struct RewindStat {
 }
 
 fn run_json(store: &Store) -> Result<()> {
+    // All time, like every other field in this document. Reading the window
+    // flags here and nowhere else would put two populations in one object and
+    // leave a consumer to discover which is which.
+    let t = store.engine_totals(0)?;
+    let engines = EngineStats {
+        bytes_saved: t.total_saved(),
+        distilled: DistilledStat {
+            calls: t.distilled_calls,
+            input_bytes: t.distilled_input,
+            output_bytes: t.distilled_output,
+            bytes_saved: t.distilled_saved(),
+            pct_of_own_input: t.distilled_pct(),
+        },
+        folded: FoldedStat {
+            folds: t.folds,
+            bytes_saved: t.fold_bytes,
+            priced_folds: t.priced_folds,
+            priced_payload_bytes: t.priced_payload,
+            pct_of_own_input: t.fold_pct(),
+            first_fold_ts: t.first_fold_ts,
+        },
+        declined: DeclinedStat {
+            calls: t.declined_calls,
+            bytes_saved: 0,
+        },
+    };
+
     let periods = store.multi_period_stats()?;
     let top_commands = get_top_commands(store, 0, 100);
     let (rewind_stored, rewind_retrieved) = store.rewind_metrics()?;
@@ -1542,6 +1636,7 @@ fn run_json(store: &Store) -> Result<()> {
             retrieved: rewind_retrieved,
         },
         avg_latency_ms: (avg_latency * 10.0).round() / 10.0,
+        engines,
     };
 
     println!("{}", serde_json::to_string_pretty(&output)?);
@@ -1958,13 +2053,6 @@ mod tests {
     }
 
     #[test]
-    fn test_format_bar_with_empty() {
-        assert_eq!(format_bar_with_empty(100.0), "████████████████████");
-        assert_eq!(format_bar_with_empty(50.0), "██████████░░░░░░░░░░");
-        assert_eq!(format_bar_with_empty(0.0), "░░░░░░░░░░░░░░░░░░░░");
-    }
-
-    #[test]
     fn test_format_number() {
         assert_eq!(format_number(0), "0");
         assert_eq!(format_number(999), "999");
@@ -1992,6 +2080,28 @@ mod tests {
                 retrieved: 5,
             },
             avg_latency_ms: 15.5,
+            engines: EngineStats {
+                bytes_saved: 5_354_232,
+                distilled: DistilledStat {
+                    calls: 1_041,
+                    input_bytes: 7_453_169,
+                    output_bytes: 3_849_739,
+                    bytes_saved: 3_603_430,
+                    pct_of_own_input: Some(48.3),
+                },
+                folded: FoldedStat {
+                    folds: 1_269,
+                    bytes_saved: 1_750_802,
+                    priced_folds: 468,
+                    priced_payload_bytes: 1_160_138,
+                    pct_of_own_input: Some(31.1),
+                    first_fold_ts: Some(1_786_712_874),
+                },
+                declined: DeclinedStat {
+                    calls: 15_443,
+                    bytes_saved: 0,
+                },
+            },
         };
 
         let json_str = serde_json::to_string(&json_struct).unwrap();
@@ -1999,6 +2109,109 @@ mod tests {
         assert!(json_str.contains("\"generated_at\":1234567890"));
         assert!(json_str.contains("\"savings_pct\":90.0"));
         assert!(json_str.contains("\"avg_latency_ms\":15.5"));
+        // #665. The two engines are separate objects with separate bases, so a
+        // consumer can sum the bytes and cannot average the percentages.
+        assert!(json_str.contains("\"folded\":{\"folds\":1269"));
+        assert!(json_str.contains("\"priced_folds\":468"));
+        assert!(json_str.contains("\"declined\":{\"calls\":15443,\"bytes_saved\":0}"));
+    }
+
+    /// The maintainer's own week, as #665 recorded it: the distiller took 48%
+    /// off the 1,041 calls it was given, and `omni stats` printed 4.5% because
+    /// it divided that saving by 15,443 calls it had deliberately declined.
+    fn a_real_week() -> EngineTotals {
+        EngineTotals {
+            distilled_calls: 1_041,
+            distilled_input: 7_453_169,
+            distilled_output: 3_849_739,
+            declined_calls: 15_443,
+            folds: 1_269,
+            fold_bytes: 1_750_802,
+            priced_folds: 468,
+            priced_fold_bytes: 360_739,
+            priced_payload: 1_160_138,
+            // 2026-08-14 13:07:54Z, the first fold this machine ever recorded.
+            first_fold_ts: Some(1_786_712_874),
+        }
+    }
+
+    /// #665. Two engines, two populations, and the report has to keep them
+    /// apart: the declined calls are neither a saving nor a base, and the byte
+    /// totals are the only thing the two engines may share a column with.
+    #[test]
+    fn no_row_takes_a_ratio_over_a_population_it_did_not_come_from() {
+        let out = engine_rows(&a_real_week()).join("\n");
+
+        assert!(out.contains("48% of what it distilled"), "{out}");
+        assert!(out.contains("31% of what it folded"), "{out}");
+        // What the old report said, from the same rows.
+        assert!(
+            !out.contains("9%"),
+            "distiller averaged over declined calls: {out}"
+        );
+        assert!(
+            !out.contains("4%"),
+            "distiller averaged over declined calls: {out}"
+        );
+
+        let declined = out
+            .lines()
+            .find(|l| l.contains("left alone"))
+            .expect("a row for the calls OMNI declined");
+        assert!(!declined.contains('%'), "a no-op has no ratio: {declined}");
+        assert!(
+            !declined.contains("MB") && !declined.contains("KB"),
+            "declined bytes are neither saved nor lost: {declined}"
+        );
+        assert!(declined.contains("15,443 calls"), "{declined}");
+    }
+
+    /// A fold row carries `payload_bytes` only since the migration that added
+    /// it, so most of them record a saving with no base. Dividing by the ones
+    /// that do and presenting it as the whole is the two-population error that
+    /// put a wrong figure in #533's thread.
+    #[test]
+    fn a_percentage_appears_only_where_a_base_exists() {
+        let mut t = a_real_week();
+        t.priced_folds = 0;
+        t.priced_fold_bytes = 0;
+        t.priced_payload = 0;
+
+        let rows = engine_rows(&t).join("\n");
+        let folded = rows.lines().find(|l| l.contains("folded")).unwrap();
+        assert!(!folded.contains('%'), "no base, no ratio: {folded}");
+        assert!(
+            folded.contains("1.7 MB"),
+            "the bytes are still known: {folded}"
+        );
+
+        let caveats = engine_caveats(&t, 0).join("\n");
+        assert!(
+            caveats.contains("no fold in this window records"),
+            "{caveats}"
+        );
+    }
+
+    /// Both caveats name a population or a date. A number printed without the
+    /// window it came from is the defect #665 was filed against, one layer down.
+    #[test]
+    fn the_caveats_name_the_population_and_the_window() {
+        let t = a_real_week();
+        // A window opening well before the first recorded fold.
+        let caveats = engine_caveats(&t, 1_700_000_000).join("\n");
+
+        assert!(
+            caveats.contains("468 of 1,269 folds"),
+            "the priced population is not named: {caveats}"
+        );
+        assert!(
+            caveats.contains("2026-08-14"),
+            "the ledger's first day is not named: {caveats}"
+        );
+
+        // A window opening after the first fold needs no date caveat.
+        let inside = engine_caveats(&t, 1_800_000_000).join("\n");
+        assert!(!inside.contains("2026-08-14"), "{inside}");
     }
 
     /// #663. `measurement_method` exists to tell a reader how far to trust the

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -351,6 +351,98 @@ impl SqliteBackend {
         Ok(rows)
     }
 
+    /// Both engines, each against its own base (#665). `omni stats` computed
+    /// everything from `distillations` and never read `ledger_folds`, so the
+    /// engine that removed the most bytes was absent from the report, and the
+    /// one percentage printed was the distiller averaged over every call OMNI
+    /// deliberately declined.
+    pub fn engine_totals(&self, since: i64) -> Result<EngineTotals> {
+        let conn = self.pool.get().context("DB pool exhausted")?;
+        let mut t = EngineTotals::default();
+
+        let mut stmt = conn.prepare(&format!(
+            "SELECT route, COUNT(*), COALESCE(SUM(input_bytes),0), COALESCE(SUM(output_bytes),0)
+             FROM distillations WHERE ts >= ?1 AND {} GROUP BY route",
+            applied_only()
+        ))?;
+        let rows = stmt.query_map(params![since], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, u64>(1)?,
+                row.get::<_, u64>(2)?,
+                row.get::<_, u64>(3)?,
+            ))
+        })?;
+        for (route, calls, input, output) in rows.flatten() {
+            // A declined call contributes no saving and no base. Averaging it in
+            // is what turned 48% into 9%, and putting its 31 MB in the same
+            // column as the savings reads as bytes that went missing.
+            if route == "Passthrough" {
+                t.declined_calls += calls;
+            } else {
+                t.distilled_calls += calls;
+                t.distilled_input += input;
+                t.distilled_output += output;
+            }
+        }
+
+        // One fold writes one row per (origin, source agent) pair and repeats
+        // the same `payload_bytes` on each, so rows are not folds. Counting rows
+        // inflates the population and, below, sums one payload several times:
+        // 479 priced rows on the maintainer's machine are 406 folds, and the
+        // difference took a real 41% down to a reported 31%. `bytes` is the one
+        // column that is genuinely per-row and stays a plain sum.
+        //
+        // `fold_id` is exact for anything written since the migration that added
+        // it. Rows older than that were backfilled from (second, session, agent,
+        // scope, payload size), which merges two folds that share all five, so a
+        // historical count is a lower bound and a historical ratio a slight
+        // overstatement.
+        let folds = conn.query_row(
+            "SELECT COUNT(*), COALESCE(SUM(bytes),0), MIN(ts) FROM (
+                 SELECT SUM(bytes) AS bytes, MIN(ts) AS ts FROM ledger_folds
+                 WHERE ts >= ?1 GROUP BY fold_id)",
+            params![since],
+            |row| {
+                Ok((
+                    row.get::<_, u64>(0)?,
+                    row.get::<_, u64>(1)?,
+                    row.get::<_, Option<i64>>(2)?,
+                ))
+            },
+        );
+        if let Ok((count, bytes, first)) = folds {
+            t.folds = count;
+            t.fold_bytes = bytes;
+            t.first_fold_ts = first;
+        }
+
+        // `payload_bytes` arrived in a migration defaulting to 0, so most rows
+        // carry a saving with no base to divide it by. Counting them separately
+        // is the difference between a ratio and the two-population error that
+        // put a wrong figure in #533's thread.
+        let priced = conn.query_row(
+            "SELECT COUNT(*), COALESCE(SUM(bytes),0), COALESCE(SUM(payload),0) FROM (
+                 SELECT SUM(bytes) AS bytes, MAX(payload_bytes) AS payload FROM ledger_folds
+                 WHERE ts >= ?1 AND payload_bytes > 0 GROUP BY fold_id)",
+            params![since],
+            |row| {
+                Ok((
+                    row.get::<_, u64>(0)?,
+                    row.get::<_, u64>(1)?,
+                    row.get::<_, u64>(2)?,
+                ))
+            },
+        );
+        if let Ok((count, bytes, payload)) = priced {
+            t.priced_folds = count;
+            t.priced_fold_bytes = bytes;
+            t.priced_payload = payload;
+        }
+
+        Ok(t)
+    }
+
     /// Route distribution: (route, count)
     pub fn route_distribution(&self, since: i64) -> Result<Vec<(String, u64)>> {
         let conn = self.pool.get().context("DB pool exhausted")?;
@@ -834,6 +926,36 @@ impl SqliteBackend {
             "ALTER TABLE ledger_folds ADD COLUMN session TEXT NOT NULL DEFAULT ''",
             [],
         );
+        // #665. One fold writes a row per (origin, source agent) pair, and until
+        // this column nothing recorded which rows belonged together. Reporting
+        // had to infer it from (second, session, agent, scope, payload size),
+        // which merges two folds that land in one second on a payload of the
+        // same size.
+        //
+        // Rows written before the column get that same inference as a backfill,
+        // because the information is genuinely gone: the smallest `id` in each
+        // inferred group, which is stable and matches what a new fold gets.
+        let fresh_fold_id = conn
+            .execute(
+                "ALTER TABLE ledger_folds ADD COLUMN fold_id INTEGER NOT NULL DEFAULT 0",
+                [],
+            )
+            .is_ok();
+        if fresh_fold_id {
+            let _ = conn.execute(
+                "UPDATE ledger_folds SET fold_id = (
+                     SELECT MIN(f.id) FROM ledger_folds f
+                     WHERE f.ts = ledger_folds.ts AND f.session = ledger_folds.session
+                       AND f.agent_id = ledger_folds.agent_id AND f.scope = ledger_folds.scope
+                       AND f.payload_bytes = ledger_folds.payload_bytes)",
+                [],
+            );
+        }
+        let _ = conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_ledger_folds_fold ON ledger_folds(fold_id)",
+            [],
+        );
+
         // #581. Set when a handle is pulled and cleared by the delivery that
         // answers it, so the content a marker sent the reader to fetch is not
         // folded back into that same marker on its way in. Separate from
@@ -2076,12 +2198,23 @@ impl SqliteBackend {
         let Ok(tx) = conn.transaction() else {
             return;
         };
+        // Every row of this call carries it, so reporting can group by fold
+        // instead of inferring one from a timestamp (#665). `id` is the rowid,
+        // so `MAX` is a lookup rather than a scan, and the value it picks is the
+        // id the first row is about to get.
+        let fold_id: i64 = tx
+            .query_row(
+                "SELECT COALESCE(MAX(id), 0) + 1 FROM ledger_folds",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap_or(0);
         {
             let Ok(mut stmt) = tx.prepare_cached(
                 "INSERT INTO ledger_folds
                      (ts, scope, agent_id, source_agent, origin, lines, bytes, whole_output,
-                      payload_bytes, session)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+                      payload_bytes, session, fold_id)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
             ) else {
                 return;
             };
@@ -2096,7 +2229,8 @@ impl SqliteBackend {
                     f.bytes as i64,
                     i64::from(f.whole_output),
                     f.payload_bytes as i64,
-                    session
+                    session,
+                    fold_id
                 ]);
             }
         }
@@ -2792,6 +2926,54 @@ impl SqliteBackend {
 /// Grouped by the caller so a payload folding twenty runs from one agent writes
 /// one row rather than twenty. The recipient is on the call, not the row, since
 /// it is the same for every fold in a payload.
+/// What each engine removed, and the base each removed it from (#665).
+///
+/// The two ratios come from different populations and may never be added or
+/// averaged together. Bytes may be summed; percentages may not.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct EngineTotals {
+    pub distilled_calls: u64,
+    pub distilled_input: u64,
+    pub distilled_output: u64,
+    /// Calls OMNI declined. They save nothing and cost nothing, and they are the
+    /// 15,395 that dragged a 48% distiller down to a reported 9%.
+    pub declined_calls: u64,
+    /// Fold operations, not `ledger_folds` rows. One fold writes a row per
+    /// (origin, source agent) pair carrying the same payload size.
+    pub folds: u64,
+    pub fold_bytes: u64,
+    /// Folds recording the payload they came out of, which is the only base the
+    /// fold ratio may be taken against. Calls, for the same reason as above.
+    pub priced_folds: u64,
+    pub priced_fold_bytes: u64,
+    pub priced_payload: u64,
+    pub first_fold_ts: Option<i64>,
+}
+
+impl EngineTotals {
+    pub fn distilled_saved(&self) -> u64 {
+        self.distilled_input.saturating_sub(self.distilled_output)
+    }
+
+    /// Bytes neither engine let through. Absolute, because summing the two
+    /// percentages is the error this whole type exists to prevent.
+    pub fn total_saved(&self) -> u64 {
+        self.distilled_saved() + self.fold_bytes
+    }
+
+    pub fn distilled_pct(&self) -> Option<f64> {
+        (self.distilled_input > 0)
+            .then(|| 100.0 * self.distilled_saved() as f64 / self.distilled_input as f64)
+    }
+
+    /// `None` when no fold in the window records a payload size, because a
+    /// ratio over a base that does not exist is a guess wearing a percent sign.
+    pub fn fold_pct(&self) -> Option<f64> {
+        (self.priced_payload > 0)
+            .then(|| 100.0 * self.priced_fold_bytes as f64 / self.priced_payload as f64)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct FoldRecord {
     /// The agent that was shown these lines first, from `ledger_lines.agent_id`.
@@ -3652,6 +3834,148 @@ mod tests {
             filtered_tokens: 25,
             delivered_bytes: 100,
         }
+    }
+
+    /// #665. The one percentage `omni stats` printed was the distiller averaged
+    /// over every call OMNI deliberately declined, and `ledger_folds` was not
+    /// read at all. On the maintainer's machine that reported 4.5% for a week in
+    /// which the distiller took 48% off what it was given and the ledger removed
+    /// 1.6 times as many bytes again.
+    ///
+    /// Both halves are here because either one alone passes with the other
+    /// broken: a base that includes the declined calls still reads folds, and a
+    /// reader that ignores the ledger still gets the distiller ratio right.
+    #[test]
+    fn the_declined_calls_stay_out_of_the_base_and_the_folds_are_counted() {
+        let (store, _dir) = get_temp_store();
+
+        let mut distilled = any_distillation();
+        distilled.input_bytes = 1_000;
+        distilled.output_bytes = 200;
+        distilled.delivered_bytes = 200;
+        store.record_distillation("s1", &distilled, "cargo build", "", "claude_code");
+
+        // Nine declined calls, each larger than the distilled one. Averaged in
+        // they drag 80% down to 8%, which is the shape of the defect.
+        let mut declined = any_distillation();
+        declined.route = crate::pipeline::Route::Passthrough;
+        declined.input_bytes = 10_000;
+        declined.output_bytes = 10_000;
+        declined.delivered_bytes = 10_000;
+        for _ in 0..9 {
+            store.record_distillation("s1", &declined, "kubectl get pods", "", "claude_code");
+        }
+
+        // One fold, two rows: the lines came from two agents, and every row of a
+        // fold repeats the same payload size. Summing `payload_bytes` over rows
+        // therefore divides 500 saved bytes by 4,000 instead of 2,000.
+        store.ledger_record_folds(
+            "/proj",
+            "claude_code",
+            "s1",
+            &[
+                FoldRecord {
+                    source_agent: "claude_code".to_string(),
+                    origin: "project",
+                    lines: 40,
+                    bytes: 400,
+                    whole_output: false,
+                    payload_bytes: 2_000,
+                },
+                FoldRecord {
+                    source_agent: "codex".to_string(),
+                    origin: "project",
+                    lines: 10,
+                    bytes: 100,
+                    whole_output: false,
+                    payload_bytes: 2_000,
+                },
+            ],
+        );
+
+        // A second fold, same second, same session, same payload size, and it
+        // repeats a (origin, source agent) pair the first one already used. The
+        // table has no fold id, so nothing but that repeat distinguishes the two.
+        store.ledger_record_folds(
+            "/proj",
+            "claude_code",
+            "s1",
+            &[FoldRecord {
+                source_agent: "claude_code".to_string(),
+                origin: "project",
+                lines: 40,
+                bytes: 400,
+                whole_output: false,
+                payload_bytes: 2_000,
+            }],
+        );
+
+        // A third fold sharing the second, the session, the agent, the scope and
+        // the payload size, and overlapping the first two in no (origin, source
+        // agent) pair at all. Nothing outside `fold_id` separates it from them.
+        store.ledger_record_folds(
+            "/proj",
+            "claude_code",
+            "s1",
+            &[FoldRecord {
+                source_agent: "codex".to_string(),
+                origin: "session",
+                lines: 10,
+                bytes: 100,
+                whole_output: false,
+                payload_bytes: 2_000,
+            }],
+        );
+
+        // A fourth fold with no payload size: summable, never divisible.
+        store.ledger_record_folds(
+            "/proj",
+            "claude_code",
+            "s1",
+            &[FoldRecord {
+                source_agent: "claude_code".to_string(),
+                origin: "session",
+                lines: 5,
+                bytes: 50,
+                whole_output: false,
+                payload_bytes: 0,
+            }],
+        );
+
+        // Force every row into one second. The recorder stamps wall clock, so a
+        // test cannot otherwise decide whether two folds land together, and the
+        // collision these three are here to prove would appear or not by timing.
+        store
+            .pool
+            .get()
+            .unwrap()
+            .execute("UPDATE ledger_folds SET ts = 1000", [])
+            .unwrap();
+
+        let t = store.engine_totals(0).unwrap();
+
+        assert_eq!(t.distilled_calls, 1);
+        assert_eq!(t.declined_calls, 9);
+        assert_eq!(t.distilled_input, 1_000, "a declined call is not a base");
+        assert_eq!(t.distilled_pct().map(|p| p.round()), Some(80.0));
+
+        assert_eq!(t.folds, 4, "four folds across five rows");
+        assert_eq!(
+            t.fold_bytes, 1_050,
+            "bytes are per row and all of them count"
+        );
+        assert_eq!(t.priced_folds, 3, "three of them record a base");
+        assert_eq!(
+            t.priced_payload, 6_000,
+            "one payload per fold, not one per row"
+        );
+        // 1,000 removed from 6,000. Two rows deep it would be 1,000 from 2,000,
+        // and one row per payload would make it 1,000 from 8,000.
+        assert_eq!(t.fold_pct().map(|p| (p * 10.0).round()), Some(167.0));
+
+        // 800 from the distiller, 1,050 from the ledger. Bytes may be summed;
+        // the two percentages above may not.
+        assert_eq!(t.total_saved(), 1_850);
     }
 
     /// #118: the "Last distill" reading came from `rewind_store`, which only

--- a/tests/smoke_test.sh
+++ b/tests/smoke_test.sh
@@ -173,8 +173,16 @@ check_exit "session start exits cleanly" "$SESSION_EXIT" "0"
 # ─── 7. Stats ────────────────────────────────────────────
 echo "▸ Scenario 7: Stats"
 STATS_OUT=$("$OMNI" stats 2>&1 || true)
-check "stats shows header" "$STATS_OUT" "Signal Report"
-check "stats shows commands" "$STATS_OUT" "commands"
+check "stats names its window" "$STATS_OUT" "last 30 days"
+# #665: the default view leads with what never reached the model and names both
+# engines. A fresh store here takes the no-data path, same as the share card.
+if echo "$STATS_OUT" | grep -q "No data yet"; then
+    check "stats says so when there is no data" "$STATS_OUT" "No data yet"
+else
+    check "stats leads with the bytes" "$STATS_OUT" "never reached your model"
+    check "stats names the ledger" "$STATS_OUT" "folded"
+    check "stats names the declined calls" "$STATS_OUT" "left alone"
+fi
 
 # The share card runs against a fresh store here, so it takes the no-data path.
 # Both branches have to exit 0: a growth surface that panics on a new install is


### PR DESCRIPTION
`omni stats` computed everything from `distillations` and never read `ledger_folds`,
so the engine that removed the most bytes was absent from the report:

```
distiller, 7 days   309,429 B removed   the whole of what the report showed
ledger,    7 days   501,385 B removed   not mentioned on any line
```

The one percentage it printed, 4.5%, was the distiller's saving divided by 15,718
calls OMNI had deliberately declined.

Default view now:

```
    5.1 MB  never reached your model

    folded      1.7 MB   41% of what it folded         906 folds
    distilled   3.4 MB   48% of what it distilled    1,056 calls
    left alone       0   by design                  15,718 calls

    nothing deleted, nothing invented, no call came back larger
    fold percentage is measured over the 409 of 906 folds that record a payload size
    folds recorded from 2026-08-14, so this window is longer than the ledger's history
```

`EngineTotals` offers no combined percentage, because the two ratios come from
different populations. The fold figures count fold operations rather than
`ledger_folds` rows: one fold writes a row per (origin, source agent) pair and
repeats the payload size on each, so summing rows divided by the same payload
several times: 31% reported against 41% real.

`ledger_folds` gains a `fold_id` for that, because nothing in the table said which
rows belonged together and every inference from the other columns merges some pair
of folds. Old rows are backfilled from (second, session, agent, scope, payload
size), so a count over history is a lower bound and anything written since the
migration is exact. Three review rounds got here: rows counted as folds, then a
timestamp key, then two folds with disjoint (origin, source agent) pairs.

`left alone` reads `0` rather than the 31 MB that passed through.

`--json` gains an `engines` object, all-time like every other field there. Session
lifetime, the per-period table, top commands and the agent split moved to
`--detail`, which also prints the decline reason under Passthrough:

```
  Passthrough:   15543  (94%)
                    14246  below guardrail
                      669  structured:yaml
                      411  structured:json
                      250  own recovery command
```

`passthrough_events.reason` has been recorded since #533 and nothing read it.

Every assertion driven red: the declined calls falling into the distiller's base,
the ledger going unread, an unpriced fold counted as a base, every fold written
under one id, the query grouping by timestamp again, the payload summed per row,
the declined bytes printed as a saving, an absent base rendering as `0%`, and the
caveat losing the population it names.

`make ci` green, smoke 48/48. Manual updated in both languages. #670 filed for the
window flags `--json` has always accepted and ignored.

Closes #665


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR separates ledger folding and distillation statistics so each engine is measured against its own input population.
- Adds exact `fold_id` tracking for newly recorded folds and a best-effort legacy backfill.
- Reports per-engine totals in the default and JSON views.
- Moves diagnostic breakdowns to `--detail` and documents passthrough reasons.
- Updates tests, smoke coverage, documentation, and the changelog.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/store/sqlite.rs | Adds per-fold identifiers, migration backfill, and separate aggregation of ledger and distiller populations. |
| src/cli/stats.rs | Renders independent engine totals and exposes the same separation through the JSON schema. |
| tests/smoke_test.sh | Updates smoke expectations for the revised default and detail statistics output. |
| docs/website/src/use/seeing-savings.md | Documents the separate engine populations, fold-coverage caveat, and revised detail output. |
| docs/website/src-id/use/seeing-savings.md | Mirrors the updated statistics documentation in Indonesian. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    D[distillations] --> DT[Distiller totals]
    L[ledger_folds grouped by fold_id] --> FT[Fold totals]
    DT --> E[EngineTotals]
    FT --> E
    E --> C[Default CLI report]
    E --> J[JSON engines object]
```
</details>

<sub>Reviews (4): Last reviewed commit: ["feat(stats): report both engines, each a..."](https://github.com/fajarhide/omni/commit/d149ae04bc868507816a727784f46b334a508bcd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55998262)</sub>

<!-- /greptile_comment -->