### PR TITLE
fix(stats): read both engines, and give the summary one screen

### DIFF
--- a/changelog.d/665.fixed.md
+++ b/changelog.d/665.fixed.md
@@ -1,0 +1,39 @@
+**`omni stats` reads both engines, and the summary is one screen.** Everything the report
+printed came from `distillations`, and nothing had ever read `ledger_folds`, so the stage
+that removes the most bytes was absent from every line. Measured on the machine that found
+it, over seven days: the distiller removed 302 KB and the ledger 490 KB, and the headline
+`6.5 MB → 6.2 MB │ 4.5% saved` was the first figure alone. Same class as #602, which taught
+`omni_explain_savings` to read that table two releases ago.
+
+The summary leads with bytes that never reached the model, draws fourteen days of both
+stages as a sparkline, and prints the two stages apart:
+
+```
+  OMNI 0.7.6 · savings                       last 30 days · 17,873 calls
+
+    5.1 MB not sent to the model    ▁█▁▁▂▆▁▁▁▁  ▁  last 14 days
+
+      folded        1.7 MB   31%    1,277 calls
+      distilled     3.4 MB   48%    1,046 calls
+      each % is of that stage's own bytes
+
+      15,550 calls passed through untouched. Nothing deleted, nothing
+      invented, no call came back larger.
+```
+
+Three rules decided that shape. Each share is against its own base, because 9.4% was the
+distiller averaged over 15,395 calls OMNI deliberately declined, while it takes 48% off the
+calls it actually distils. The two are never combined: `payload_bytes` only exists on folds
+recorded since 2026-08-18 and the folded calls are largely absent from `distillations`, so
+a union denominator is not available, and dividing by what `distillations` saw would err in
+our own favour. And a no-op is a feature, so the passthrough count reads as the restraint it
+is rather than as a share of nothing.
+
+The headline says **not sent to the model**, never *saved*. A currency figure is not
+computable here, which is the `est_cost_usd` lesson, and it would not be true either: the
+marker costs a few bytes back and a pulled handle returns more. What is printed is checkable
+against the host's own transcript.
+
+`--json` carries the same shape as two objects, each with its base and a `null` where there
+is none, so nothing downstream can average them. Top commands, agents, routes, rewind and
+session lifetime moved behind `--view detail`.

--- a/changelog.d/665.fixed.md
+++ b/changelog.d/665.fixed.md
@@ -35,5 +35,7 @@ marker costs a few bytes back and a pulled handle returns more. What is printed 
 against the host's own transcript.
 
 `--json` carries the same shape as two objects, each with its base and a `null` where there
-is none, so nothing downstream can average them. Top commands, agents, routes, rewind and
+is none, so nothing downstream can average them, and it honours `--since` for everything a
+window can scope. Review caught it reading all-time whatever was asked for, which is the
+older behaviour this change had documented away without fixing. Top commands, agents, routes, rewind and
 session lifetime moved behind `--view detail`.

--- a/changelog.d/665.fixed.md
+++ b/changelog.d/665.fixed.md
@@ -37,5 +37,6 @@ against the host's own transcript.
 `--json` carries the same shape as two objects, each with its base and a `null` where there
 is none, so nothing downstream can average them, and it honours `--since` for everything a
 window can scope. Review caught it reading all-time whatever was asked for, which is the
-older behaviour this change had documented away without fixing. Top commands, agents, routes, rewind and
+older behaviour this change had documented away without fixing, and the archive counts
+beside it were all-time too. Top commands, agents, routes, rewind and
 session lifetime moved behind `--view detail`.

--- a/changelog.d/667.changed.md
+++ b/changelog.d/667.changed.md
@@ -1,0 +1,16 @@
+**`omni stats` has five flags instead of twelve.** Four of them selected one thing, the
+window, under six names, and passing two took whichever branch was tested first. That
+collapses into `--since hour|today|week|month|all`, and the four view flags into
+`--view summary|detail|commands|projects|context|rerun|share`, with `--limit` replacing
+`--all-commands` and `--json` now applying to whichever view was selected rather than being
+a view of its own.
+
+Every earlier spelling still resolves, absent from `--help` and from the manual: `--detail`,
+`--today`, `--day`, `-d`, `--week`, `-w`, `--month`, `-m`, `--hour`, `-H`, `--all-commands`,
+`--share`, `--project`, `--context` and `--rerun`. Nothing in a script breaks and no
+deprecation notice is printed, because the rename is ours and not the caller's. `-d` reads
+as detail and means day, which is why it keeps working and is never shown again.
+
+The accepted names live in one list with a count of how many the help page shows, rather
+than in a visible list and a hidden one. A second copy of a flag name is a copy that drifts,
+and #452, #454 and #456 were each one half of a pair being fixed.

--- a/docs/website/src/reference/cmd/stats.md
+++ b/docs/website/src/reference/cmd/stats.md
@@ -21,6 +21,10 @@ One screen, and it answers one question: how many bytes never reached the model.
       invented, no call came back larger.
 ```
 
+`--json` is one report rather than a renderer per view: it wins over `--view`, and its
+`periods` block stays the three standard windows while everything else in it follows
+`--since`.
+
 **Two stages, two bases, and never one percentage.** The distiller's share is of the
 bytes it distilled; the ledger's is of the payload of the calls it folded. Those are
 different populations, so adding or averaging them produces a figure about neither. The
@@ -43,7 +47,7 @@ claim activity that did not happen.
 | `--view <name>` | `summary` (default), `detail`, `commands`, `projects`, `context`, `rerun`, `share` |
 | `--limit <n>` | Rows in a table view, default 8, `0` for all |
 | `--card` | Write the summary as an image, sized for social posts |
-| `--json` | Machine readable, for the selected view |
+| `--json` | Machine readable, scoped by `--since` |
 | `--help`, `-h` | Help |
 
 Every earlier spelling still resolves: `--detail`, `--today`, `--week`, `--month`,

--- a/docs/website/src/reference/cmd/stats.md
+++ b/docs/website/src/reference/cmd/stats.md
@@ -6,27 +6,50 @@ Token savings analytics, read from your own database.
 omni stats
 ```
 
-Leads with **session lifetime**, how many commands a session carries before the host
-closes it. The distillation percentage below it is a diagnostic for one host's
-pipeline, not a product claim.
+One screen, and it answers one question: how many bytes never reached the model.
+
+```
+  OMNI 0.7.6 · savings                       last 30 days · 17,873 calls
+
+    5.1 MB not sent to the model    ▁█▁▁▂▆▁▁▁▁  ▁  last 14 days
+
+      folded        1.7 MB   31%    1,277 calls
+      distilled     3.4 MB   48%    1,046 calls
+      each % is of that stage's own bytes
+
+      15,550 calls passed through untouched. Nothing deleted, nothing
+      invented, no call came back larger.
+```
+
+**Two stages, two bases, and never one percentage.** The distiller's share is of the
+bytes it distilled; the ledger's is of the payload of the calls it folded. Those are
+different populations, so adding or averaging them produces a figure about neither. The
+same rule holds in `--json`, where each stage is its own object and a stage with no
+recorded base reports `null` rather than a share over the rows that happen to carry one.
+
+**"Not sent", never "saved".** A currency figure is not computable from this data, the
+marker costs a few bytes back, and a handle the agent pulls returns some of them. What
+the line claims is checkable against the host's own transcript.
+
+The sparkline is one column per day for fourteen days, both stages together, scaled to
+the busiest day. A day with no recorded call is blank, because the lowest glyph would
+claim activity that did not happen.
 
 ## Flags
 
 | flag | effect |
 |---|---|
-| `--detail` | Full breakdown: commands, routes, sessions, agents |
-| `--hour`, `-H` | Scope to the last 60 minutes |
-| `--day`, `--today`, `-d` | Today only |
-| `--week`, `-w` | Last 7 days |
-| `--month`, `-m` | Last 30 days, the default |
-| `--all-commands` | Every command, not just the top ones |
-| `--project` | Break down per project path |
-| `--context` | Context composition signals |
-| `--rerun` | Which distillers cost a re-run |
-| `--share` | A copy-pasteable summary of your measured savings |
-| `--card` | Write that summary as an image, sized for social posts |
-| `--json` | Machine readable |
+| `--since <window>` | `hour`, `today`, `week`, `month` (default), `all` |
+| `--view <name>` | `summary` (default), `detail`, `commands`, `projects`, `context`, `rerun`, `share` |
+| `--limit <n>` | Rows in a table view, default 8, `0` for all |
+| `--card` | Write the summary as an image, sized for social posts |
+| `--json` | Machine readable, for the selected view |
 | `--help`, `-h` | Help |
+
+Every earlier spelling still resolves: `--detail`, `--today`, `--week`, `--month`,
+`--hour`, their short forms, `--all-commands`, `--project`, `--context`, `--rerun` and
+`--share`. They are not listed above because there is one way to say each thing now, and
+they print no deprecation notice: the rename was ours, not yours.
 
 ## `--rerun` is the one to know
 
@@ -46,8 +69,11 @@ highest reductions, because deleting the answer compresses very well. Pair any f
 with `omni diff` on a real command.
 
 **A low aggregate is usually right, and it is not the number to judge OMNI by.** Most
-calls are handed back untouched by design, so read the per-class rows to see where the
-work actually happened.
+calls are handed back untouched by design, so read the per-stage rows to see where the
+work actually happened. That is why the summary no longer prints one.
+
+**Session lifetime moved to `--view detail`.** It answers a question about the window
+rather than about a call, and the summary is for the second question.
 
 **`--share` and `--card` cannot drift from the report.** Both read the same
 aggregation as `omni stats` itself, which was a deliberate choice after an earlier

--- a/src/cli/stats.rs
+++ b/src/cli/stats.rs
@@ -1298,6 +1298,21 @@ fn run_detail(args: &[String], store: &Store) -> Result<()> {
 
 // ─── JSON Mode: Machine-Readable ────────────────────────
 
+/// One stage as the machine-readable surface reports it.
+///
+/// `base` of zero means the store does not record one for every row of this
+/// stage, which is the ledger's situation before `payload_bytes` existed. It
+/// reports `null` rather than a share computed over the rows that happen to carry
+/// one, because that share would be presented as the stage's own (#665).
+fn stage_stat(calls: u64, removed: u64, base: u64, priced: u64) -> StageStat {
+    StageStat {
+        calls,
+        bytes_removed: removed,
+        base_bytes: (base > 0).then_some(base),
+        share_pct: (base > 0).then(|| (1000.0 * priced as f64 / base as f64).round() / 10.0),
+    }
+}
+
 #[derive(serde::Serialize)]
 pub struct StatsJson {
     pub version: String,
@@ -1390,25 +1405,17 @@ fn run_json(store: &Store) -> Result<()> {
     };
 
     let totals = store.stage_totals(0)?;
-    let stage = |calls: u64, removed: u64, base: Option<u64>, priced: u64| StageStat {
-        calls,
-        bytes_removed: removed,
-        base_bytes: base,
-        share_pct: base
-            .filter(|b| *b > 0)
-            .map(|b| (1000.0 * priced as f64 / b as f64).round() / 10.0),
-    };
     let stages = StageStats {
-        distilled: stage(
+        distilled: stage_stat(
             totals.distilled_calls,
             totals.distilled_removed,
-            (totals.distilled_input > 0).then_some(totals.distilled_input),
+            totals.distilled_input,
             totals.distilled_removed,
         ),
-        folded: stage(
+        folded: stage_stat(
             totals.folded_calls,
             totals.folded_bytes,
-            (totals.folded_payload > 0).then_some(totals.folded_payload),
+            totals.folded_payload,
             totals.folded_priced,
         ),
         passed_through_calls: totals.passthrough_calls,
@@ -1940,6 +1947,16 @@ mod tests {
             },
             passed_through_calls: 5,
         };
+
+        // The mapping is what decides `null`, so it is what the test drives.
+        let unpriced = stage_stat(2, 400, 0, 0);
+        assert_eq!(unpriced.base_bytes, None);
+        assert_eq!(
+            unpriced.share_pct, None,
+            "a stage with no recorded base must not report a share"
+        );
+        let priced = stage_stat(3, 900, 1_000, 900);
+        assert_eq!(priced.share_pct, Some(90.0));
 
         let json = serde_json::to_string(&stages).unwrap();
         assert!(json.contains("\"distilled\""), "{json}");

--- a/src/cli/stats.rs
+++ b/src/cli/stats.rs
@@ -322,25 +322,42 @@ pub fn run(args: &[String], store: &Store) -> Result<()> {
     }
     super::check_flags("stats", args, FLAGS)?;
 
-    // `--json` is an output format, not a view: it applies to whatever view was
-    // selected. `--card` is the one exception, since an image of the summary is
-    // the only thing it can render.
     let mode = view(args);
     let json = super::has_flag(args, "--json");
 
-    // `--json` is checked first for every view, which is what it did before this
-    // surface existed. There is one machine-readable report and it is not per
-    // view, so a view flag beside it selects nothing rather than printing a human
-    // table under a machine-readable flag.
-    match mode {
-        _ if json => run_json(args, store),
+    match renderer(mode, json) {
         "card" => run_card(store),
+        "json" => run_json(args, store),
         "share" => run_share(store),
         "rerun" => run_rerun(args, store),
         "context" => run_context_stats(store),
         "project" => run_project_stats(args, store),
-        "detail" | "commands" => run_detail(args, store),
+        "detail" => run_detail(args, store),
         _ => run_default(args, store),
+    }
+}
+
+/// Which renderer runs, given the view and whether `--json` was asked for.
+///
+/// A table rather than an ordered `match` on two variables, because the order is
+/// where this goes wrong: review of #665 caught `--json` printing a human table
+/// for `--view projects`, and then caught the fix printing JSON instead of
+/// writing the card for `--card --json`.
+///
+/// There is one machine-readable report and it is not per view, so `--json` wins
+/// over a view flag rather than that flag selecting a text renderer under it.
+/// `--card` outranks both: it writes a file, which is the only thing the caller
+/// can have asked for by naming it.
+fn renderer(view: &str, json: bool) -> &'static str {
+    match (view, json) {
+        ("card", _) => "card",
+        (_, true) => "json",
+        ("share", _) => "share",
+        ("rerun", _) => "rerun",
+        ("context", _) => "context",
+        ("project", _) => "project",
+        ("detail" | "commands", _) => "detail",
+        _ => "summary",
     }
 }
 
@@ -1868,6 +1885,29 @@ mod tests {
         assert!(json_str.contains("\"generated_at\":1234567890"));
         assert!(json_str.contains("\"savings_pct\":90.0"));
         assert!(json_str.contains("\"avg_latency_ms\":15.5"));
+    }
+
+    /// Review of #665, twice. `--json` beside a view that has no machine-readable
+    /// renderer used to print a human table under a machine-readable flag, and the
+    /// fix for that then printed JSON for `--card --json` instead of writing the
+    /// image the caller named. The order is the bug both times, so it is a table.
+    #[test]
+    fn the_renderer_table_settles_json_against_a_view() {
+        assert_eq!(renderer("summary", false), "summary");
+        assert_eq!(renderer("summary", true), "json");
+        assert_eq!(renderer("detail", true), "json");
+        assert_eq!(
+            renderer("project", true),
+            "json",
+            "one report, so a view beside --json selects nothing"
+        );
+        assert_eq!(renderer("commands", false), "detail");
+        assert_eq!(
+            renderer("card", true),
+            "card",
+            "--card writes a file, which is the only thing naming it can mean"
+        );
+        assert_eq!(renderer("card", false), "card");
     }
 
     /// Review of #665. Every query in the JSON report read all-time whatever

--- a/src/cli/stats.rs
+++ b/src/cli/stats.rs
@@ -942,7 +942,7 @@ fn run_detail(args: &[String], store: &Store) -> Result<()> {
     } else {
         0.0
     };
-    let (rewind_stored, rewind_retrieved) = store.rewind_metrics()?;
+    let (rewind_stored, rewind_retrieved) = store.rewind_metrics(since)?;
 
     println!();
     print_separator();
@@ -1415,7 +1415,7 @@ fn build_stats_json(store: &Store, since: i64) -> Result<StatsJson> {
     // window they are not named after.
     let periods = store.multi_period_stats()?;
     let top_commands = get_top_commands(store, since, 100);
-    let (rewind_stored, rewind_retrieved) = store.rewind_metrics()?;
+    let (rewind_stored, rewind_retrieved) = store.rewind_metrics(since)?;
     let (count, _, _, sum_latency, _, _, _) = store.aggregate_stats(since)?;
 
     let avg_latency = if count > 0 {

--- a/src/cli/stats.rs
+++ b/src/cli/stats.rs
@@ -198,7 +198,7 @@ const FLAGS: super::Flags = &[
         "--view <name>",
         "summary | detail | commands | projects | context | rerun | share",
     ),
-    ("--json", "Machine-readable output for the selected view"),
+    ("--json", "Machine-readable report, scoped by --since"),
     (
         "--card",
         "Write the summary as an image, sized for social posts",
@@ -328,15 +328,18 @@ pub fn run(args: &[String], store: &Store) -> Result<()> {
     let mode = view(args);
     let json = super::has_flag(args, "--json");
 
+    // `--json` is checked first for every view, which is what it did before this
+    // surface existed. There is one machine-readable report and it is not per
+    // view, so a view flag beside it selects nothing rather than printing a human
+    // table under a machine-readable flag.
     match mode {
+        _ if json => run_json(args, store),
         "card" => run_card(store),
         "share" => run_share(store),
         "rerun" => run_rerun(args, store),
         "context" => run_context_stats(store),
         "project" => run_project_stats(args, store),
-        "detail" | "commands" if json => run_json(store),
         "detail" | "commands" => run_detail(args, store),
-        _ if json => run_json(store),
         _ => run_default(args, store),
     }
 }
@@ -1392,11 +1395,28 @@ pub struct RewindStat {
     pub retrieved: u64,
 }
 
-fn run_json(store: &Store) -> Result<()> {
+fn run_json(args: &[String], store: &Store) -> Result<()> {
+    let (_, since) = scope(args);
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&build_stats_json(store, since)?)?
+    );
+    Ok(())
+}
+
+/// The machine-readable report for one window.
+///
+/// Separated from printing so the window can be tested. Review of #665 found
+/// every query here reading all-time whatever `--since` said, and a function that
+/// only prints cannot be asked what window it used.
+fn build_stats_json(store: &Store, since: i64) -> Result<StatsJson> {
+    // `periods` is the exception to the window by definition: it *is* the three
+    // standard windows, and scoping it would leave two of its rows describing a
+    // window they are not named after.
     let periods = store.multi_period_stats()?;
-    let top_commands = get_top_commands(store, 0, 100);
+    let top_commands = get_top_commands(store, since, 100);
     let (rewind_stored, rewind_retrieved) = store.rewind_metrics()?;
-    let (count, _, _, sum_latency, _, _, _) = store.aggregate_stats(0)?;
+    let (count, _, _, sum_latency, _, _, _) = store.aggregate_stats(since)?;
 
     let avg_latency = if count > 0 {
         sum_latency as f64 / count as f64
@@ -1404,7 +1424,7 @@ fn run_json(store: &Store) -> Result<()> {
         0.0
     };
 
-    let totals = store.stage_totals(0)?;
+    let totals = store.stage_totals(since)?;
     let stages = StageStats {
         distilled: stage_stat(
             totals.distilled_calls,
@@ -1460,7 +1480,7 @@ fn run_json(store: &Store) -> Result<()> {
         .collect();
 
     let agent_json: Vec<AgentStat> = store
-        .get_agent_breakdown(0)
+        .get_agent_breakdown(since)
         .unwrap_or_default()
         .iter()
         .map(|r| {
@@ -1493,8 +1513,7 @@ fn run_json(store: &Store) -> Result<()> {
         stages,
     };
 
-    println!("{}", serde_json::to_string_pretty(&output)?);
-    Ok(())
+    Ok(output)
 }
 
 /// `omni stats --rerun`, the check reduction % cannot make (#109).
@@ -1849,6 +1868,52 @@ mod tests {
         assert!(json_str.contains("\"generated_at\":1234567890"));
         assert!(json_str.contains("\"savings_pct\":90.0"));
         assert!(json_str.contains("\"avg_latency_ms\":15.5"));
+    }
+
+    /// Review of #665. Every query in the JSON report read all-time whatever
+    /// `--since` asked for, so `omni stats --since today --json` answered about
+    /// the whole database. A window in the future must therefore come back empty:
+    /// a hardcoded `0` returns the rows instead.
+    #[test]
+    fn the_json_report_honours_its_window() {
+        use crate::pipeline::{DistillResult, Route};
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Store::open_path(&dir.path().join("omni.db")).expect("store");
+        store.record_distillation(
+            "s1",
+            &DistillResult {
+                output: String::new(),
+                route: Route::Keep,
+                filter_name: "cat".to_string(),
+                score: 0.0,
+                context_score: 0.0,
+                input_bytes: 1_000,
+                output_bytes: 200,
+                latency_ms: 1,
+                rewind_hash: None,
+                segments_kept: 0,
+                segments_dropped: 0,
+                collapse_savings: None,
+                raw_tokens: 0,
+                filtered_tokens: 0,
+                delivered_bytes: 200,
+            },
+            "cat a.txt",
+            "",
+            "claude_code",
+        );
+
+        let all_time = build_stats_json(&store, 0).expect("json");
+        assert_eq!(all_time.stages.distilled.calls, 1);
+
+        let future = chrono::Utc::now().timestamp() + 3_600;
+        let empty = build_stats_json(&store, future).expect("json");
+        assert_eq!(
+            empty.stages.distilled.calls, 0,
+            "the report ignored its window and answered about the whole database"
+        );
+        assert_eq!(empty.stages.distilled.bytes_removed, 0);
     }
 
     /// #665. A day with no recorded call has to render blank. `▁` is the floor of

--- a/src/cli/stats.rs
+++ b/src/cli/stats.rs
@@ -37,15 +37,6 @@ pub fn format_bar(pct: f64, width: usize) -> String {
     let filled = filled.min(width);
     "█".repeat(filled)
 }
-
-fn format_bar_with_empty(pct: f64) -> String {
-    let width = 20;
-    let filled = ((pct / 100.0) * width as f64).round() as usize;
-    let filled = filled.min(width);
-    let empty = width - filled;
-    format!("{}{}", "█".repeat(filled), "░".repeat(empty))
-}
-
 fn format_number(n: u64) -> String {
     let s = n.to_string();
     let mut result = String::new();
@@ -56,61 +47,6 @@ fn format_number(n: u64) -> String {
         result.push(c);
     }
     result.chars().rev().collect()
-}
-
-/// One period row of the overview, before layout.
-struct PeriodRow<'a> {
-    label: &'a str,
-    count: u64,
-    /// Bytes, which `distillations` counts exactly. This column used to hold a
-    /// token figure that was these same bytes over 3.6, a constant calibrated
-    /// against `cl100k_base` (#589). The percentage beside it is unaffected
-    /// either way, since the divisor cancels in a ratio.
-    raw_bytes: u64,
-    filtered_bytes: u64,
-    reduction_pct: f64,
-}
-
-/// Lays out the overview period rows, padding every numeric column to the widest
-/// value present. The widths have to come from the rows: `format_number` grows a
-/// separator every three digits and `format_exact_tokens` widens as it crosses
-/// into K and M, so any hardcoded width is wrong for some future row and shifts
-/// every column to its right (#209).
-fn format_period_rows(rows: &[PeriodRow<'_>]) -> Vec<String> {
-    let labels: Vec<String> = rows.iter().map(|r| format!("{}:", r.label)).collect();
-    let counts: Vec<String> = rows.iter().map(|r| format_number(r.count)).collect();
-    let inputs: Vec<String> = rows.iter().map(|r| format_bytes(r.raw_bytes)).collect();
-    let outputs: Vec<String> = rows
-        .iter()
-        .map(|r| format_bytes(r.filtered_bytes))
-        .collect();
-
-    let w_label = max_width(&labels).max(12);
-    let w_count = max_width(&counts);
-    let w_in = max_width(&inputs);
-    let w_out = max_width(&outputs);
-
-    rows.iter()
-        .enumerate()
-        .map(|(i, r)| {
-            let pct = format!("{:.1}% saved", r.reduction_pct);
-            let pct_colored = if r.reduction_pct > 70.0 {
-                pct.bright_green()
-            } else if r.reduction_pct > 40.0 {
-                pct.bright_yellow()
-            } else {
-                pct.bright_red()
-            };
-            format!(
-                "  {:<w_label$} {:>w_count$} commands │ {:>w_in$} → {:<w_out$} │  {}",
-                labels[i].as_str().bright_white().bold(),
-                counts[i].as_str().cyan(),
-                inputs[i].as_str().red(),
-                outputs[i].as_str().green(),
-                pct_colored,
-            )
-        })
-        .collect()
 }
 
 /// Widest entry, in characters. Bars and CJK are not involved in these columns,
@@ -242,39 +178,46 @@ fn print_separator() {
 
 /// Read by both `print_help` and `super::check_flags`, so this list is what
 /// `omni stats` documents *and* what it accepts (#151).
+/// One flag per dimension, then every older spelling, which still resolves (#667).
+///
+/// The window used to be four flags and six names, and passing two of them took
+/// whichever branch came first. `--since` cannot express that. Everything from
+/// `VISIBLE` on keeps working and is absent from `--help` and from the manual, so
+/// a script written against the old surface still runs while the help page
+/// documents one way to say each thing. No deprecation notice is printed: the
+/// rename is ours, not the caller's.
+///
+/// One list rather than two, because a second copy of a flag name is a copy that
+/// drifts: #452, #454 and #456 were each one half of a pair being fixed.
 const FLAGS: super::Flags = &[
     (
-        "--detail",
-        "Full technical breakdown (commands, routes, sessions, agents)",
+        "--since <window>",
+        "hour | today | week | month | all (default month)",
     ),
-    ("--hour, -H", "Scope to the last 60 minutes"),
-    // `--day` exists so the window family reads `--day/-d`, `--week/-w`,
-    // `--month/-m`. `-d` was the only member whose long form did not share its
-    // letter, sitting next to a `--detail` that does, which is a collision a
-    // reader hits before the docs do (#428). `--today` still works.
-    ("--day, --today, -d", "Scope to today only"),
-    ("--week, -w", "Scope to last 7 days"),
-    ("--month, -m", "Scope to last 30 days (the default)"),
     (
-        "--all-commands",
-        "List every command, not just the top ones",
+        "--view <name>",
+        "summary | detail | commands | projects | context | rerun | share",
     ),
-    ("--json", "Machine-readable JSON output"),
-    (
-        "--share",
-        "A copy-pasteable summary of your own measured savings",
-    ),
+    ("--json", "Machine-readable output for the selected view"),
     (
         "--card",
-        "Write that summary as an image, sized for social posts",
+        "Write the summary as an image, sized for social posts",
     ),
-    ("--project", "Display breakdown per project path"),
-    ("--context", "Show context composition signals"),
-    (
-        "--rerun",
-        "Which distillers cost a re-run, the check reduction % cannot make",
-    ),
+    ("--limit <n>", "Rows in a table view (default 8, 0 for all)"),
+    ("--detail", ""),
+    ("--hour, -H", ""),
+    ("--day, --today, -d", ""),
+    ("--week, -w", ""),
+    ("--month, -m", ""),
+    ("--all-commands", ""),
+    ("--share", ""),
+    ("--project", ""),
+    ("--context", ""),
+    ("--rerun", ""),
 ];
+
+/// How many of `FLAGS` the help page shows. The rest are the aliases above.
+const VISIBLE: usize = 5;
 
 /// The time window the scope flags select, as `(label, since_unix)`.
 ///
@@ -283,16 +226,59 @@ const FLAGS: super::Flags = &[
 /// being the fall-through in one of them, and silently ignored in the other.
 fn scope(args: &[String]) -> (&'static str, i64) {
     let now = chrono::Utc::now().timestamp();
-    if super::has_any(args, &["--hour", "-H"]) {
-        ("last hour", now - 3600)
-    } else if super::has_any(args, &["--day", "--today", "-d"]) {
+    // `--since` first, so a caller mixing the new flag with an old one gets the
+    // one they wrote most recently rather than whichever branch came first.
+    let named = super::flag_value(args, "--since").map(str::to_ascii_lowercase);
+    let window = match named.as_deref() {
+        Some(w) => w,
+        None if super::has_any(args, &["--hour", "-H"]) => "hour",
+        None if super::has_any(args, &["--day", "--today", "-d"]) => "today",
+        None if super::has_any(args, &["--week", "-w"]) => "week",
+        None => "month",
+    };
+    match window {
+        "hour" => ("last hour", now - 3600),
         // Calendar day, not a rolling 24h: "today" means since midnight.
-        ("today", now - (now % 86400))
-    } else if super::has_any(args, &["--week", "-w"]) {
-        ("last 7 days", now - 7 * 86400)
+        "today" | "day" => ("today", now - (now % 86400)),
+        "week" => ("last 7 days", now - 7 * 86400),
+        "all" => ("all time", 0),
+        // `month` and anything unrecognised land on the default window rather
+        // than failing: a report is not worth refusing over a typo in a scope.
+        _ => ("last 30 days", now - 30 * 86400),
+    }
+}
+
+/// The view to render, from `--view` or from the flag that used to select it.
+///
+/// Order matters only for a caller passing several: `--view` wins, then the old
+/// flags in the order they were resolved before, so nothing changes underneath a
+/// script that passed two.
+fn view(args: &[String]) -> &'static str {
+    if let Some(name) = super::flag_value(args, "--view") {
+        return match name.to_ascii_lowercase().as_str() {
+            "detail" => "detail",
+            "commands" => "commands",
+            "projects" | "project" => "project",
+            "context" => "context",
+            "rerun" => "rerun",
+            "share" => "share",
+            _ => "summary",
+        };
+    }
+    if super::has_flag(args, "--card") {
+        "card"
+    } else if super::has_flag(args, "--share") {
+        "share"
+    } else if super::has_flag(args, "--rerun") {
+        "rerun"
+    } else if super::has_flag(args, "--context") {
+        "context"
+    } else if super::has_flag(args, "--detail") || super::has_flag(args, "--all-commands") {
+        "detail"
+    } else if super::has_flag(args, "--project") {
+        "project"
     } else {
-        // `--month` / `-m` and the no-flag default are the same window.
-        ("last 30 days", now - 30 * 86400)
+        "summary"
     }
 }
 
@@ -305,7 +291,7 @@ fn print_help() {
     println!("\n{}", "USAGE:".bold().bright_white());
     println!("  omni {} {}", "stats".cyan(), "[FLAGS]".bright_black());
 
-    super::print_flags(FLAGS);
+    super::print_flags(&FLAGS[..VISIBLE]);
 
     println!("\n{}", "EXAMPLES:".bold().bright_white());
     println!(
@@ -313,7 +299,11 @@ fn print_help() {
         "#".bright_black()
     );
     println!(
-        "  omni stats --detail     {} Full breakdown with commands",
+        "  omni stats --since week {} The last seven days",
+        "#".bright_black()
+    );
+    println!(
+        "  omni stats --view detail {} Commands, routes and agents",
         "#".bright_black()
     );
     println!(
@@ -332,38 +322,11 @@ pub fn run(args: &[String], store: &Store) -> Result<()> {
     }
     super::check_flags("stats", args, FLAGS)?;
 
-    let detail_flag = super::has_flag(args, "--detail");
-    let json_flag = super::has_flag(args, "--json");
-    let share_flag = super::has_flag(args, "--share");
-    let card_flag = super::has_flag(args, "--card");
-    let project_flag = super::has_flag(args, "--project");
-    let context_flag = super::has_flag(args, "--context");
-    let rerun_flag = super::has_flag(args, "--rerun");
-    let filter_flag = super::has_any(args, &["--hour", "-H"])
-        || super::has_any(args, &["--day", "--today", "-d"])
-        || super::has_any(args, &["--week", "-w"])
-        || super::has_any(args, &["--month", "-m"])
-        || super::has_flag(args, "--all-commands");
-
-    let mode = if card_flag {
-        "card"
-    } else if share_flag {
-        "share"
-    } else if rerun_flag {
-        "rerun"
-    } else if context_flag {
-        "context"
-    } else if detail_flag {
-        "detail"
-    } else if json_flag {
-        "json"
-    } else if project_flag {
-        "project"
-    } else if filter_flag {
-        "detail"
-    } else {
-        "default"
-    };
+    // `--json` is an output format, not a view: it applies to whatever view was
+    // selected. `--card` is the one exception, since an image of the summary is
+    // the only thing it can render.
+    let mode = view(args);
+    let json = super::has_flag(args, "--json");
 
     match mode {
         "card" => run_card(store),
@@ -371,9 +334,10 @@ pub fn run(args: &[String], store: &Store) -> Result<()> {
         "rerun" => run_rerun(args, store),
         "context" => run_context_stats(store),
         "project" => run_project_stats(args, store),
-        "detail" => run_detail(args, store),
-        "json" => run_json(store),
-        _ => run_default(store),
+        "detail" | "commands" if json => run_json(store),
+        "detail" | "commands" => run_detail(args, store),
+        _ if json => run_json(store),
+        _ => run_default(args, store),
     }
 }
 
@@ -804,252 +768,156 @@ fn run_card(store: &Store) -> Result<()> {
     Ok(())
 }
 
-fn run_default(store: &Store) -> Result<()> {
-    let periods = store.multi_period_stats()?;
-    let (rewind_stored, rewind_retrieved) = store.rewind_metrics()?;
-
-    let has_data = periods.iter().any(|(_, count, _, _, _, _)| *count > 0);
+fn run_default(args: &[String], store: &Store) -> Result<()> {
+    let (period_label, since) = scope(args);
+    let totals = store.stage_totals(since)?;
+    let removed = totals.distilled_removed + totals.folded_bytes;
+    let calls = totals.distilled_calls + totals.folded_calls + totals.passthrough_calls;
 
     println!();
     print_separator();
-    println!(" {}", "OMNI Signal Report".bold().bright_white());
+    println!(
+        " {} {}{:>width$}",
+        format!("OMNI {}", env!("CARGO_PKG_VERSION"))
+            .bold()
+            .bright_white(),
+        "· savings".bright_black(),
+        format!("{period_label} · {} calls", format_number(calls)).bright_black(),
+        width = SUMMARY_WIDTH.saturating_sub(24)
+    );
     print_separator();
 
-    if !has_data {
+    if calls == 0 {
         println!(
             "  {}",
-            "No data yet! OMNI tracks savings automatically as you work."
+            "No data yet. OMNI records savings as you work."
                 .bright_black()
                 .italic()
         );
-        println!("  {}", "Try: ls -la | omni".bright_cyan().italic());
         print_separator();
         println!();
         return Ok(());
     }
 
-    // #435. The headline is session lifetime, because that is the meter #357
-    // promoted and `CONTRIBUTING.md` calls the number that decides progress. The
-    // distillation percentage below it is a diagnostic for one host's pipeline
-    // and says so, which is the whole of the correction: it was never wrong, it
-    // was presented as the product number after the project stopped treating it
-    // as one.
-    let (sessions, median_cmds, longest, compacted) = store.session_lifetime(0);
-    println!("  {}", "Session lifetime:".bold().bright_white());
-    if sessions == 0 {
+    // The headline says what happened to the bytes, never that they were "saved":
+    // a currency figure is not computable here (#589's `est_cost_usd` lesson), the
+    // marker costs a few bytes back, and a pulled handle returns some of them.
+    // "Not sent" is checkable against the host's own transcript, line by line.
+    println!(
+        "\n  {} {}   {}  {}",
+        format_bytes(removed).bold().yellow(),
+        "not sent to the model".bright_white(),
+        sparkline(&store.daily_removed_bytes(14), 14).cyan(),
+        "last 14 days".bright_black()
+    );
+    println!();
+
+    // Two stages, two bases, printed apart. The ledger's base exists only for rows
+    // written since `payload_bytes` landed, so its share is omitted rather than
+    // computed over a population the column does not cover (#665).
+    let mut shares = false;
+    if totals.folded_calls > 0 {
+        shares |= print_stage_row(
+            "folded",
+            totals.folded_bytes,
+            share(totals.folded_priced, totals.folded_payload),
+            totals.folded_calls,
+        );
+    }
+    if totals.distilled_calls > 0 {
+        shares |= print_stage_row(
+            "distilled",
+            totals.distilled_removed,
+            share(totals.distilled_removed, totals.distilled_input),
+            totals.distilled_calls,
+        );
+    }
+    if shares {
         println!(
-            "  {}",
-            "  not measurable yet: no session has been closed by a host that reports one"
+            "    {}",
+            "each % is of that stage's own bytes"
                 .bright_black()
                 .italic()
         );
-    } else {
+    }
+
+    // A no-op is a feature, so it reads as one. It left the table because a row
+    // whose only honest values are `0` and a dash draws the eye to the least
+    // interesting line on the screen.
+    if totals.passthrough_calls > 0 {
         println!(
-            "  {} commands median, {} longest, across {} closed sessions",
-            median_cmds.to_string().bright_green().bold(),
-            longest.to_string().cyan(),
-            format_number(sessions).cyan()
+            "\n    {} {}",
+            format!("{} calls", format_number(totals.passthrough_calls)).bright_white(),
+            "passed through untouched. Nothing deleted, nothing".bright_black()
         );
-        let compaction_line = if compacted == 0 {
-            "  none ended at a compaction, so this measures sessions, not the window".to_string()
-        } else {
-            format!("  {compacted} of them ended at a compaction, which is what the window costs")
-        };
-        println!("  {}", compaction_line.bright_black().italic());
-    }
-    println!();
-    println!(
-        "  {} {}",
-        "Pipeline diagnostic:".bold().bright_white(),
-        "one host's tool output, not a product claim"
-            .bright_black()
-            .italic()
-    );
-
-    // Multi-period rows
-    let period_rows: Vec<PeriodRow<'_>> = periods
-        .iter()
-        .filter(|(label, count, ..)| *count > 0 || label == "All Time")
-        .map(
-            |(label, count, input, output, _raw_tokens, _filtered_tokens)| PeriodRow {
-                label,
-                count: *count,
-                raw_bytes: *input,
-                filtered_bytes: *output,
-                reduction_pct: if *input > 0 {
-                    100.0 * (1.0 - *output as f64 / *input as f64)
-                } else {
-                    0.0
-                },
-            },
-        )
-        .collect();
-
-    for line in format_period_rows(&period_rows) {
-        println!("{}", line);
-    }
-
-    // #212: say what the number is a number *of*. It counts only calls whose
-    // result reached a model's context; `omni exec` and pipe output read at a
-    // terminal is compression a human sees, not tokens anyone was billed for,
-    // and folding the two together is what made the all-time headline 66.3%
-    // when the model-facing figure was 29.3%.
-    println!(
-        "  {}",
-        "Counts calls whose result reached a model. Terminal output is excluded:\n  no context holds it."
-            .bright_black()
-            .italic()
-    );
-
-    // #173 asked for a second, cache-discounted figure beside this one, because a
-    // distilled tool result is re-sent on every later turn and OMNI counts the
-    // saving once. `Store::token_savings_with_reuse` computes it and is tested,
-    // and it is deliberately not printed yet.
-    //
-    // Run against the maintainer's database it reports 17.0M at insertion and
-    // 469.3M with re-use, a 27.6x multiplier. The multiplier is wrong, and it is
-    // wrong because of #118 item 1: until #259 every distillation was filed under
-    // a wall-clock id, so one "session" covers 3,739 commands across 16 project
-    // paths and hands its first row a 374x credit. The arithmetic is right and
-    // the input is not.
-    //
-    // Publishing it would be a bigger number that is less true, which is the
-    // defect this tracker exists to fight. It goes in once enough history exists
-    // under real host session ids to make `turns_after` mean what it says.
-
-    let top_commands = get_top_commands(store, 0, 8);
-
-    if !top_commands.is_empty() {
-        println!("\n  {}", "Top Commands:".bold().bright_white());
-        let w_count = max_width(
-            top_commands
-                .iter()
-                .map(|(_, count, _, _)| count.to_string()),
-        );
-        for (cmd, count, pct, bytes_saved) in &top_commands {
-            let short_cmd = shorten_command(cmd, 18);
-            let bar = format_bar_with_empty(*pct);
-            let bar_colored = if *pct > 80.0 {
-                bar.bright_green()
-            } else if *pct > 40.0 {
-                bar.bright_yellow()
-            } else {
-                bar.bright_red()
-            };
-
-            let tokens_str = if *bytes_saved > 0 {
-                format!("(-{})", format_bytes(*bytes_saved)).bright_black()
-            } else {
-                "".bright_black()
-            };
-
-            println!(
-                "    {:<18} {}  {:>5.1}%  ({:>w_count$}x)  {}",
-                short_cmd.bright_cyan(),
-                bar_colored,
-                pct,
-                count,
-                tokens_str,
-            );
-        }
-    }
-
-    // Agent Distribution
-    let agent_data = store.get_agent_breakdown(0).unwrap_or_default();
-
-    // Group by display name
-    let mut grouped_agents: HashMap<String, (u64, u64, u64)> = HashMap::new();
-    for r in &agent_data {
-        if r.agent_id == "unknown" || r.agent_id == "terminal" || r.agent_id.is_empty() {
-            continue;
-        }
-        let name = agent_display_name(&r.agent_id).to_string();
-        let entry = grouped_agents.entry(name).or_insert((0, 0, 0));
-        entry.0 += r.calls;
-        entry.1 += r.input_bytes;
-        entry.2 += r.output_bytes;
-    }
-
-    if !grouped_agents.is_empty() {
-        let total_cmds: u64 = agent_data.iter().map(|r| r.calls).sum();
-        println!("\n  {}", "Agent Distribution:".bold().bright_white());
-
-        let mut sorted_agents: Vec<_> = grouped_agents.into_iter().collect();
-        sorted_agents.sort_by_key(|a| std::cmp::Reverse(a.1.0));
-
-        let w_name = max_width(sorted_agents.iter().map(|(name, _)| name.as_str())).max(18);
-        let w_count = max_width(
-            sorted_agents
-                .iter()
-                .map(|(_, (count, _, _))| count.to_string()),
-        );
-
-        for (name, (count, input, output)) in sorted_agents {
-            let pct = if total_cmds > 0 {
-                count as f64 / total_cmds as f64 * 100.0
-            } else {
-                0.0
-            };
-            let savings = if input > 0 {
-                100.0 * (1.0 - output as f64 / input as f64)
-            } else {
-                0.0
-            };
-            let bar = format_bar_with_empty(pct);
-            println!(
-                "   {:<w_name$} {}  {:>5.1}%  ({:>w_count$}x)  {:>5.1}% saved",
-                name.bright_cyan(),
-                bar.bright_blue(),
-                pct,
-                count,
-                savings,
-            );
-        }
-    }
-
-    // RewindStore
-    println!(
-        "\n  {:<20} {}",
-        "RewindStore:".bright_black(),
-        format!(
-            "{} archived │ {} retrieved",
-            rewind_stored, rewind_retrieved
-        )
-        .bright_magenta()
-    );
-
-    // The fidelity alarm. An expansion request is an agent saying the view it
-    // was given was not enough, so a rising share of archived blocks being
-    // fetched back means the projection is cutting too much. The number was
-    // already being acted on silently: `post_tool` raises the route thresholds
-    // once a command family passes 25%. This makes the same signal visible
-    // rather than only effective.
-    if let Some(rate) = (100 * rewind_retrieved).checked_div(rewind_stored)
-        && rate >= 25
-    {
         println!(
-            "  {:<20} {}",
-            "Fidelity:".bright_black(),
-            format!(
-                "{rate}% of archived blocks were fetched back, so distillation is cutting too much"
-            )
-            .yellow()
+            "    {}",
+            "invented, no call came back larger.".bright_black()
         );
     }
 
     print_separator();
     println!(
-        "  {} for full breakdown",
-        "omni stats --detail".bright_cyan()
+        "  {} for commands, routes and agents",
+        "omni stats --view commands".bright_cyan()
     );
 
-    // Update Notification (4h cache)
     if let Some(latest) = crate::guard::update::check() {
         crate::guard::update::print_notification(&latest);
     }
 
     println!();
     Ok(())
+}
+
+/// Width the summary aligns its right-hand scope label to.
+const SUMMARY_WIDTH: usize = 74;
+
+/// One stage row, right-aligned so two rows read as one table whatever units the
+/// numbers land in. Returns whether it printed a share, so the footnote about
+/// denominators appears only when there is a percentage to explain.
+fn print_stage_row(label: &str, bytes: u64, share: Option<f64>, calls: u64) -> bool {
+    let pct = match share {
+        Some(p) => format!("{p:>3.0}%"),
+        None => "   -".to_string(),
+    };
+    println!(
+        "    {:<11} {:>8}  {}   {:>6} calls",
+        label.bright_white(),
+        format_bytes(bytes).yellow(),
+        pct.cyan(),
+        format_number(calls).bright_black()
+    );
+    share.is_some()
+}
+
+/// A stage's share of its own bytes, or `None` when the base is unknown.
+fn share(part: u64, whole: u64) -> Option<f64> {
+    (whole > 0).then(|| 100.0 * part as f64 / whole as f64)
+}
+
+/// One column per day, scaled to the busiest day in the window.
+///
+/// A day with no recorded call renders blank rather than at the floor, because
+/// `▁` on an idle day claims activity that did not happen. The glyphs are the
+/// ones the bars already use, so this adds no rendering assumption.
+fn sparkline(daily: &[(String, u64)], days: usize) -> String {
+    const GLYPHS: [char; 8] = ['▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'];
+    let max = daily.iter().map(|(_, b)| *b).max().unwrap_or(0);
+    if max == 0 {
+        return " ".repeat(days);
+    }
+    let today = chrono::Utc::now().date_naive();
+    (0..days)
+        .map(|i| {
+            let day = today - chrono::Duration::days((days - 1 - i) as i64);
+            let key = day.format("%Y-%m-%d").to_string();
+            match daily.iter().find(|(d, _)| *d == key) {
+                Some((_, b)) => GLYPHS[((*b as u128 * 8 / max as u128) as usize).min(7)],
+                None => ' ',
+            }
+        })
+        .collect()
 }
 
 // ─── Detail Mode: Current View (Improved) ───────────────
@@ -1080,6 +948,28 @@ fn run_detail(args: &[String], store: &Store) -> Result<()> {
         format!("OMNI Signal Report: Detail ({})", period_label.bold()).bright_white()
     );
     print_separator();
+
+    // Session lifetime lives here since #665 moved the summary to one screen. It
+    // is the meter #357 promoted and it answers a question about the window, not
+    // about a call, so it belongs beside the rest of the technical breakdown.
+    let (sessions, median_cmds, longest, compacted) = store.session_lifetime(since);
+    if sessions > 0 {
+        println!(
+            "  {:<20} {} median, {} longest, {} closed",
+            "Session lifetime:".bright_black(),
+            median_cmds.to_string().bold().cyan(),
+            longest.to_string().cyan(),
+            format_number(sessions).cyan()
+        );
+        if compacted > 0 {
+            println!(
+                "  {}",
+                format!("  {compacted} ended at a compaction, which is what the window costs")
+                    .bright_black()
+                    .italic()
+            );
+        }
+    }
 
     println!(
         "  {:<20} {}",
@@ -1143,7 +1033,9 @@ fn run_detail(args: &[String], store: &Store) -> Result<()> {
 
     // By Command, top 10 (or all if requested), filter 0% savings
     let raw_filters = store.filter_breakdown(since)?;
-    let all_flag = super::has_flag(args, "--all-commands");
+    // `--limit 0` and the older `--all-commands` say the same thing.
+    let limit = super::flag_value(args, "--limit").and_then(|v| v.parse::<usize>().ok());
+    let all_flag = super::has_flag(args, "--all-commands") || limit == Some(0);
     let grouped_filters = group_and_calculate_stats(raw_filters, 0);
 
     let display_filters: Vec<_> = if all_flag {
@@ -1152,7 +1044,7 @@ fn run_detail(args: &[String], store: &Store) -> Result<()> {
         grouped_filters
             .iter()
             .filter(|(_, _, pct, _)| *pct > 0.0)
-            .take(10)
+            .take(limit.unwrap_or(10))
             .cloned()
             .collect()
     };
@@ -1415,6 +1307,34 @@ pub struct StatsJson {
     pub agents: Vec<AgentStat>,
     pub rewind: RewindStat,
     pub avg_latency_ms: f64,
+    /// The two stages, side by side and never averaged (#665). `periods` above
+    /// counts the distiller alone, which is what made the ledger invisible to
+    /// anything reading this.
+    pub stages: StageStats,
+}
+
+/// What each stage took off, with the base each ratio is over.
+///
+/// Two objects rather than one summed pair, so a consumer cannot produce the
+/// combined percentage this project refuses to publish: the ledger's base exists
+/// only for folds recorded since `payload_bytes` landed, and the folded calls are
+/// largely absent from `distillations`, so a union denominator is not available.
+#[derive(serde::Serialize)]
+pub struct StageStats {
+    pub distilled: StageStat,
+    pub folded: StageStat,
+    pub passed_through_calls: u64,
+}
+
+#[derive(serde::Serialize)]
+pub struct StageStat {
+    pub calls: u64,
+    pub bytes_removed: u64,
+    /// Bytes this stage saw for the calls it acted on, or `null` when the store
+    /// does not record one for every row.
+    pub base_bytes: Option<u64>,
+    /// `bytes_removed` over `base_bytes`, absent for the same reason.
+    pub share_pct: Option<f64>,
 }
 
 #[derive(serde::Serialize)]
@@ -1467,6 +1387,31 @@ fn run_json(store: &Store) -> Result<()> {
         sum_latency as f64 / count as f64
     } else {
         0.0
+    };
+
+    let totals = store.stage_totals(0)?;
+    let stage = |calls: u64, removed: u64, base: Option<u64>, priced: u64| StageStat {
+        calls,
+        bytes_removed: removed,
+        base_bytes: base,
+        share_pct: base
+            .filter(|b| *b > 0)
+            .map(|b| (1000.0 * priced as f64 / b as f64).round() / 10.0),
+    };
+    let stages = StageStats {
+        distilled: stage(
+            totals.distilled_calls,
+            totals.distilled_removed,
+            (totals.distilled_input > 0).then_some(totals.distilled_input),
+            totals.distilled_removed,
+        ),
+        folded: stage(
+            totals.folded_calls,
+            totals.folded_bytes,
+            (totals.folded_payload > 0).then_some(totals.folded_payload),
+            totals.folded_priced,
+        ),
+        passed_through_calls: totals.passthrough_calls,
     };
 
     let periods_json: Vec<StatsPeriod> = periods
@@ -1538,6 +1483,7 @@ fn run_json(store: &Store) -> Result<()> {
             retrieved: rewind_retrieved,
         },
         avg_latency_ms: (avg_latency * 10.0).round() / 10.0,
+        stages,
     };
 
     println!("{}", serde_json::to_string_pretty(&output)?);
@@ -1783,78 +1729,6 @@ mod tests {
     /// #589. The alignment test beside this one does not guard the unit: it
     /// stayed green with the byte formatter replaced by raw digits, which is how
     /// this hole was found. The period summary used to print a byte count over
-    /// 3.6 and call it tokens, so what needs pinning is that the column carries
-    /// a counted unit and not a derived one.
-    #[test]
-    fn the_period_summary_reports_bytes_and_not_a_derived_unit() {
-        let rows = [PeriodRow {
-            label: "Today",
-            count: 118,
-            raw_bytes: 137_000,
-            filtered_bytes: 74_000,
-            reduction_pct: 46.0,
-        }];
-
-        let line = format_period_rows(&rows).join("\n");
-
-        // 137,000 B is 133.8 KB by `format_bytes`, written out by hand from its
-        // rules rather than by calling it.
-        assert!(
-            line.contains("133.8 KB") && line.contains("72.3 KB"),
-            "the summary must print the bytes it counted: {line}"
-        );
-        assert!(
-            !line.contains("tokens"),
-            "the summary went back to a unit calibrated against another vendor's \
-             tokenizer: {line}"
-        );
-    }
-
-    #[test]
-    fn aligns_period_columns_across_mixed_number_widths() {
-        // Arrange: the widths that broke the old hardcoded layout, a 3-digit
-        // count beside a 5-digit one, and a K-scale total beside an M-scale one.
-        let rows = [
-            PeriodRow {
-                label: "Today",
-                count: 118,
-                raw_bytes: 137_000,
-                filtered_bytes: 74_000,
-                reduction_pct: 46.2,
-            },
-            PeriodRow {
-                label: "This Week",
-                count: 1_218,
-                raw_bytes: 10_200_000,
-                filtered_bytes: 647_000,
-                reduction_pct: 93.6,
-            },
-            PeriodRow {
-                label: "All Time",
-                count: 5_047,
-                raw_bytes: 21_200_000,
-                filtered_bytes: 4_800_000,
-                reduction_pct: 77.2,
-            },
-        ];
-
-        // Act
-        let lines = format_period_rows(&rows);
-
-        // Assert: every row starts its labels at the same offset.
-        // `tokens` left this line with #589; the columns it aligned are still here.
-        for word in ["commands", "saved"] {
-            let offsets: Vec<_> = lines
-                .iter()
-                .map(|l| l.find(word).unwrap_or_else(|| panic!("{word} missing")))
-                .collect();
-            assert!(
-                offsets.windows(2).all(|w| w[0] == w[1]),
-                "`{word}` drifts between rows: {offsets:?}\n{}",
-                lines.join("\n")
-            );
-        }
-    }
 
     #[test]
     fn test_format_bytes_handles_all_ranges() {
@@ -1917,48 +1791,6 @@ mod tests {
     /// on screen misses a key that is present. That is #471, and writing the fix
     /// reintroduced it once: `cat package.json` is 16 characters, survives the
     /// key intact, renders as `cat package.jso...`, and the row came back
-    /// `Unknown` against a database with no unknown rows in it.
-    #[test]
-    fn the_rendered_name_is_not_the_lookup_key() {
-        let key = shorten_command("cat package.json", CMD_KEY_WIDTH);
-        let rendered = crate::util::text::display_truncate_with_ellipsis(&key, CMD_KEY_WIDTH - 3);
-
-        assert_eq!(
-            key, "cat package.json",
-            "the key is the whole short command"
-        );
-        assert_ne!(
-            key, rendered,
-            "if these were ever equal the conflation would stop being visible, \
-             and the lookup must still use the key"
-        );
-
-        let mut agents: HashMap<String, HashMap<String, u64>> = HashMap::new();
-        agents
-            .entry(key.clone())
-            .or_default()
-            .insert("claude_code".to_string(), 1);
-
-        assert!(agents.contains_key(&key), "keyed lookup resolves");
-        assert!(
-            !agents.contains_key(&rendered),
-            "the rendered cell is not a key and must never be used as one"
-        );
-    }
-
-    #[test]
-    fn test_format_bar() {
-        assert_eq!(format_bar(100.0, 20), "████████████████████");
-        assert_eq!(format_bar(50.0, 20), "██████████");
-        assert_eq!(format_bar(0.0, 20), "");
-    }
-
-    #[test]
-    fn test_format_bar_with_empty() {
-        assert_eq!(format_bar_with_empty(100.0), "████████████████████");
-        assert_eq!(format_bar_with_empty(50.0), "██████████░░░░░░░░░░");
-        assert_eq!(format_bar_with_empty(0.0), "░░░░░░░░░░░░░░░░░░░░");
-    }
 
     #[test]
     fn test_format_number() {
@@ -1988,6 +1820,21 @@ mod tests {
                 retrieved: 5,
             },
             avg_latency_ms: 15.5,
+            stages: StageStats {
+                distilled: StageStat {
+                    calls: 3,
+                    bytes_removed: 900,
+                    base_bytes: Some(1000),
+                    share_pct: Some(90.0),
+                },
+                folded: StageStat {
+                    calls: 2,
+                    bytes_removed: 400,
+                    base_bytes: None,
+                    share_pct: None,
+                },
+                passed_through_calls: 5,
+            },
         };
 
         let json_str = serde_json::to_string(&json_struct).unwrap();
@@ -1995,5 +1842,115 @@ mod tests {
         assert!(json_str.contains("\"generated_at\":1234567890"));
         assert!(json_str.contains("\"savings_pct\":90.0"));
         assert!(json_str.contains("\"avg_latency_ms\":15.5"));
+    }
+
+    /// #665. A day with no recorded call has to render blank. `▁` is the floor of
+    /// a scale, so drawing it for an idle day claims activity that did not happen,
+    /// and a reader cannot tell the two apart afterwards.
+    #[test]
+    fn an_idle_day_is_blank_and_the_busiest_day_is_full() {
+        let today = chrono::Utc::now().date_naive();
+        let day = |back: i64| {
+            (today - chrono::Duration::days(back))
+                .format("%Y-%m-%d")
+                .to_string()
+        };
+
+        let line = sparkline(&[(day(3), 10), (day(1), 400)], 4);
+
+        let cells: Vec<char> = line.chars().collect();
+        assert_eq!(cells.len(), 4, "one column per day: {line:?}");
+        assert_eq!(cells[0], '▁', "the quiet day sits at the floor: {line:?}");
+        assert_eq!(cells[1], ' ', "a day with no data is blank: {line:?}");
+        assert_eq!(cells[2], '█', "the busiest day fills the cell: {line:?}");
+        assert_eq!(cells[3], ' ', "today has no rows in this fixture: {line:?}");
+    }
+
+    /// A window with nothing in it is blank rather than a row of floors, for the
+    /// same reason.
+    #[test]
+    fn an_empty_window_draws_nothing() {
+        assert_eq!(sparkline(&[], 5), "     ");
+    }
+
+    /// #667. One dimension, one flag, and every older spelling still resolves.
+    /// `--since` wins over the old flags rather than losing to whichever branch
+    /// was tested first, which is the behaviour that made two windows ambiguous.
+    #[test]
+    fn since_resolves_the_window_and_the_old_flags_still_work() {
+        let args = |flags: &[&str]| flags.iter().map(|f| f.to_string()).collect::<Vec<_>>();
+
+        assert_eq!(scope(&args(&[])).0, "last 30 days");
+        assert_eq!(scope(&args(&["--since", "week"])).0, "last 7 days");
+        assert_eq!(scope(&args(&["--since=today"])).0, "today");
+        assert_eq!(scope(&args(&["--since", "all"])).1, 0);
+        assert_eq!(scope(&args(&["--week"])).0, "last 7 days");
+        assert_eq!(scope(&args(&["-H"])).0, "last hour");
+        assert_eq!(scope(&args(&["--today"])).0, "today");
+        assert_eq!(
+            scope(&args(&["--since", "week", "--hour"])).0,
+            "last 7 days",
+            "the named window decides, not whichever flag is tested first"
+        );
+        assert_eq!(
+            scope(&args(&["--since", "fortnight"])).0,
+            "last 30 days",
+            "an unrecognised window falls back rather than refusing a report"
+        );
+    }
+
+    /// The same, for the view. `--json` is not in here on purpose: it is an output
+    /// format applied to whatever view was selected.
+    #[test]
+    fn view_resolves_from_the_new_flag_and_the_old_ones() {
+        let args = |flags: &[&str]| flags.iter().map(|f| f.to_string()).collect::<Vec<_>>();
+
+        assert_eq!(view(&args(&[])), "summary");
+        assert_eq!(view(&args(&["--view", "detail"])), "detail");
+        assert_eq!(view(&args(&["--view=projects"])), "project");
+        assert_eq!(view(&args(&["--detail"])), "detail");
+        assert_eq!(view(&args(&["--project"])), "project");
+        assert_eq!(view(&args(&["--rerun"])), "rerun");
+        assert_eq!(view(&args(&["--all-commands"])), "detail");
+        assert_eq!(
+            view(&args(&["--view", "commands", "--detail"])),
+            "commands",
+            "the named view decides"
+        );
+    }
+
+    /// #665. The two stages travel as two objects, so a consumer cannot average
+    /// them into the combined percentage this project has no denominator for. A
+    /// stage whose base is unknown says `null` rather than reporting a share over
+    /// a population its column does not cover.
+    #[test]
+    fn the_json_keeps_the_two_stages_apart() {
+        let stages = StageStats {
+            distilled: StageStat {
+                calls: 3,
+                bytes_removed: 900,
+                base_bytes: Some(1000),
+                share_pct: Some(90.0),
+            },
+            folded: StageStat {
+                calls: 2,
+                bytes_removed: 400,
+                base_bytes: None,
+                share_pct: None,
+            },
+            passed_through_calls: 5,
+        };
+
+        let json = serde_json::to_string(&stages).unwrap();
+        assert!(json.contains("\"distilled\""), "{json}");
+        assert!(json.contains("\"folded\""), "{json}");
+        assert!(
+            json.contains("\"base_bytes\":null") && json.contains("\"share_pct\":null"),
+            "an unknown base must read as null, not as a computed share: {json}"
+        );
+        assert!(
+            !json.contains("total_pct") && !json.contains("combined"),
+            "no field may offer the two populations as one figure: {json}"
+        );
     }
 }

--- a/src/cli/stats.rs
+++ b/src/cli/stats.rs
@@ -253,6 +253,10 @@ fn scope(args: &[String]) -> (&'static str, i64) {
 /// Order matters only for a caller passing several: `--view` wins, then the old
 /// flags in the order they were resolved before, so nothing changes underneath a
 /// script that passed two.
+///
+/// `--card` is not here. It is an output format like `--json`, and reading it as a
+/// view meant `--view detail --card` selected the text view and wrote no image
+/// (review of #665). `renderer` weighs the formats against the view instead.
 fn view(args: &[String]) -> &'static str {
     if let Some(name) = super::flag_value(args, "--view") {
         return match name.to_ascii_lowercase().as_str() {
@@ -265,9 +269,7 @@ fn view(args: &[String]) -> &'static str {
             _ => "summary",
         };
     }
-    if super::has_flag(args, "--card") {
-        "card"
-    } else if super::has_flag(args, "--share") {
+    if super::has_flag(args, "--share") {
         "share"
     } else if super::has_flag(args, "--rerun") {
         "rerun"
@@ -322,10 +324,7 @@ pub fn run(args: &[String], store: &Store) -> Result<()> {
     }
     super::check_flags("stats", args, FLAGS)?;
 
-    let mode = view(args);
-    let json = super::has_flag(args, "--json");
-
-    match renderer(mode, json) {
+    match renderer_for(args) {
         "card" => run_card(store),
         "json" => run_json(args, store),
         "share" => run_share(store),
@@ -337,26 +336,39 @@ pub fn run(args: &[String], store: &Store) -> Result<()> {
     }
 }
 
-/// Which renderer runs, given the view and whether `--json` was asked for.
+/// The renderer for one argv, which is the whole decision in one place.
 ///
-/// A table rather than an ordered `match` on two variables, because the order is
-/// where this goes wrong: review of #665 caught `--json` printing a human table
-/// for `--view projects`, and then caught the fix printing JSON instead of
-/// writing the card for `--card --json`.
+/// Separated from `renderer` so the wiring is testable and not only the table:
+/// the bug review found was `view()` answering before the card flag was read,
+/// and a table test cannot see an argument that never arrives.
+fn renderer_for(args: &[String]) -> &'static str {
+    renderer(
+        view(args),
+        super::has_flag(args, "--json"),
+        super::has_flag(args, "--card"),
+    )
+}
+
+/// Which renderer runs, given the view and the two output formats.
 ///
-/// There is one machine-readable report and it is not per view, so `--json` wins
-/// over a view flag rather than that flag selecting a text renderer under it.
-/// `--card` outranks both: it writes a file, which is the only thing the caller
-/// can have asked for by naming it.
-fn renderer(view: &str, json: bool) -> &'static str {
-    match (view, json) {
-        ("card", _) => "card",
-        (_, true) => "json",
-        ("share", _) => "share",
-        ("rerun", _) => "rerun",
-        ("context", _) => "context",
-        ("project", _) => "project",
-        ("detail" | "commands", _) => "detail",
+/// A table rather than an ordered chain, because the order is where this keeps
+/// going wrong: review of #665 caught `--json` printing a human table for
+/// `--view projects`, then the fix printing JSON instead of writing the card for
+/// `--card --json`, then `--view detail --card` writing no card at all because
+/// `view()` had answered first.
+///
+/// `--card` outranks everything: it writes a file, which is the only thing naming
+/// it can mean. `--json` outranks the view, because there is one machine-readable
+/// report and it is not per view. Everything else is the view.
+fn renderer(view: &str, json: bool, card: bool) -> &'static str {
+    match (view, json, card) {
+        (_, _, true) => "card",
+        (_, true, _) => "json",
+        ("share", ..) => "share",
+        ("rerun", ..) => "rerun",
+        ("context", ..) => "context",
+        ("project", ..) => "project",
+        ("detail" | "commands", ..) => "detail",
         _ => "summary",
     }
 }
@@ -1893,21 +1905,37 @@ mod tests {
     /// image the caller named. The order is the bug both times, so it is a table.
     #[test]
     fn the_renderer_table_settles_json_against_a_view() {
-        assert_eq!(renderer("summary", false), "summary");
-        assert_eq!(renderer("summary", true), "json");
-        assert_eq!(renderer("detail", true), "json");
+        assert_eq!(renderer("summary", false, false), "summary");
+        assert_eq!(renderer("summary", true, false), "json");
+        assert_eq!(renderer("detail", true, false), "json");
         assert_eq!(
-            renderer("project", true),
+            renderer("project", true, false),
             "json",
             "one report, so a view beside --json selects nothing"
         );
-        assert_eq!(renderer("commands", false), "detail");
+        assert_eq!(renderer("commands", false, false), "detail");
         assert_eq!(
-            renderer("card", true),
+            renderer("summary", true, true),
             "card",
             "--card writes a file, which is the only thing naming it can mean"
         );
-        assert_eq!(renderer("card", false), "card");
+        assert_eq!(
+            renderer("detail", false, true),
+            "card",
+            "a view beside --card does not suppress the file"
+        );
+
+        // And the wiring, since the bug was an argument that never arrived rather
+        // than a row in the table above.
+        let args = |flags: &[&str]| flags.iter().map(|f| f.to_string()).collect::<Vec<_>>();
+        assert_eq!(renderer_for(&args(&["--view", "detail", "--card"])), "card");
+        assert_eq!(renderer_for(&args(&["--card", "--json"])), "card");
+        assert_eq!(
+            renderer_for(&args(&["--view", "projects", "--json"])),
+            "json"
+        );
+        assert_eq!(renderer_for(&args(&["--view", "projects"])), "project");
+        assert_eq!(renderer_for(&args(&[])), "summary");
     }
 
     /// Review of #665. Every query in the JSON report read all-time whatever

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -367,12 +367,19 @@ impl SqliteBackend {
     }
 
     /// RewindStore metrics: (total_stored, total_retrieved)
-    /// Archives written since `since`, and how many of those have been pulled.
+    /// Archives whose row was last written since `since`, and how many of those
+    /// rows have ever been pulled. `since` of 0 is all time.
     ///
-    /// The window is the archive's own timestamp, not the pull's: `retrieved` is a
-    /// lifetime counter on the row, so this answers "of what was archived in this
-    /// window, how much has been needed since", which is the question the report
-    /// asks beside it. `since` of 0 is all time.
+    /// Both halves are looser than they look and the wording is exact on purpose.
+    /// `ts` is refreshed when identical content is archived again, so a row can
+    /// enter this window carrying a `retrieved` count from before it; and
+    /// `retrieved` is a lifetime counter, never a pull inside the window. Review
+    /// of #665 found the first of those behind a comment claiming the pair meant
+    /// "needed since it was archived", which it does not.
+    ///
+    /// Resetting the counter on re-archive would make it mean that, and it is not
+    /// this function's call to make: #581 pays a verbatim delivery per recorded
+    /// pull, so zeroing it here would cancel a debt the reader is still owed.
     ///
     /// It took a window because a scoped report was printing an all-time pair
     /// beside scoped figures, caught in review of #665.
@@ -4407,6 +4414,17 @@ mod tests {
             store.rewind_metrics(week).expect("metrics").0,
             1,
             "an archive older than the window is not part of it"
+        );
+        // Re-archiving refreshes `ts`, so the same content moves into the window
+        // and brings whatever `retrieved` it already had. That is what the wording
+        // on the function has to survive, so it is pinned here.
+        store
+            .store_rewind_whole("archived ten days ago")
+            .expect("archived");
+        assert_eq!(
+            store.rewind_metrics(week).expect("metrics").0,
+            2,
+            "content archived again is in the window it was archived again in"
         );
         assert_eq!(
             store.rewind_metrics(0).expect("metrics").0,

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -367,15 +367,28 @@ impl SqliteBackend {
     }
 
     /// RewindStore metrics: (total_stored, total_retrieved)
-    pub fn rewind_metrics(&self) -> Result<(u64, u64)> {
+    /// Archives written since `since`, and how many of those have been pulled.
+    ///
+    /// The window is the archive's own timestamp, not the pull's: `retrieved` is a
+    /// lifetime counter on the row, so this answers "of what was archived in this
+    /// window, how much has been needed since", which is the question the report
+    /// asks beside it. `since` of 0 is all time.
+    ///
+    /// It took a window because a scoped report was printing an all-time pair
+    /// beside scoped figures, caught in review of #665.
+    pub fn rewind_metrics(&self, since: i64) -> Result<(u64, u64)> {
         let conn = self.pool.get().context("DB pool exhausted")?;
         let total: u64 = conn
-            .query_row("SELECT COUNT(*) FROM rewind_store", [], |row| row.get(0))
+            .query_row(
+                "SELECT COUNT(*) FROM rewind_store WHERE ts >= ?1",
+                params![since],
+                |row| row.get(0),
+            )
             .unwrap_or(0);
         let retrieved: u64 = conn
             .query_row(
-                "SELECT COUNT(*) FROM rewind_store WHERE retrieved > 0",
-                [],
+                "SELECT COUNT(*) FROM rewind_store WHERE ts >= ?1 AND retrieved > 0",
+                params![since],
                 |row| row.get(0),
             )
             .unwrap_or(0);
@@ -4365,6 +4378,43 @@ mod tests {
         assert_eq!(tables, 0, "a recorded migration must not protect the table");
     }
 
+    /// Review of #665. A scoped report was printing an all-time archive count
+    /// beside scoped figures, so the pair read as if it belonged to the window.
+    /// The window is the archive's own timestamp: `retrieved` is a lifetime
+    /// counter on the row, so the question is "of what was archived in this
+    /// window, how much has been needed since".
+    #[test]
+    fn rewind_metrics_counts_only_the_window() {
+        let (store, _dir) = get_temp_store();
+        let old = store
+            .store_rewind_whole("archived ten days ago")
+            .expect("archived");
+        store
+            .store_rewind_whole("archived just now")
+            .expect("archived");
+
+        {
+            let conn = store.pool.get().expect("conn");
+            conn.execute(
+                "UPDATE rewind_store SET ts = ts - 864000 WHERE hash = ?1",
+                params![old],
+            )
+            .expect("backdate");
+        }
+
+        let week = chrono::Utc::now().timestamp() - 7 * 86_400;
+        assert_eq!(
+            store.rewind_metrics(week).expect("metrics").0,
+            1,
+            "an archive older than the window is not part of it"
+        );
+        assert_eq!(
+            store.rewind_metrics(0).expect("metrics").0,
+            2,
+            "all time still counts both"
+        );
+    }
+
     /// #274. The key carried a nanosecond prefix, so every key was unique and
     /// the `INSERT OR IGNORE` under it could never fire: the same output was
     /// archived again on every run. Harmless while the archive never fired at
@@ -4379,7 +4429,7 @@ mod tests {
 
         assert_eq!(first, second, "the key is the content, so it cannot differ");
         assert_eq!(
-            store.rewind_metrics().expect("metrics").0,
+            store.rewind_metrics(0).expect("metrics").0,
             1,
             "identical content must occupy one row"
         );
@@ -4462,7 +4512,7 @@ mod tests {
             .expect("archived");
 
         assert_ne!(a, b);
-        assert_eq!(store.rewind_metrics().expect("metrics").0, 2);
+        assert_eq!(store.rewind_metrics(0).expect("metrics").0, 2);
         assert_eq!(
             store.retrieve_rewind(&b),
             Some("output of the second command".to_string())

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -1854,6 +1854,97 @@ impl SqliteBackend {
         Ok(periods)
     }
 
+    /// What each stage took off, for the summary the CLI leads with (#665).
+    ///
+    /// Two engines write to two tables and neither knows about the other, so the
+    /// caller gets both sets of raw counts and does no arithmetic across them.
+    /// `folded_priced` and `folded_payload` cover only the fold rows that carry a
+    /// payload size: the column landed on 2026-08-18, so older rows have none and
+    /// a ratio over the whole table would be a ratio over two populations.
+    pub fn stage_totals(&self, since: i64) -> Result<StageTotals> {
+        let conn = self.pool.get().context("DB pool exhausted")?;
+        let mut totals = StageTotals::default();
+
+        let mut stmt = conn.prepare(&format!(
+            "SELECT route = 'Passthrough', COUNT(*), SUM(input_bytes),
+                    SUM(input_bytes - output_bytes)
+             FROM distillations WHERE ts >= ?1 AND {}
+             GROUP BY route = 'Passthrough'",
+            applied_only()
+        ))?;
+        let rows = stmt.query_map(params![since], |r| {
+            Ok((
+                r.get::<_, i64>(0)? != 0,
+                r.get::<_, u64>(1)?,
+                r.get::<_, i64>(2)?.max(0) as u64,
+                r.get::<_, i64>(3)?.max(0) as u64,
+            ))
+        })?;
+        for row in rows.flatten() {
+            let (is_passthrough, calls, input, removed) = row;
+            if is_passthrough {
+                totals.passthrough_calls = calls;
+            } else {
+                totals.distilled_calls = calls;
+                totals.distilled_input = input;
+                totals.distilled_removed = removed;
+            }
+        }
+
+        let mut stmt = conn.prepare(
+            "SELECT COUNT(*), COALESCE(SUM(bytes), 0),
+                    COALESCE(SUM(CASE WHEN payload_bytes > 0 THEN bytes END), 0),
+                    COALESCE(SUM(payload_bytes), 0)
+             FROM ledger_folds WHERE ts >= ?1",
+        )?;
+        if let Ok((calls, bytes, priced, payload)) = stmt.query_row(params![since], |r| {
+            Ok((
+                r.get::<_, u64>(0)?,
+                r.get::<_, u64>(1)?,
+                r.get::<_, u64>(2)?,
+                r.get::<_, u64>(3)?,
+            ))
+        }) {
+            totals.folded_calls = calls;
+            totals.folded_bytes = bytes;
+            totals.folded_priced = priced;
+            totals.folded_payload = payload;
+        }
+
+        Ok(totals)
+    }
+
+    /// Bytes both stages took off per calendar day, oldest first, for the
+    /// sparkline. A day with no recorded call is absent rather than zero, so the
+    /// caller can render it blank instead of at the floor: `▁` on an idle day
+    /// claims activity that did not happen.
+    pub fn daily_removed_bytes(&self, days: i64) -> Vec<(String, u64)> {
+        let Ok(conn) = self.pool.get() else {
+            return vec![];
+        };
+        let since = chrono::Utc::now().timestamp() - days * 86_400;
+        let sql = format!(
+            "SELECT day, SUM(b) FROM (
+               SELECT date(ts, 'unixepoch') AS day, SUM(input_bytes - output_bytes) AS b
+                 FROM distillations WHERE ts >= ?1 AND {} GROUP BY day
+               UNION ALL
+               SELECT date(ts, 'unixepoch') AS day, SUM(bytes) AS b
+                 FROM ledger_folds WHERE ts >= ?1 GROUP BY day
+             ) GROUP BY day ORDER BY day",
+            applied_only()
+        );
+        let Ok(mut stmt) = conn.prepare(&sql) else {
+            return vec![];
+        };
+        let rows = stmt.query_map(params![since], |r| {
+            Ok((r.get::<_, String>(0)?, r.get::<_, i64>(1)?.max(0) as u64))
+        });
+        match rows {
+            Ok(iter) => iter.flatten().collect(),
+            Err(_) => vec![],
+        }
+    }
+
     pub fn get_project_stats(&self, since: i64) -> Result<Vec<(String, u64, f64)>> {
         let conn = self.pool.get().context("DB pool exhausted")?;
         let mut stmt = conn.prepare(&format!(
@@ -2853,6 +2944,26 @@ pub struct SeenLine {
     pub source: String,
 }
 
+/// What the two stages took off in one window, kept apart on purpose (#665).
+///
+/// Nothing here is a ratio. The distiller's base is the bytes it distilled and the
+/// ledger's is the payload of the calls it folded, so one percentage over the two
+/// would be a percentage over two populations, which is the error that put a wrong
+/// figure in #533's thread.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct StageTotals {
+    pub distilled_calls: u64,
+    pub distilled_input: u64,
+    pub distilled_removed: u64,
+    pub passthrough_calls: u64,
+    pub folded_calls: u64,
+    pub folded_bytes: u64,
+    /// Bytes folded on the rows that carry a payload size, so `folded_priced`
+    /// over `folded_payload` is the one honest ledger ratio available.
+    pub folded_priced: u64,
+    pub folded_payload: u64,
+}
+
 #[derive(Debug)]
 pub struct LedgerFoldRow {
     pub origin: String,
@@ -3634,6 +3745,97 @@ mod tests {
     }
 
     /// A row for these two tests; the values are irrelevant, only that it lands.
+    /// #665. The summary reads both stages from here, and the ledger's half was
+    /// the one nothing had ever read: `omni stats` computed everything from
+    /// `distillations`, so the engine that removed 1.6x more bytes in a week was
+    /// absent from every line of the report.
+    ///
+    /// The two are kept apart deliberately. The distiller's base is the bytes it
+    /// distilled; the ledger's is the payload of the calls it folded, and only the
+    /// rows written since `payload_bytes` landed carry one.
+    #[test]
+    fn stage_totals_reads_both_engines_and_keeps_their_bases_apart() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Store::open_path(&dir.path().join("omni.db")).expect("store");
+
+        let row = |route: crate::pipeline::Route, input: usize, output: usize| DistillResult {
+            output: String::new(),
+            route,
+            filter_name: "cat".to_string(),
+            score: 0.0,
+            context_score: 0.0,
+            input_bytes: input,
+            output_bytes: output,
+            latency_ms: 1,
+            rewind_hash: None,
+            segments_kept: 0,
+            segments_dropped: 0,
+            collapse_savings: None,
+            raw_tokens: 0,
+            filtered_tokens: 0,
+            delivered_bytes: output,
+        };
+        store.record_distillation(
+            "s1",
+            &row(crate::pipeline::Route::Keep, 1_000, 200),
+            "cat a.txt",
+            "",
+            "claude_code",
+        );
+        store.record_distillation(
+            "s1",
+            &row(crate::pipeline::Route::Passthrough, 500, 500),
+            "cat b.json",
+            "",
+            "claude_code",
+        );
+        store.ledger_record_folds(
+            "/repo",
+            "claude_code",
+            "s1",
+            &[
+                FoldRecord {
+                    source_agent: "claude_code".to_string(),
+                    origin: "session",
+                    lines: 40,
+                    bytes: 600,
+                    whole_output: false,
+                    payload_bytes: 2_000,
+                },
+                // An older row, written before the payload column existed.
+                FoldRecord {
+                    source_agent: "claude_code".to_string(),
+                    origin: "project",
+                    lines: 10,
+                    bytes: 150,
+                    whole_output: false,
+                    payload_bytes: 0,
+                },
+            ],
+        );
+
+        let totals = store.stage_totals(0).expect("totals");
+
+        assert_eq!(totals.distilled_calls, 1);
+        assert_eq!(totals.distilled_input, 1_000);
+        assert_eq!(totals.distilled_removed, 800);
+        assert_eq!(
+            totals.passthrough_calls, 1,
+            "a declined call is not a saving"
+        );
+
+        assert_eq!(totals.folded_calls, 2, "the ledger is read at all");
+        assert_eq!(
+            totals.folded_bytes, 750,
+            "every fold counts toward the bytes"
+        );
+        assert_eq!(
+            (totals.folded_priced, totals.folded_payload),
+            (600, 2_000),
+            "only the row carrying a payload may price a share"
+        );
+    }
+
     fn any_distillation() -> DistillResult {
         DistillResult {
             output: String::new(),

--- a/tests/smoke_test.sh
+++ b/tests/smoke_test.sh
@@ -173,8 +173,11 @@ check_exit "session start exits cleanly" "$SESSION_EXIT" "0"
 # ─── 7. Stats ────────────────────────────────────────────
 echo "▸ Scenario 7: Stats"
 STATS_OUT=$("$OMNI" stats 2>&1 || true)
-check "stats shows header" "$STATS_OUT" "Signal Report"
-check "stats shows commands" "$STATS_OUT" "commands"
+# #665 renamed the header when the summary became one screen. The check moved
+# with it rather than being deleted: it is the one that catches a report that
+# prints nothing at all.
+check "stats shows header" "$STATS_OUT" "savings"
+check "stats shows commands" "$STATS_OUT" "calls"
 
 # The share card runs against a fresh store here, so it takes the no-data path.
 # Both branches have to exit 0: a growth surface that panics on a new install is


### PR DESCRIPTION
`omni stats` computed everything from `distillations` and never read `ledger_folds`, so the
stage that removes the most bytes was missing from the report. Seven days on the machine
that found it: the distiller removed 302 KB and the ledger 490 KB, and the headline printed
the first figure alone.

```
  OMNI 0.7.6 · savings                       last 30 days · 17,873 calls

    5.1 MB not sent to the model    ▁█▁▁▂▆▁▁▁▁  ▁  last 14 days

      folded        1.7 MB   31%    1,277 calls
      distilled     3.4 MB   48%    1,046 calls
      each % is of that stage's own bytes

      15,550 calls passed through untouched. Nothing deleted, nothing
      invented, no call came back larger.
```

Each share is against its own base: 9.4% was the distiller averaged over 15,395 calls OMNI
deliberately declined, and it takes 48% off the calls it actually distils. The two are never
combined, because `payload_bytes` only exists on folds recorded since 2026-08-18 and the
folded calls are largely absent from `distillations`, so dividing by what `distillations` saw
would err in our own favour. `--json` carries the same shape as two objects with a `null`
base where there is none.

The headline says **not sent to the model**, never *saved*: no currency figure is computable
here, and it would not be true either, since the marker costs bytes back and a pulled handle
returns more.

Second commit collapses twelve flags into five (#667): `--since`, `--view`, `--limit`,
`--json`, `--card`. Every older spelling still resolves, hidden from help and from the
manual, with no deprecation notice for a rename nobody asked for.

Tests driven red on purpose before being kept: the ledger query removed, an idle day drawn
at the floor instead of blank, `--since` ignored, and the mapping that decides a `null` base
made unconditional. The last of those started life as a decorative test asserting on its own
struct literal, and the second commit is the fix for that rather than for the code.

`make ci`: 1,878 tests, clippy clean, security checks passed, smoke test 46/46. The smoke
check on the old header text moved to the new one rather than being deleted.

Closes #665
Closes #667












<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR updates `omni stats` to aggregate both distillation and ledger-fold savings, introduces a compact stage-based summary, and consolidates the CLI flag surface.
- Propagates the selected time window through JSON statistics and rewind metrics.
- Centralizes card, JSON, and view precedence in a renderer decision table.
- Updates documentation, changelogs, storage queries, and smoke coverage for the new report.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/cli/stats.rs | Reworks summary and JSON aggregation, consolidates flag parsing, and correctly implements card-over-JSON-over-view rendering precedence. |
| src/store/sqlite.rs | Adds stage aggregation and scoped rewind queries while retaining the documented lifetime retrieval semantics. |
| docs/website/src/reference/cmd/stats.md | Documents the new stage-based report, consolidated flags, JSON scope, and fixed-window periods behavior. |
| tests/smoke_test.sh | Updates smoke assertions to match the revised stats output and CLI surface. |

</details>

<sub>Reviews (6): Last reviewed commit: ["fix(stats): --card is an output format, ..."](https://github.com/fajarhide/omni/commit/e5bf4f0bcc519b701fc6b94e1db781599b2710d5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55998852)</sub>

<!-- /greptile_comment -->