### PR TITLE
fix(stats): keep --project ahead of --all-commands, as the old chain had it

### DIFF
--- a/changelog.d/673.fixed.md
+++ b/changelog.d/673.fixed.md
@@ -1,0 +1,8 @@
+**`omni stats --all-commands --project` gives the project breakdown again.** The old flag
+chain tested `--all-commands` last, after `--project`, so a script passing both got the
+project view. #667 grouped it with `--detail` while collapsing that chain, which reversed
+the precedence and handed those callers the detail report instead.
+
+Fourth finding on that refactor and the third of the same shape: collapsing an ordered chain
+into a resolver drops the order, and the order was the contract. Each of the legacy branches
+carries an assertion for both orders now, the way the output-format table already did.

--- a/src/cli/stats.rs
+++ b/src/cli/stats.rs
@@ -368,10 +368,14 @@ fn view(args: &[String]) -> &'static str {
     // printed commands, routes and agents. `--since week` means the summary for
     // that window, which is the sane reading, but the old spellings keep the old
     // behaviour: a script that says `--week` is asking for what it always got.
-    let legacy_window = super::has_any(args, &["--hour", "-H"])
+    // The old chain tested these last, after `--project`, so `--all-commands
+    // --project` gave the project breakdown. Grouping `--all-commands` with
+    // `--detail` reversed that for a script passing both (#672).
+    let legacy_detail = super::has_any(args, &["--hour", "-H"])
         || super::has_any(args, &["--day", "--today", "-d"])
         || super::has_any(args, &["--week", "-w"])
-        || super::has_any(args, &["--month", "-m"]);
+        || super::has_any(args, &["--month", "-m"])
+        || super::has_flag(args, "--all-commands");
 
     if super::has_flag(args, "--share") {
         "share"
@@ -379,11 +383,11 @@ fn view(args: &[String]) -> &'static str {
         "rerun"
     } else if super::has_flag(args, "--context") {
         "context"
-    } else if super::has_flag(args, "--detail") || super::has_flag(args, "--all-commands") {
+    } else if super::has_flag(args, "--detail") {
         "detail"
     } else if super::has_flag(args, "--project") {
         "project"
-    } else if legacy_window {
+    } else if legacy_detail {
         "detail"
     } else {
         "summary"
@@ -1956,6 +1960,17 @@ mod tests {
             view(&args(&["--week"])),
             "detail",
             "a window flag on its own selected the detail view and still does"
+        );
+        assert_eq!(view(&args(&["--all-commands"])), "detail");
+        assert_eq!(
+            view(&args(&["--all-commands", "--project"])),
+            "project",
+            "the old chain tested --project first, and a script passing both got it"
+        );
+        assert_eq!(
+            view(&args(&["--week", "--project"])),
+            "project",
+            "same for a window flag beside it"
         );
         assert_eq!(
             view(&args(&["--since", "week"])),


### PR DESCRIPTION
`omni stats --all-commands --project` returns the detail report on `7a973d2`. It used to
return the project breakdown: the old flag chain tested `--all-commands` last, in the
`filter_flag` branch after `--project`, and #667 grouped it with `--detail` while collapsing
that chain.

```
before 7a973d2   omni stats --all-commands --project   ->  project breakdown
after  7a973d2   omni stats --all-commands --project   ->  detail report
```

It joins the window flags in the final branch, which is where the old chain had it, and both
orders are asserted. Moving it back beside `--detail` turns the test red.

Found by review on #671 and pushed a minute after that PR merged, which is why it is a
separate change rather than another commit there.

Third finding of the same shape on that one refactor, so it is worth naming: collapsing an
ordered chain into a resolver drops the order, and the order was the contract. The other two
were `--card` losing to `--json`, and `view()` answering before the card flag was read.

`make ci`: 1,892 tests, clippy clean, security checks passed, smoke test 51/51.

Closes #673


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Restores the legacy `omni stats` view-selection precedence so `--project` wins over `--all-commands`.
- Moves `--all-commands` into the legacy detail fallback evaluated after `--project`.
- Adds regression coverage for mixed project, all-commands, and window flags.
- Documents the corrected behavior in the changelog.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The updated resolver reproduces the legacy precedence for `--all-commands` across the surrounding view and renderer flags, while the new tests cover the reported regression.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/cli/stats.rs | Restores the former flag precedence and adds focused tests for both affected mixed-flag orders. |
| changelog.d/673.fixed.md | Accurately documents the regression and restored project-breakdown behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(stats): keep --project ahead of --al..."](https://github.com/fajarhide/omni/commit/ab6ce9222332f2a4dd5d4ce0c0eb7491855875e3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56008243)</sub>

<!-- /greptile_comment -->