### PR TITLE
fix(store): prune the passthrough log and key it by session

### DIFF
--- a/changelog.d/672.fixed.md
+++ b/changelog.d/672.fixed.md
@@ -1,0 +1,14 @@
+**The passthrough log outlived every retention window.** `cleanup_old` prunes
+`sessions`, `distillations`, `file_access`, `rewind_store`, `session_events`,
+`ledger_folds`, `ledger_lines`, `loop_memory` and `execution_traces`.
+`passthrough_events` was not on that list and never had been, so the one table
+holding a command string for every declined call kept it forever while everything
+else rolled off. A user who shortens retention got it everywhere except there.
+
+It also had no session key, so a declined call could not be attributed to the
+session that made it and the reason breakdown could only ever be global. A time
+window is not a substitute: a third of the sessions on the machine this was
+measured on overlap another. `passthrough_reasons_for(since, session)` narrows it
+now, and asking for an empty session id returns nothing rather than everything:
+empty means the host sent no id, so it is shared by every pipe-mode row in the table
+and cannot identify a session. The reader that uses this is #612.

--- a/src/hooks/pipe.rs
+++ b/src/hooks/pipe.rs
@@ -88,6 +88,7 @@ pub fn run_inner<R: Read, W: Write, E: Write>(
                 command_to_use.unwrap_or(""),
                 passthrough.len(),
                 "own recovery command",
+                "",
             );
         }
         return Ok(());
@@ -134,6 +135,10 @@ pub fn run_inner<R: Read, W: Write, E: Write>(
                 command_to_use.unwrap_or(""),
                 input_text.len(),
                 &crate::pipeline::format::passthrough_reason(kind),
+                // Pipe mode has no host session id. Empty says that, where the
+                // `SessionState` fallback would say "whenever OMNI last started"
+                // and group 16 project paths under one id (#118, #672).
+                "",
             );
         }
         return Ok(());

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -297,6 +297,7 @@ fn declined(normalized: &crate::hooks::normalize::NormalizedInput, store: Option
                 &normalized.command,
                 normalized.content.len(),
                 "own recovery command",
+                normalized.host_session_id.as_deref().unwrap_or(""),
             );
         }
         return true;
@@ -319,6 +320,7 @@ fn declined(normalized: &crate::hooks::normalize::NormalizedInput, store: Option
                 &normalized.command,
                 normalized.content.len(),
                 &format::passthrough_reason(kind),
+                normalized.host_session_id.as_deref().unwrap_or(""),
             );
         }
         return true;
@@ -352,6 +354,7 @@ fn declined(normalized: &crate::hooks::normalize::NormalizedInput, store: Option
                 &normalized.command,
                 normalized.content.len(),
                 "host output cap",
+                normalized.host_session_id.as_deref().unwrap_or(""),
             );
         }
         return true;
@@ -810,6 +813,7 @@ pub fn process_payload(
                 clean_command,
                 content.len(),
                 "would have dropped the failure",
+                normalized.host_session_id.as_deref().unwrap_or(""),
             );
         }
         final_out = content.to_string();
@@ -892,7 +896,12 @@ pub fn process_payload(
     if !redacted_here && final_out.len() >= content.len() * 9 / 10 {
         // Record passthrough metric regardless of size
         if let Some(ref s) = store {
-            s.record_passthrough(clean_command, content.len(), "below guardrail");
+            s.record_passthrough(
+                clean_command,
+                content.len(),
+                "below guardrail",
+                normalized.host_session_id.as_deref().unwrap_or(""),
+            );
         }
 
         // Take the route the banner names. Prefixing `Passthrough` onto

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -974,6 +974,20 @@ impl SqliteBackend {
             [],
         );
 
+        // #672. Nothing tied a declined call to the session that made it, so the
+        // reason breakdown could only ever be global. A time window is not a
+        // substitute: a third of sessions on this machine overlap another.
+        // Empty means the host sent no id, which is the honest answer for pipe
+        // mode rather than the wall-clock fallback that made #118's slices wrong.
+        let _ = conn.execute(
+            "ALTER TABLE passthrough_events ADD COLUMN session TEXT NOT NULL DEFAULT ''",
+            [],
+        );
+        let _ = conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_pt_session ON passthrough_events(session)",
+            [],
+        );
+
         // #581. Set when a handle is pulled and cleared by the delivery that
         // answers it, so the content a marker sent the reader to fetch is not
         // folded back into that same marker on its way in. Separate from
@@ -1393,15 +1407,16 @@ impl SqliteBackend {
     /// JSON" and "declined because no distiller could parse it" call for
     /// opposite work, and the second is the only direct evidence that the
     /// never-fabricate invariant is doing any.
-    pub fn record_passthrough(&self, command: &str, bytes: usize, reason: &str) {
+    pub fn record_passthrough(&self, command: &str, bytes: usize, reason: &str, session: &str) {
         let conn = match self.pool.get() {
             Ok(c) => c,
             Err(_) => return,
         };
         let now = chrono::Utc::now().timestamp();
         let _ = conn.execute(
-            "INSERT INTO passthrough_events (command, bytes, ts, reason) VALUES (?1, ?2, ?3, ?4)",
-            params![command, bytes as i64, now, reason],
+            "INSERT INTO passthrough_events (command, bytes, ts, reason, session)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![command, bytes as i64, now, reason, session],
         );
     }
 
@@ -1410,20 +1425,45 @@ impl SqliteBackend {
     /// The point of the column: most calls are passthrough and correctly do
     /// nothing, and until this existed that population was one bucket.
     pub fn passthrough_reasons(&self, since: i64) -> Vec<(String, u64)> {
+        self.passthrough_reasons_for(since, None)
+    }
+
+    /// One session's declines, or every session's when `session` is `None`.
+    ///
+    /// `Some("")` returns nothing. An empty id means the host sent none, so it is
+    /// shared by every pipe-mode row in the table and cannot identify a session.
+    pub fn passthrough_reasons_for(&self, since: i64, session: Option<&str>) -> Vec<(String, u64)> {
+        // An empty id is not a session, it is the host declining to name one, so
+        // every pipe-mode row from every session carries it. Falling through to
+        // the unscoped query here answered "what did this session decline" with
+        // every session's declines, which is worse than not answering.
+        if matches!(session, Some("")) {
+            return Vec::new();
+        }
         let Ok(conn) = self.pool.get() else {
             return Vec::new();
         };
-        let Ok(mut stmt) = conn.prepare(
+        let scoped = session.is_some();
+        let sql = if scoped {
             "SELECT reason, COUNT(*) FROM passthrough_events
-             WHERE ts >= ?1 GROUP BY reason ORDER BY 2 DESC",
-        ) else {
+             WHERE ts >= ?1 AND session = ?2 GROUP BY reason ORDER BY 2 DESC"
+        } else {
+            "SELECT reason, COUNT(*) FROM passthrough_events
+             WHERE ts >= ?1 GROUP BY reason ORDER BY 2 DESC"
+        };
+        let Ok(mut stmt) = conn.prepare(sql) else {
             return Vec::new();
         };
-        stmt.query_map(params![since], |r| {
-            Ok((r.get::<_, String>(0)?, r.get::<_, i64>(1)? as u64))
-        })
-        .map(|rows| rows.flatten().collect())
-        .unwrap_or_default()
+        let row = |r: &rusqlite::Row<'_>| Ok((r.get::<_, String>(0)?, r.get::<_, i64>(1)? as u64));
+        if scoped {
+            stmt.query_map(params![since, session.unwrap_or("")], row)
+                .map(|rows| rows.flatten().collect())
+                .unwrap_or_default()
+        } else {
+            stmt.query_map(params![since], row)
+                .map(|rows| rows.flatten().collect())
+                .unwrap_or_default()
+        }
     }
 
     /// Newest first. Exists so the tag above can be asserted; nothing in the
@@ -2328,6 +2368,12 @@ impl SqliteBackend {
         );
         let _ = conn.execute(
             "DELETE FROM session_events WHERE ts < ?1",
+            params![ts_threshold],
+        );
+        // #672. This was the one time-series table nobody pruned, so it kept
+        // command strings past the window every other table honours.
+        let _ = conn.execute(
+            "DELETE FROM passthrough_events WHERE ts < ?1",
             params![ts_threshold],
         );
         // The ledger's eviction policy, defined before the project scope shipped
@@ -3643,9 +3689,9 @@ mod tests {
     #[test]
     fn counts_passthroughs_by_the_gate_that_declined_them() {
         let (store, _d) = get_temp_store();
-        store.record_passthrough("kubectl get pods -o json", 900, "structured json");
-        store.record_passthrough("gh api repos", 700, "structured json");
-        store.record_passthrough("cargo build", 500, "below guardrail");
+        store.record_passthrough("kubectl get pods -o json", 900, "structured json", "s1");
+        store.record_passthrough("gh api repos", 700, "structured json", "s1");
+        store.record_passthrough("cargo build", 500, "below guardrail", "s2");
 
         let by_reason = store.passthrough_reasons(0);
 
@@ -5185,5 +5231,64 @@ mod tests {
         let (store, _dir) = get_temp_store();
         assert_eq!(store.aggregate_stats(0).unwrap().0, 0);
         assert!(store.get_agent_breakdown(0).unwrap().is_empty());
+    }
+
+    /// #672. Every other time-series table is pruned by `cleanup_old` and this
+    /// one was not, so it kept command strings past the window the rest honour.
+    /// A user who shortens retention got it everywhere except here.
+    #[test]
+    fn the_retention_window_reaches_the_passthrough_log() {
+        let (store, _dir) = get_temp_store();
+        store.record_passthrough("kubectl get pods", 900, "structured:json", "s1");
+        store
+            .pool
+            .get()
+            .unwrap()
+            .execute(
+                "UPDATE passthrough_events SET ts = strftime('%s','now') - 60 * 86400",
+                [],
+            )
+            .unwrap();
+        store.record_passthrough("cargo build", 500, "below guardrail", "s1");
+
+        store.cleanup_old(30);
+
+        let left = store.passthrough_reasons(0);
+        assert_eq!(
+            left,
+            vec![("below guardrail".to_string(), 1)],
+            "the 60 day old decline outlived a 30 day window"
+        );
+    }
+
+    /// #672. Nothing tied a decline to the session that made it, so the reason
+    /// breakdown could only be global. A time window is not a substitute: a
+    /// third of the sessions on the machine this was measured on overlap another.
+    #[test]
+    fn a_decline_is_attributed_to_the_session_that_made_it() {
+        let (store, _dir) = get_temp_store();
+        store.record_passthrough("kubectl get pods", 900, "structured:json", "mine");
+        store.record_passthrough("terraform plan", 800, "structured:json", "theirs");
+        store.record_passthrough("cargo build", 500, "below guardrail", "theirs");
+        // Pipe mode, where the host sends no id at all.
+        store.record_passthrough("sort -u", 400, "below guardrail", "");
+
+        assert_eq!(
+            store.passthrough_reasons_for(0, Some("mine")),
+            vec![("structured:json".to_string(), 1)]
+        );
+        let theirs = store.passthrough_reasons_for(0, Some("theirs"));
+        assert_eq!(theirs.len(), 2, "{theirs:?}");
+        assert_eq!(theirs.iter().map(|(_, n)| n).sum::<u64>(), 2);
+
+        // An empty id is not a session. Asking for one must not hand back every
+        // *other* session's declines, which is what falling through to the
+        // unscoped query did, and what the first version of this assertion
+        // locked in by expecting it.
+        assert!(
+            store.passthrough_reasons_for(0, Some("")).is_empty(),
+            "an empty session id answered with the whole table"
+        );
+        assert_eq!(store.passthrough_reasons_for(0, None).len(), 2);
     }
 }


### PR DESCRIPTION
`cleanup_old` prunes every time-series table this project keeps:

```
sessions, distillations, file_access, rewind_store, session_events,
ledger_folds, ledger_lines, loop_memory, execution_traces
```

`passthrough_events` was not on that list and never had been. It holds a command
string for every declined call, 16,333 rows on the machine that found it, and it has
not visibly diverged from `distillations` only because this database is twelve days
old and both start 2026-08-11. A user who shortens retention gets it everywhere
except there.

It also had no session key, so a decline could not be attributed to the session that
made it and `omni stats` could only ever print the reasons globally.
`passthrough_reasons_for(since, session)` narrows it now. The writer takes the host's
session id, the same one `record_distillation` already prefers.

Two things worth stating because they are decisions, not oversights:

**`Some("")` returns nothing rather than everything.** Empty means the host sent no
id, so every pipe-mode row shares it; falling through to the unscoped query answered
"what did this session decline" with every session's declines. Caught in review, and
the first version of the test asserted that result and called it a refusal.

**Pipe mode passes `""` deliberately.** The `SessionState` fallback would say
"whenever OMNI last started" and group 16 project paths under one id, which is what
made #118's slices wrong. Better to record that we do not know.

A time window is not a substitute for the column: a third of the sessions on this
machine overlap another.

**The consumer is deferred to #612 on purpose.** This PR is the column and the prune.
Both existing callers of `passthrough_reasons` live in `src/cli/stats.rs`, which
another session holds for #667 and #673, and the column is worth landing alone because
a row written today without a session id cannot be given one later.

Five assertions, each driven red: the prune line removed, the session filter dropped
from the query, an empty session treated as a real one, the writer dropping the
session it was handed, and the empty-id refusal removed.

`make ci` green on top of `7a973d2`.

Closes #672
