### PR TITLE
feat(ledger): keep the line count, so a fold may sit in the middle of a Read

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ it is ever needed.
 This is the half a filter cannot reach. No pattern in that file is noise, so nothing
 in it can be dropped on its own merits. It goes because the agent has already seen it.
 
+**And when the file has changed since?** The parts already seen still fold, in place,
+around the parts that have not. Each fold keeps the line count of what it replaced, so
+every surviving line stays on the number your editor gives it and the agent can still act
+on those numbers.
+
 ## The same `git log`, side by side
 
 Without OMNI, one commit's `Author` / `Date` / body already fills the screen. With

--- a/changelog.d/664.changed.md
+++ b/changelog.d/664.changed.md
@@ -1,0 +1,30 @@
+**A fold in the middle of a `Read` keeps the file's line count, so it may fold at all.**
+The editor numbers whatever it is handed, counting from the line the read started at, so a
+view with fewer lines than the payload puts every surviving line on a number it is not at
+(#557). #658 worked around that by folding only down to the first line that survives, which
+left everything below the first change on the table. A marker followed by one `⋮` per line
+it replaced removes the constraint instead: the survivors keep their own numbers and no
+starting number moves.
+
+Measured over 20 markdown files read twice with no edit between the reads, 615 KB:
+
+| | #658 | now |
+| --- | --- | --- |
+| corpus | 27.3% | **82.3%** |
+| `CHANGELOG.md`, 434 KB | 4.4% | 76.5% |
+| `CONTRIBUTING.md` | 8.3% | 84.9% |
+| `docs/website/src/develop/index.md` | 7.8% | 84.0% |
+| files that already folded whole | 95.4% to 99.6% | unchanged |
+
+Every one of the 20 delivers a fold now; four of them delivered nothing before #658 and
+little after it.
+
+`⋮` rather than a blank or a tilde, because editors already read it as elided content, so a
+reader who skips the marker above does not take it for a line of the file. It costs 4 bytes
+against the ~50 a line of source runs to, and the run has to beat that filler as well as its
+marker before it folds: a seen line arriving alone between new ones is left verbatim, where
+before it could buy a marker it never paid for.
+
+The padding is only used where the survivors would otherwise be split. A fold with nothing
+under it, or one whose survivors are already contiguous, keeps its `startLine` bump and
+emits no filler.

--- a/docs/website/src-id/concepts/the-ledger.md
+++ b/docs/website/src-id/concepts/the-ledger.md
@@ -23,6 +23,23 @@ byte.
 [OMNI: 40 lines already shown, omni retrieve 0000000000000000]
 ```
 
+Di sebuah `Read`, markernya diikuti satu `⋮` untuk tiap baris yang digantikannya:
+
+```
+[OMNI: 40 lines already shown, omni retrieve 0000000000000000]
+⋮
+⋮      (38 baris lagi)
+⋮
+```
+
+Itu terlihat seperti pengisi dan sebenarnya bekerja. Editor menomori apa pun yang
+diterimanya, dihitung dari baris tempat pembacaan dimulai, jadi tampilan dengan baris
+lebih sedikit daripada filenya menaruh tiap baris yang selamat di nomor yang bukan
+miliknya. Mempertahankan jumlah baris berarti yang selamat tetap di nomornya sendiri, dan
+itulah yang membuat sebuah lipatan boleh berada di tengah file. Tanpa itu lipatan harus
+berhenti di baris pertama yang selamat, dan di `CHANGELOG.md` repo ini angkanya 4,4%
+melawan 76,5% yang sebenarnya bisa didapat.
+
 Ia menjangkau kelas yang tidak bisa dijangkau apa pun. Pembacaan berkas adalah
 kelas terbesar di korpus, dan penyaring menghemat **0,0%** darinya, dan itu
 benar: Anda tidak bisa membuang baris dari berkas yang diminta agent tanpa

--- a/docs/website/src-id/index.md
+++ b/docs/website/src-id/index.md
@@ -153,6 +153,10 @@ korpus 5.984 perintah yang diputar ulang di 0.7.5, kelas itu yang terbesar menur
 byte dan ledger memangkas **89,6%** darinya. File yang dibaca agent Anda dua kali
 kembali **97,2%** lebih kecil pada bacaan keduanya.
 
+File yang berubah di antara dua bacaan tetap dilipat di sekitar perubahannya. Tiap lipatan
+mempertahankan jumlah baris yang digantikannya, jadi baris yang tidak berpindah tetap ada
+di nomor yang diberikan editor Anda.
+
 Ketika tidak ada yang aman untuk diambil, ia tidak mengambil apa pun. `git status`
 dua baris tidak punya basa-basi untuk dibuang dan tidak punya pengulangan untuk
 dilipat, dan payload JSON yang akan diurai langkah berikutnya sama sekali tidak

--- a/docs/website/src-id/use/markers.md
+++ b/docs/website/src-id/use/markers.md
@@ -47,6 +47,19 @@ baris di tempat run ulang akan mencetak ratusan baris yang sama. Apa pun yang
 kurang dari seluruh jawaban memakai kalimat di atasnya.
 
 ```
+[OMNI: 40 lines already shown, omni retrieve 0000000000000000]
+⋮
+⋮
+```
+
+Di pembacaan file, dan hanya di situ, markernya diikuti satu `⋮` untuk tiap baris yang
+digantikannya. Editor menomori baris yang diterimanya, dihitung dari baris tempat
+pembacaan dimulai, jadi tampilan yang lebih pendek akan menaruh tiap baris yang selamat di
+nomor yang bukan miliknya. Mempertahankan jumlah baris itulah yang membuat sebuah lipatan
+boleh berada di antara dua bagian yang masih Anda butuhkan. Baris pengisi itu bukan konten
+yang bisa diambil: `omni retrieve` pada handle di atas mencetak baris aslinya.
+
+```
 [OMNI: 40 lines already shown from charlie.tf, omni retrieve 0000000000000000]
 ```
 

--- a/docs/website/src/concepts/the-ledger.md
+++ b/docs/website/src/concepts/the-ledger.md
@@ -21,6 +21,22 @@ the count and a handle. Everything else passes through byte for byte.
 [OMNI: 40 lines already shown, omni retrieve 0000000000000000]
 ```
 
+In a `Read`, the marker is followed by one `⋮` per line it replaced:
+
+```
+[OMNI: 40 lines already shown, omni retrieve 0000000000000000]
+⋮
+⋮      (38 more)
+⋮
+```
+
+That looks like padding and it is doing real work. The editor numbers whatever it is
+handed, counting from the line the read started at, so a view with fewer lines than the
+file puts every surviving line on a number it is not at. Keeping the count means the
+survivors keep their own numbers, which is what lets a fold sit in the middle of a file at
+all. Without it a fold had to stop at the first line that survived, and on this repo's
+`CHANGELOG.md` that was 4.4% against the 76.5% its runs were worth.
+
 It reaches the class nothing else can. File reads are the largest class in the
 corpus, and the filters save **0.0%** of them, correctly: you cannot strip lines from
 a file the agent asked to see without guessing which parts it meant. The ledger takes

--- a/docs/website/src/index.md
+++ b/docs/website/src/index.md
@@ -128,6 +128,10 @@ command corpus replayed on 0.7.5, that class is the largest by bytes and the led
 takes **89.6%** off it. A file your agent reads twice comes back **97.2%** smaller the
 second time.
 
+A file that changed between the two reads still folds around the change. Each fold keeps
+the line count of what it replaced, so the lines you did not see moved stay on the numbers
+your editor gives them.
+
 Where there is nothing safe to take it takes nothing. A two-line `git status` has no
 ceremony to drop and no repeats to fold, and a JSON payload a later step parses is never
 touched at all, so OMNI hands those straight back rather than inventing a saving to

--- a/docs/website/src/use/markers.md
+++ b/docs/website/src/use/markers.md
@@ -45,6 +45,18 @@ every line, the marker is the whole output rather than a gap inside it, so it sa
 hundreds. Anything less than the whole reply keeps the wording above.
 
 ```
+[OMNI: 40 lines already shown, omni retrieve 0000000000000000]
+⋮
+⋮
+```
+
+In a file read, and only there, the marker is followed by one `⋮` per line it replaced.
+Your editor numbers the lines it is handed, counting from the line the read began at, so a
+shorter view would put every surviving line on a number it is not at. Keeping the count is
+what lets a fold sit between two pieces of content you still need. The filler is never
+retrievable content: `omni retrieve` on the handle above prints the real lines.
+
+```
 [OMNI: 40 lines already shown from charlie.tf, omni retrieve 0000000000000000]
 ```
 

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -3363,11 +3363,13 @@ src/distillers/system_ops.rs:849:                is_sensitive_key(key),
         );
     }
 
-    /// #657, narrowed by #658. A `Read` whose survivors split now folds its head
-    /// and stops there, so the case that still delivers nothing is the one with no
-    /// head to fold: a payload whose first line is new and whose survivors split
-    /// below it. The books must be empty for it, because the agent received every
-    /// byte.
+    /// #657, narrowed twice. A `Read` whose survivors split folds every run now
+    /// (#664), so the case that still delivers nothing is the one where no run is
+    /// worth its marker: seen lines arriving one at a time between new ones. The
+    /// books must be empty for it, because the agent received every byte.
+    ///
+    /// The fixture is also the cost rule: a padded fold pays for its own filler,
+    /// so a one-line run can never buy a marker plus the lines it replaces.
     ///
     /// Measured before #657: 4 of 17 markdown files read twice unchanged delivered
     /// nothing and recorded 78% to 97% as saved, `CHANGELOG.md` among them at
@@ -3376,17 +3378,14 @@ src/distillers/system_ops.rs:849:                is_sensitive_key(key),
     fn a_refused_read_fold_records_nothing() {
         let line = |i: usize| format!("    let unique_marker_{i:03} = \"quokka-{i:03}-xyzzy\";\n");
         let range = |from: usize, to: usize| (from..to).map(line).collect::<String>();
-        let seen = range(100, 200);
-        // The payload opens on a new line, so there is no head to fold, and a
-        // second new line further down splits what is left. Nothing can be
-        // folded here at all, which is the case that must still record nothing.
-        let split = format!(
-            "{}{}{}{}",
-            "    let fresh_one = \"added since the first read\";\n",
-            range(100, 170),
-            "    let fresh_two = \"added since the first read too\";\n",
-            range(170, 200)
-        );
+        let seen = range(100, 145);
+        // Every seen line arrives alone, between lines the session has not been
+        // shown, so no run reaches the size its own marker and filler would cost.
+        // Kept under `MIN_DISTILL_TOKENS` deliberately: a larger payload is taken
+        // by the readfile distiller and never reaches the ledger at all.
+        let split: String = (100..145)
+            .map(|i| format!("{}    let fresh_{i:03} = \"new\";\n", line(i)))
+            .collect();
         let payload = |content: &str| {
             json!({
                 "session_id": "host-657-split",
@@ -3419,18 +3418,15 @@ src/distillers/system_ops.rs:849:                is_sensitive_key(key),
         );
     }
 
-    /// #658. Refusing the whole view when the survivors split gave up the bytes
-    /// above the first split too: an unchanged re-read of `CONTRIBUTING.md` saved
-    /// nothing, because six lines stating a failure are never folded (#458) and
-    /// each one splits the run around it.
+    /// #658, then #664. Refusing the whole view when the survivors split gave up
+    /// every byte; folding down to the first survivor gave up everything below it,
+    /// which on `CHANGELOG.md` was 4.4% against the 77% its runs were worth.
     ///
-    /// Folding down to the first surviving line leaves everything below it
-    /// contiguous, so `startLine` still describes all of it. Priced over 18
-    /// markdown files read twice: the corpus goes from 23.9% to 27.3%, and
-    /// `CHANGELOG.md` from nothing to 4.4%. The ceiling is structural, since a
-    /// fold that keeps the line count is the only way past it.
+    /// Padding each fold back to its own line count removes the constraint the
+    /// other two worked around: the survivors keep the numbers they came with, so
+    /// every run may fold and `startLine` never moves.
     #[test]
-    fn a_split_read_folds_its_head_and_stops_there() {
+    fn a_split_read_folds_every_run_and_keeps_the_line_count() {
         let line = |i: usize| format!("    let unique_marker_{i:03} = \"quokka-{i:03}-xyzzy\";\n");
         let range = |from: usize, to: usize| (from..to).map(line).collect::<String>();
         let seen = range(100, 200);
@@ -3468,30 +3464,47 @@ src/distillers/system_ops.rs:849:                is_sensitive_key(key),
         let file = &v["hookSpecificOutput"]["updatedToolOutput"]["file"];
         let content = file["content"].as_str().expect("content");
 
-        // One marker, at the head, and nothing folded below the first survivor.
-        assert_eq!(
-            content.matches("[OMNI:").count(),
-            1,
-            "only the head may fold, or the survivors split again: {content}"
-        );
+        // Every run folds now, not just the head.
         assert!(
-            content.starts_with("[OMNI:"),
-            "the fold has to be the head for one start line to describe the rest: {content}"
+            content.matches("[OMNI:").count() >= 2,
+            "a split payload folds each of its runs: {content}"
         );
-        assert!(
-            content.contains("let fresh_two") && content.contains("unique_marker_169"),
-            "everything below the first survivor is delivered verbatim: {content}"
-        );
-        // Thirty lines became one marker, so the survivors sit 29 lines higher.
         assert_eq!(
-            file["startLine"], 129,
-            "the survivors keep numbers they are no longer at: {out}"
+            content.lines().count(),
+            split.lines().count(),
+            "the delivered view has to carry the payload's own line count: {content}"
         );
-        // #657: the books say what was delivered, which is the head and only it.
+        assert_eq!(
+            file["startLine"], 100,
+            "the count is preserved, so the starting number does not move: {out}"
+        );
+
+        // The two new lines are still at the offsets the payload had them at,
+        // which is the whole point of paying for the filler.
+        let at = |text: &str, i: usize| text.lines().nth(i).unwrap_or_default().to_string();
+        let first_fresh = split
+            .lines()
+            .position(|l| l.contains("fresh_one"))
+            .expect("fixture");
+        let second_fresh = split
+            .lines()
+            .position(|l| l.contains("fresh_two"))
+            .expect("fixture");
+        assert_eq!(
+            at(content, first_fresh),
+            at(&split, first_fresh),
+            "{content}"
+        );
+        assert_eq!(
+            at(content, second_fresh),
+            at(&split, second_fresh),
+            "{content}"
+        );
+
+        // #657: the books say what was delivered, and now that is every run.
         let folds = store.get_recent_ledger_folds(None, 10);
-        assert_eq!(
-            folds.iter().map(|f| f.lines).sum::<usize>(),
-            30,
+        assert!(
+            folds.iter().map(|f| f.lines).sum::<usize>() >= 90,
             "the fold recorded is not the fold delivered: {folds:?}"
         );
     }
@@ -3644,7 +3657,7 @@ src/distillers/system_ops.rs:849:                is_sensitive_key(key),
     /// corrected by a starting number, because one number cannot describe two
     /// offsets, so the fold is refused and the payload goes back whole.
     #[test]
-    fn refuses_an_interior_fold_that_would_renumber_the_lines_below_it() {
+    fn an_interior_fold_keeps_the_lines_below_it_on_their_own_numbers() {
         let line = |i: usize| format!("    let unique_marker_{i:03} = \"quokka-{i:03}-xyzzy\";\n");
         let range = |from: usize, to: usize| (from..to).map(line).collect::<String>();
         let payload = |from: usize, to: usize| {
@@ -3666,11 +3679,33 @@ src/distillers/system_ops.rs:849:                is_sensitive_key(key),
         let dir = tempfile::tempdir().expect("tempdir");
         let store = Arc::new(Store::open_path(&dir.path().join("omni.db")).expect("store"));
         let _ = process_payload(&payload(130, 165), Some(store.clone()), None);
-        let out =
-            process_payload(&payload(100, 200), Some(store.clone()), None).unwrap_or_default();
+        let raw = range(100, 200);
+        let out = process_payload(&payload(100, 200), Some(store.clone()), None)
+            .expect("the middle repeats, so it folds");
+
+        let v: serde_json::Value = serde_json::from_str(&out).expect("hook json");
+        let file = &v["hookSpecificOutput"]["updatedToolOutput"]["file"];
+        let content = file["content"].as_str().expect("content");
+
         assert!(
-            !out.contains("[OMNI:"),
-            "a fold with content on both sides renumbered the lines under it: {out}"
+            content.contains("[OMNI:"),
+            "the middle did not fold: {content}"
+        );
+        assert_eq!(
+            content.lines().count(),
+            raw.lines().count(),
+            "a fold with content under it has to keep the line count: {content}"
+        );
+        assert_eq!(
+            file["startLine"], 100,
+            "the count is preserved, so nothing may move the starting number: {out}"
+        );
+        // The survivor below the fold is still the line the file has at that offset.
+        let at = |text: &str, i: usize| text.lines().nth(i).unwrap_or_default().to_string();
+        assert_eq!(
+            at(content, 70),
+            at(&raw, 70),
+            "the line below the fold moved: {content}"
         );
     }
 
@@ -3928,13 +3963,22 @@ src/distillers/system_ops.rs:849:                is_sensitive_key(key),
         let dir = tempfile::tempdir().expect("tempdir");
         let store = Arc::new(Store::open_path(&dir.path().join("omni.db")).expect("store"));
         let _ = process_payload(&payload(130, 165), Some(store.clone()), None);
-        let out =
-            process_payload(&payload(100, 200), Some(store.clone()), None).unwrap_or_default();
-        assert!(
-            !out.contains("omni retrieve"),
-            "an interior fold went through because the surviving content was read \
-             as markers: {out}"
+        let raw = range(100, 200);
+        let out = process_payload(&payload(100, 200), Some(store.clone()), None)
+            .expect("the middle repeats, so it folds");
+
+        let v: serde_json::Value = serde_json::from_str(&out).expect("hook json");
+        let file = &v["hookSpecificOutput"]["updatedToolOutput"]["file"];
+        let content = file["content"].as_str().expect("content");
+
+        assert_eq!(
+            content.lines().count(),
+            raw.lines().count(),
+            "content that reads like a marker still may not move a line: {content}"
         );
+        assert_eq!(file["startLine"], 100, "{out}");
+        let at = |text: &str, i: usize| text.lines().nth(i).unwrap_or_default().to_string();
+        assert_eq!(at(content, 70), at(&raw, 70), "{content}");
     }
 
     #[test]

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -3363,6 +3363,66 @@ src/distillers/system_ops.rs:849:                is_sensitive_key(key),
         );
     }
 
+    /// #664's cost rule, which the books test above cannot reach: its runs are one
+    /// line each, and one line pays no filler.
+    ///
+    /// A run of twenty short lines clears the marker and the session's gain on its
+    /// own, and does not clear them once it also has to buy nineteen `⋮`. It stays
+    /// verbatim, which is the honest answer: folding it would spend more on the
+    /// padding than the lines were worth.
+    #[test]
+    fn a_run_pays_for_its_own_filler_before_it_folds() {
+        let short = |i: usize| format!("  x{i:02} = 1;\n");
+        let wide = |i: usize| format!("    let brand_new_line_{i:03} = \"never seen before\";\n");
+        let run: String = (0..20).map(short).collect();
+        let payload = |content: String| {
+            json!({
+                "session_id": "host-664-cost",
+                "tool_name": "Read",
+                "tool_input": {"path": "probe.rs"},
+                "tool_response": {"file": {
+                    "filePath": "probe.rs",
+                    "content": content,
+                    "startLine": 1,
+                    "numLines": 60,
+                    "totalLines": 400,
+                }},
+            })
+            .to_string()
+        };
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Arc::new(Store::open_path(&dir.path().join("omni.db")).expect("store"));
+        // The short run is shown first, padded past `MIN_LEDGER_INPUT` with lines
+        // that appear nowhere else: at 220 bytes on its own the first read is
+        // under the floor and nothing is recorded at all, which makes the second
+        // read a fold against an empty scope and the test green either way.
+        let first_only = |i: usize| format!("    let only_in_the_first_read_{i:03} = 0;\n");
+        let seeded = format!("{}{}", run, (0..10).map(first_only).collect::<String>());
+        assert!(
+            seeded.len() > 264,
+            "the first read has to clear MIN_LEDGER_INPUT"
+        );
+        let _ = process_payload(&payload(seeded), Some(store.clone()), None);
+        let split = format!(
+            "{}{}{}",
+            (0..20).map(wide).collect::<String>(),
+            run,
+            (20..40).map(wide).collect::<String>()
+        );
+        let out = process_payload(&payload(split), Some(store.clone()), None);
+
+        let content = out
+            .as_deref()
+            .and_then(|o| serde_json::from_str::<serde_json::Value>(o).ok())
+            .map(|v| v["hookSpecificOutput"]["updatedToolOutput"]["file"]["content"].to_string())
+            .unwrap_or_default();
+        assert!(
+            !content.contains("[OMNI:"),
+            "the run folded without paying for the filler it needs: {content}"
+        );
+    }
+
     /// #657, narrowed twice. A `Read` whose survivors split folds every run now
     /// (#664), so the case that still delivers nothing is the one where no run is
     /// worth its marker: seen lines arriving one at a time between new ones. The

--- a/src/ledger/mod.rs
+++ b/src/ledger/mod.rs
@@ -346,6 +346,19 @@ struct Run {
     seen: Option<Seen>,
 }
 
+/// One folded line, kept so the delivered line count matches the file's.
+///
+/// A host that numbers what it is handed cannot take a view with fewer lines than
+/// the payload, and folding to a single marker is exactly that. Emitting the
+/// marker plus one of these per remaining line keeps every survivor on its own
+/// number without a `startLine` bump, which is what makes an interior fold legal
+/// at all (#664).
+///
+/// `⋮` and not a blank or a tilde: editors already read it as elided content, so a
+/// reader who skips the marker above does not take it for a line of the file. It
+/// costs 4 bytes against the ~50 a real line of source runs to.
+const PAD_LINE: &str = "⋮\n";
+
 impl<'a> Ledger<'a> {
     pub fn new(store: &'a Store, scope: impl Into<String>) -> Self {
         Self {
@@ -500,15 +513,23 @@ impl<'a> Ledger<'a> {
         // deterministic for a caller replaying the same session.
         let projected = self
             .substitute(&lines, &hashes, &origin_of)
-            .filter(|(view, _, _)| view.len() < text.len());
+            .filter(|(view, _, _, _)| view.len() < text.len());
 
         // What the fold did to the numbering below it (#557), read from the folded
         // indices where the answer is known. Decided here rather than after the
         // recording below, because a host that renumbers will drop a split view and
         // the books must not carry a fold the agent never received (#657).
+        // A padded view has the payload's own line count, so every survivor is
+        // already where the file has it and no starting number moves (#664).
         let shifts = projected
             .as_ref()
-            .map(|(_, folded, above)| FoldShift::of(folded, lines.len(), *above))
+            .map(|(_, folded, above, padded)| {
+                if *padded {
+                    FoldShift::None
+                } else {
+                    FoldShift::of(folded, lines.len(), *above)
+                }
+            })
             .unwrap_or(FoldShift::None);
         let projected = projected.filter(|_| !(self.renumbered && shifts == FoldShift::Interior));
 
@@ -524,7 +545,7 @@ impl<'a> Ledger<'a> {
         // the gain filter above, the caller emits `text` verbatim and every line
         // was delivered. That is the empty-set case and needs no special arm.
         let delivered: Vec<String> = match &projected {
-            Some((_, folded, _)) => hashes
+            Some((_, folded, _, _)) => hashes
                 .iter()
                 .enumerate()
                 .filter(|(i, _)| !folded.contains(i))
@@ -536,7 +557,7 @@ impl<'a> Ledger<'a> {
         // like this session's (#533). `PROJECT_FLOOR_MULT` prices cross-agent
         // reuse and was calibrated on the single-agent case, and nothing recorded
         // enough to tell the two apart after the fact.
-        if let Some((_, folded, _)) = &projected {
+        if let Some((_, folded, _, _)) = &projected {
             // Every line folded means the agent holds markers and nothing else,
             // which is the case `MIN_WHOLE_OUTPUT_FOLD` refuses below 1 KB. Read
             // here rather than threaded out of `substitute`, because that flag is
@@ -598,7 +619,7 @@ impl<'a> Ledger<'a> {
                 .ledger_record(p, &delivered, &self.agent, &self.source);
         }
 
-        projected.map(|(view, _, _)| (view, shifts))
+        projected.map(|(view, _, _, _)| (view, shifts))
     }
 
     /// The marker one run would be replaced by, rendered rather than estimated
@@ -627,7 +648,7 @@ impl<'a> Ledger<'a> {
         lines: &[&str],
         hashes: &[String],
         origin_of: &dyn Fn(&String) -> Option<Seen>,
-    ) -> Option<(String, HashSet<usize>, usize)> {
+    ) -> Option<(String, HashSet<usize>, usize, bool)> {
         let runs = group_runs(hashes, origin_of);
         if !runs.iter().any(|r| r.seen.is_some()) {
             return None;
@@ -691,23 +712,24 @@ impl<'a> Ledger<'a> {
             })
             .collect();
 
-        // #658. A host that renumbers what it is handed cannot take survivors
-        // sitting in two blocks, and refusing the whole view gave up the bytes
-        // above the first split as well. Folding only down to the first run that
-        // survives leaves the rest contiguous, so the head still folds and one
-        // `startLine` still describes everything under it. `markers_above` is
-        // irrelevant to that question, so the plan asks it with zero: the bump is
-        // counted for real during the emit below.
+        // #658, then #664. A host that renumbers what it is handed cannot take
+        // survivors sitting in two blocks. #658 answered that by folding only down
+        // to the first survivor, which left everything below the first change on
+        // the table: 4.4% of a 434 KB CHANGELOG against the 77% its runs were
+        // worth. Padding each fold back to its own line count removes the
+        // constraint instead of working around it, since the survivors then keep
+        // the numbers they came with and no bump is needed.
+        //
+        // `markers_above` is irrelevant to the question the plan asks, so it asks
+        // with zero; the bump is counted for real during the emit below.
         let planned_folds: HashSet<usize> = runs
             .iter()
             .zip(&planned)
             .filter(|(_, fold)| **fold)
             .flat_map(|(run, _)| run.start..run.end)
             .collect();
-        let cutoff = (self.renumbered
-            && FoldShift::of(&planned_folds, lines.len(), 0) == FoldShift::Interior)
-            .then(|| planned.iter().position(|fold| !fold))
-            .flatten();
+        let pad =
+            self.renumbered && FoldShift::of(&planned_folds, lines.len(), 0) == FoldShift::Interior;
 
         let mut out = String::with_capacity(payload_bytes);
         let mut folded: HashSet<usize> = HashSet::new();
@@ -718,6 +740,7 @@ impl<'a> Ledger<'a> {
         // runs. Every attempt to infer it downstream was wrong (#573).
         let mut markers_above = 0usize;
         let mut still_above = true;
+        let mut padded_any = false;
         for (i, run) in runs.iter().enumerate() {
             let body = lines[run.start..run.end].concat();
             // The only question that decides a fold: does this run save more
@@ -747,7 +770,21 @@ impl<'a> Ledger<'a> {
             // payload above: does this run save more than the marker replacing
             // it costs. The marker is rendered rather than estimated, so the
             // test cannot drift from the string it is weighing (#450).
-            let long_enough = planned[i] && cutoff.is_none_or(|c| i < c);
+            // Padding is part of what the fold costs, so the run has to beat it
+            // as well as the marker. Without this a short run "saves" bytes it
+            // then spends on its own filler.
+            let padding = if pad {
+                PAD_LINE.len() * (run.end - run.start - 1)
+            } else {
+                0
+            };
+            let long_enough = planned[i]
+                && run.seen.as_ref().is_some_and(|seen| {
+                    let marker = self
+                        .marker_for(run, seen, lines.len(), &"0".repeat(HANDLE_LEN))
+                        .len();
+                    body.len() >= marker + padding + seen.origin.min_gain()
+                });
 
             // A handle is only offered for content that is provably retrievable.
             // `store_rewind` returns `None` when the row did not land, and the
@@ -775,6 +812,12 @@ impl<'a> Ledger<'a> {
                     if body.ends_with('\n') {
                         out.push('\n');
                     }
+                    if pad {
+                        for _ in 1..(run.end - run.start) {
+                            out.push_str(PAD_LINE);
+                        }
+                        padded_any = true;
+                    }
                     folded.extend(run.start..run.end);
                     replaced_any = true;
                     if still_above {
@@ -787,7 +830,7 @@ impl<'a> Ledger<'a> {
                 }
             }
         }
-        replaced_any.then_some((out, folded, markers_above))
+        replaced_any.then_some((out, folded, markers_above, padded_any))
     }
 }
 

--- a/src/ledger/mod.rs
+++ b/src/ledger/mod.rs
@@ -780,9 +780,14 @@ impl<'a> Ledger<'a> {
             };
             let long_enough = planned[i]
                 && run.seen.as_ref().is_some_and(|seen| {
+                    // The marker is rendered without its terminator and the emit
+                    // adds one back for a run that ended a line, so the test has to
+                    // count it: at the boundary a run folded one byte short of the
+                    // gain it is required to make (review of #664).
                     let marker = self
                         .marker_for(run, seen, lines.len(), &"0".repeat(HANDLE_LEN))
-                        .len();
+                        .len()
+                        + usize::from(body.ends_with('\n'));
                     body.len() >= marker + padding + seen.origin.min_gain()
                 });
 


### PR DESCRIPTION
An editor numbers whatever it is handed, counting from the line the read began at, so a
view with fewer lines than the payload puts every surviving line on a number it is not at
(#557). #658 answered that by folding only down to the first line that survives, which left
everything below the first change unfolded: 4.4% of a 434 KB `CHANGELOG.md` against the
76.5% its runs were worth.

A marker followed by one `⋮` per line it replaced removes the constraint rather than
working around it. The survivors keep the numbers they came with, `startLine` never moves,
and every run may fold.

20 markdown files read twice with no edit between the reads, 615 KB:

| | #658 | now |
| --- | --- | --- |
| corpus | 27.3% | **82.3%** |
| `CHANGELOG.md`, 434 KB | 4.4% | 76.5% |
| `CONTRIBUTING.md` | 8.3% | 84.9% |
| `docs/website/src/develop/index.md` | 7.8% | 84.0% |
| files that already folded whole | 95.4% to 99.6% | unchanged |

All 20 deliver a fold now, and none records one it did not deliver.

`⋮` rather than a blank or a tilde, because editors already read it as elided content, so a
reader who skips the marker above does not take it for a line of the file. The run has to
beat that filler as well as its marker before it folds, so a seen line arriving alone
between new ones stays verbatim. Padding is used only where the survivors would otherwise
split; a contiguous fold keeps its bump and emits none.

**Four existing tests asserted the contract this changes.** They were rewritten to the
property behind it rather than deleted: the lines under a fold keep their numbers, checked
now by comparing the delivered line at an offset against the payload's, which holds whatever
mechanism delivers it.

**Two of my own fixtures were green when they should have been red**, both on thresholds
rather than logic: a one-line run pays no filler, so it could not test the filler cost, and
the replacement seeded the ledger with 220 bytes, under `MIN_LEDGER_INPUT`, so nothing was
recorded and the fold ran against an empty scope. The commit messages say so, and the
assertion names the floor it needs.

Docs: the marker reference, the ledger concept page, both index pages and the README now
describe the changed-file case and the filler line. No published figure moves here. The
corpus numbers come from replaying 5,984 recorded traces on 0.7.5 and this change would
move them, so `benchmarks.md` needs that harness re-run before any of them is restated.

`make ci`: 1,894 tests, clippy clean, security checks passed, smoke test 51/51.

Closes #664




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR preserves line numbering when ledger folds occur inside file reads by emitting one filler line for each omitted line.
- Adds filler-aware fold profitability accounting, including the marker’s emitted newline.
- Keeps `startLine` unchanged for padded views and records only folds actually delivered.
- Updates read-fold tests and English and Indonesian documentation.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the previously reported marker-newline accounting defect is fixed.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/ledger/mod.rs | Implements line-count-preserving read folds and correctly accounts for marker newline and filler costs. |
| src/hooks/post_tool.rs | Updates integration tests to verify fold profitability, preserved line offsets, and accurate ledger recording. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ledger): count the newline the emit ..."](https://github.com/fajarhide/omni/commit/b437cecd28530544be88c1536a713306e75279e6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56011471)</sub>

<!-- /greptile_comment -->