### PR TITLE
fix(producer): a label is the program, not a fragment of the command line

### DIFF
--- a/changelog.d/605.fixed.md
+++ b/changelog.d/605.fixed.md
@@ -1,0 +1,16 @@
+**Rows written before the label fix are corrected rather than waited out.** #603
+fixed `filter_name` going forward and left everything already recorded, so 2,892
+of 17,402 rows on the machine that measured it, 16.6% across 398 distinct names,
+were still filed under an assignment or a binary's full path. They kept
+accumulating until this release was *installed*, because merging a fix does not
+change the binary on disk.
+
+A migration recomputes them from the command each row still carries.
+`producer_label` is a pure function and every stale row kept its command, so this
+is arithmetic rather than a judgement about which rows are real, which is what
+separates it from #163: there the truth was unrecoverable and the answer was to
+exclude by timestamp and delete nothing. It needs no timestamp constant either,
+because recomputing a row written after the fix returns that row's own label.
+
+A row that lost its command is left exactly as it is. The migration runs once,
+records itself in `schema_migrations`, and is its own fixed point if it runs again.

--- a/changelog.d/677.fixed.md
+++ b/changelog.d/677.fixed.md
@@ -1,0 +1,25 @@
+**A producer label could be a fragment of your own command line.** `filter_name`
+is what `omni stats` groups on, and it is derived by stripping leading `VAR=value`
+words off the command. The strip cut on whitespace, and both a command
+substitution and a quoted value are wider than one word:
+
+```
+A=$(kubectl get pods -n web) && echo done   ->  "get"        want kubectl
+A=$(ls -1t /tmp/x.gz | head -1)             ->  "-1t"        want ls
+C="--context abc"; kubectl get pods         ->  "abc"        want kubectl
+```
+
+`-1t` is not a program, and the third line is worse than untidy: a column sized
+for `cargo` and `kubectl` was absorbing whatever word happened to sit inside a
+quoted flag. `is_silent` had the same whitespace split, which is why that segment
+was picked as the producer at all, so both now read one shared quote-aware word
+splitter rather than two copies of the same wrong one.
+
+An assignment whose value opens `$(` names the program inside the substitution,
+but only when nothing follows it. `TAG=$(git rev-parse HEAD) docker build .` runs
+docker, and a substitution's output is captured into the variable rather than
+written to stdout, so as soon as a real command comes after, that command is what
+produced the payload.
+
+The scanner balances `$( )` and honours backslash escapes, so a nested
+substitution and `FOO="a\"b c" kubectl` both stay one word.

--- a/src/pipeline/producer.rs
+++ b/src/pipeline/producer.rs
@@ -211,17 +211,15 @@ fn split_pipeline(segment: &str) -> Vec<&str> {
 }
 
 fn is_silent(segment: &str) -> bool {
-    let mut words = segment
-        .split_whitespace()
-        .map(|w| w.trim_matches(|c| c == '"' || c == '\''));
-    let Some(first) = words.next() else {
+    let mut parts = words(segment).map(|w| w.trim_matches(|c| c == '"' || c == '\''));
+    let Some(first) = parts.next() else {
         return true;
     };
     if HEADER_KEYWORDS.contains(&first) {
         return true;
     }
     let mut rest = std::iter::once(first)
-        .chain(words)
+        .chain(parts)
         .skip_while(|w| CLAUSE_PREFIXES.contains(w) || is_assignment(w));
     match rest.next() {
         // Every word was a clause prefix or an assignment, so nothing ran.
@@ -246,16 +244,92 @@ fn is_silent(segment: &str) -> bool {
 /// is what that buys.
 pub(crate) fn strip_assignments(command: &str) -> &str {
     let mut rest = command.trim_start();
-    while let Some(word) = rest.split_whitespace().next() {
+    // The last assignment consumed, kept only for the case below where every word
+    // is an assignment and there is nothing after them to be the producer.
+    let mut last = "";
+    while let Some((word, tail)) = split_word(rest) {
         if !is_assignment(word) {
-            break;
+            return rest;
         }
-        // `rest` is left-trimmed, so `word` is exactly its prefix. `strip_prefix`
-        // rather than a range index because the crate denies `clippy::string_slice`
-        // and this needs no proof of a char boundary to be correct.
-        rest = rest.strip_prefix(word).unwrap_or(rest).trim_start();
+        last = word;
+        rest = tail.trim_start();
+    }
+
+    // Nothing follows the assignments, so if one of them opened a substitution the
+    // program that ran is inside it: `A=$(kubectl get pods)` runs kubectl, and
+    // before #677 this returned `get`.
+    //
+    // Only in this branch. `TAG=$(git rev-parse HEAD) docker build .` runs
+    // *docker*, and reaching into the substitution there would label and route the
+    // command as git.
+    if let Some((_, inner)) = last.split_once("$(") {
+        let inner = inner.trim_start().trim_end_matches(')').trim_end();
+        if !inner.is_empty() {
+            return inner;
+        }
     }
     rest
+}
+
+/// Words, counting a quoted run as one word.
+///
+/// `split_whitespace` cuts `C="--context abc"` after `--context`, so both callers
+/// treated `C="--context` as a whole assignment and left `abc"` standing as the
+/// command: `is_silent` then called the segment a producer and `strip_assignments`
+/// handed back a fragment of somebody's argument for a reporting column (#677).
+///
+/// One splitter rather than two, because this file already carries the scar of
+/// `program_name` existing twice. Same one-directional quote handling as
+/// `split_sequential`: an unbalanced quote runs to the end and yields one word
+/// rather than inventing a split.
+fn split_word(s: &str) -> Option<(&str, &str)> {
+    let s = s.trim_start();
+    if s.is_empty() {
+        return None;
+    }
+    let mut quote: Option<char> = None;
+    let mut depth = 0usize;
+    let mut escaped = false;
+    let mut end = s.len();
+    let mut chars = s.char_indices().peekable();
+    while let Some((i, c)) = chars.next() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        match c {
+            // A backslash escapes the next character everywhere but inside single
+            // quotes, where the shell takes it literally. Without this,
+            // `FOO="a\"b c" kubectl` closed its quote at the escaped one and the
+            // value's tail became the producer.
+            '\\' if quote != Some('\'') => escaped = true,
+            _ if quote == Some(c) => quote = None,
+            _ if quote.is_some() => {}
+            '"' | '\'' => quote = Some(c),
+            // `$( )` belongs to the word that opens it, so an assignment holding a
+            // substitution is consumed whole rather than cut at its first space.
+            '$' if matches!(chars.peek(), Some((_, '('))) => {
+                chars.next();
+                depth += 1;
+            }
+            ')' if depth > 0 => depth -= 1,
+            _ if c.is_whitespace() && depth == 0 => {
+                end = i;
+                break;
+            }
+            _ => {}
+        }
+    }
+    Some((s.get(..end)?, s.get(end..)?))
+}
+
+fn words(s: &str) -> impl Iterator<Item = &str> {
+    let mut rest = s;
+    std::iter::from_fn(move || {
+        let (word, tail) = split_word(rest)?;
+        rest = tail;
+        Some(word)
+    })
 }
 
 /// The program name to file a recorded row under, for any command string.
@@ -449,5 +523,76 @@ mod producer_label_tests {
         for (name, command, expected) in cases {
             assert_eq!(producer_label(command), expected, "case: {name}");
         }
+    }
+}
+
+#[cfg(test)]
+mod label_fragments {
+    use super::producer_label;
+
+    /// #677. `strip_assignments` removed one whitespace-delimited word, and both
+    /// a command substitution and a quoted value are wider than that. What was
+    /// left standing as the command was a fragment of the argument list, so a
+    /// column sized for `cargo` and `kubectl` could hold `-1t` or any word the
+    /// user typed inside a quoted flag.
+    #[test]
+    fn an_assignment_holding_a_substitution_names_the_program_inside_it() {
+        assert_eq!(producer_label("A=$(kubectl get pods -n web)"), "kubectl");
+        // The one that made it obvious: `-1t` is not a program.
+        assert_eq!(producer_label("A=$(ls -1t /tmp/x.gz | head -1)"), "ls");
+        // An empty substitution names nothing, so the next segment stands.
+        assert_eq!(producer_label("X=$(  ) echo hi"), "echo");
+    }
+
+    /// The substitution is only the producer when nothing follows it. Its output
+    /// is captured into the variable rather than written to stdout, so as soon as
+    /// a real command comes after, that command is what wrote the payload.
+    #[test]
+    fn a_command_after_the_substitution_is_the_producer() {
+        assert_eq!(
+            producer_label("TAG=$(git rev-parse HEAD) docker build ."),
+            "docker"
+        );
+        // Same reason across a sequence: `echo` is what printed, not `kubectl`.
+        assert_eq!(
+            producer_label("A=$(kubectl get pods -n web) && echo done"),
+            "echo"
+        );
+    }
+
+    /// A backslash escape inside a quoted value does not end the quote, so the
+    /// value stays one word and its tail cannot become the label.
+    #[test]
+    fn an_escaped_quote_does_not_end_the_value() {
+        assert_eq!(
+            producer_label("FOO=\"a\\\"b c\" kubectl get pods"),
+            "kubectl"
+        );
+    }
+
+    /// The quoted half. `C="--context abc"` is one word, and splitting it on
+    /// whitespace left `abc"` as the producer. `is_silent` had the same split,
+    /// which is why the segment was picked at all, so both had to move together.
+    #[test]
+    fn a_quoted_assignment_value_is_one_word() {
+        assert_eq!(
+            producer_label("C=\"--context abc\"; kubectl get pods"),
+            "kubectl"
+        );
+        assert_eq!(producer_label("MSG=\"a b c\" echo hi"), "echo");
+    }
+
+    /// #339's cases, which this must not regress: the whole point of stripping
+    /// assignments is that an env prefix does not change the producer.
+    #[test]
+    fn a_plain_env_prefix_still_names_the_program() {
+        assert_eq!(producer_label("FOO=1 cargo build --release"), "cargo");
+        assert_eq!(producer_label("A=1 B=2 make ci"), "make");
+        assert_eq!(
+            producer_label("OMNI_DB_PATH=/tmp/d.db kubectl get pods"),
+            "kubectl"
+        );
+        assert_eq!(producer_label("/bin/ls -l /tmp"), "ls");
+        assert_eq!(producer_label("cargo build"), "cargo");
     }
 }

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -1159,6 +1159,60 @@ impl SqliteBackend {
             tx.commit()?;
         }
 
+        // #605. #603 fixed `filter_name` going forward and left every row already
+        // written, so `omni stats` and every workload query still group 16% of
+        // this corpus under an assignment or a binary's full path. 2,892 of
+        // 17,402 rows across 398 names on the machine that measured it, and they
+        // kept accumulating until 0.7.7 was installed, because merging a fix does
+        // not change the binary on disk.
+        //
+        // Not the #163 shape, which is what makes this cheap. There the rows
+        // recorded a saving that never reached an agent, no arithmetic could
+        // recover the truth, and the answer was to exclude them by timestamp and
+        // delete nothing. Here every column is right except a derived one, the
+        // column it derives from is intact on all of them, and `producer_label`
+        // is pure. So the recompute is arithmetic rather than a judgement, and it
+        // needs no timestamp constant: run over a row written after the fix it
+        // returns that row's own label.
+        //
+        // Ordered after #677 deliberately. Recomputing before that landed would
+        // have turned `A=$(ls` into `-1t`, destroying the original label to write
+        // something no more correct.
+        let migration_labels = "2026_08_recompute_filter_name_from_command";
+        let labels_applied: Option<i64> = conn
+            .query_row(
+                "SELECT 1 FROM schema_migrations WHERE id = ?1 LIMIT 1",
+                params![migration_labels],
+                |row| row.get(0),
+            )
+            .optional()?;
+        if labels_applied.is_none() {
+            let tx = conn.unchecked_transaction()?;
+            let stale: Vec<(i64, String)> = {
+                let mut stmt = tx.prepare(
+                    "SELECT id, command FROM distillations
+                     WHERE command IS NOT NULL AND command != ''
+                       AND (filter_name LIKE '%=%' OR filter_name LIKE '/%')",
+                )?;
+                let rows = stmt.query_map([], |row| {
+                    Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
+                })?;
+                rows.flatten().collect()
+            };
+            for (id, command) in stale {
+                let label = crate::pipeline::producer::producer_label(&command);
+                tx.execute(
+                    "UPDATE distillations SET filter_name = ?1 WHERE id = ?2",
+                    params![label, id],
+                )?;
+            }
+            tx.execute(
+                "INSERT INTO schema_migrations (id, applied_at) VALUES (?1, ?2)",
+                params![migration_labels, chrono::Utc::now().timestamp()],
+            )?;
+            tx.commit()?;
+        }
+
         // `context_turns` was written on every hooked command, carried an index,
         // and had no `SELECT` anywhere in the tree: 5,532 rows paying write
         // latency and disk for a reader that never existed (#270). The in-memory
@@ -5290,5 +5344,109 @@ mod tests {
             "an empty session id answered with the whole table"
         );
         assert_eq!(store.passthrough_reasons_for(0, None).len(), 2);
+    }
+
+    /// #605. #603 fixed the label going forward and left 16% of the recorded
+    /// corpus filed under an assignment or a binary's full path, which every
+    /// workload query groups on equally.
+    ///
+    /// Run twice on purpose. #379 is the precedent for a migration undone by live
+    /// code, and a recompute that is not idempotent is the same hazard wearing a
+    /// different hat: the predicate that selects a stale row must not match the
+    /// row the migration just wrote.
+    #[test]
+    fn the_recompute_fixes_a_stale_label_and_does_not_run_twice() {
+        let dir = tempdir().unwrap();
+        let db = dir.path().join("omni.db");
+        drop(Store::open_path(&db).expect("first open builds the schema"));
+
+        let seed = [
+            ("A=$(kubectl", "A=$(kubectl get pods -n web)"),
+            ("/bin/ls", "/bin/ls -l /tmp"),
+            ("S=/tmp/x", "S=/tmp/x cargo build --release"),
+            // Already correct, and it must come out unchanged.
+            ("cargo", "cargo build --release"),
+        ];
+        {
+            let conn = rusqlite::Connection::open(&db).expect("open seed db");
+            conn.execute(
+                "DELETE FROM schema_migrations
+                 WHERE id = '2026_08_recompute_filter_name_from_command'",
+                [],
+            )
+            .expect("re-arm migration");
+            for (i, (name, command)) in seed.iter().enumerate() {
+                conn.execute(
+                    "INSERT INTO distillations
+                        (id, session_id, ts, filter_name, input_bytes, output_bytes,
+                         route, latency_ms, command)
+                     VALUES (?1, 's1', 1, ?2, 100, 50, 'Keep', 1, ?3)",
+                    params![i as i64 + 1, name, command],
+                )
+                .expect("seed row");
+            }
+        }
+
+        let labels = |db: &std::path::Path| -> Vec<String> {
+            let store = Store::open_path(db).expect("reopen runs the migration");
+            let conn = store.pool.get().unwrap();
+            let mut stmt = conn
+                .prepare("SELECT filter_name FROM distillations ORDER BY id")
+                .unwrap();
+            stmt.query_map([], |r| r.get::<_, String>(0))
+                .unwrap()
+                .flatten()
+                .collect()
+        };
+
+        let after = labels(&db);
+        assert_eq!(
+            after,
+            vec![
+                "kubectl".to_string(),
+                "ls".to_string(),
+                "cargo".to_string(),
+                "cargo".to_string()
+            ],
+            "a stale label survived the recompute"
+        );
+
+        // Second open. The migration is recorded, so nothing runs, and even if it
+        // did the recompute is its own fixed point.
+        assert_eq!(labels(&db), after, "a second open changed the labels again");
+    }
+
+    /// The recompute reads `command` and nothing else, so a row that lost its
+    /// command has no arithmetic to recover and is left exactly as it is rather
+    /// than relabelled from a guess.
+    #[test]
+    fn a_row_with_no_command_keeps_its_stale_label() {
+        let dir = tempdir().unwrap();
+        let db = dir.path().join("omni.db");
+        drop(Store::open_path(&db).expect("first open builds the schema"));
+        {
+            let conn = rusqlite::Connection::open(&db).expect("open seed db");
+            conn.execute(
+                "DELETE FROM schema_migrations
+                 WHERE id = '2026_08_recompute_filter_name_from_command'",
+                [],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO distillations
+                    (id, session_id, ts, filter_name, input_bytes, output_bytes,
+                     route, latency_ms, command)
+                 VALUES (1, 's1', 1, 'A=$(kubectl', 100, 50, 'Keep', 1, '')",
+                [],
+            )
+            .unwrap();
+        }
+
+        let store = Store::open_path(&db).expect("reopen runs the migration");
+        let conn = store.pool.get().unwrap();
+        let name: String = conn
+            .query_row("SELECT filter_name FROM distillations", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(name, "A=$(kubectl");
     }
 }


### PR DESCRIPTION
Two issues, in the order they have to happen.

**#677.** `filter_name` is what `omni stats` groups on, derived by stripping leading
`VAR=value` words off the command. The strip cut on whitespace, and both a command
substitution and a quoted value are wider than one word:

```
A=$(kubectl get pods -n web) && echo done   ->  "get"        want kubectl
A=$(ls -1t /tmp/x.gz | head -1)             ->  "-1t"        want ls
C="--context abc"; kubectl get pods         ->  "abc"        want kubectl
FOO=1 cargo build --release                 ->  "cargo"      correct
/bin/ls -l /tmp                             ->  "ls"         correct
```

`-1t` is not a program. The third line is the one that is worse than untidy: a
column sized for `cargo` and `kubectl` was absorbing whatever word happened to sit
inside a quoted flag, and one real row on this machine took its label from inside a
`--context` value.

`is_silent` had the same whitespace split, which is why that segment was picked as
the producer at all, so the two now read one shared quote-aware splitter instead of
two copies of the same wrong one. This file already carries the scar of
`program_name` having existed twice.

**#605**, which the above unblocks. #603 fixed the label going forward and left
everything already recorded: 2,892 of 17,402 rows here, 16.6% across 398 names,
still filed under an assignment or a binary's full path, and still accumulating,
because a merged fix does not change the binary on disk. A migration recomputes them
from the command each row still carries.

That is arithmetic rather than a judgement about which rows are real, which is what
separates it from #163: there the truth was unrecoverable and the answer was to
exclude by timestamp and delete nothing. `producer_label` is pure and every stale row
kept its command, so it also needs no timestamp constant, because recomputing a row
written after the fix returns that row's own label. A row that lost its command is
left exactly as it is.

**The order is the point.** Recomputing before #677 landed would have turned
`A=$(ls` into `-1t`: the original label destroyed to write something no more correct.

Six assertions, each driven red: the substitution branch removed, `strip_assignments`
back on `split_whitespace`, `is_silent` back on `split_whitespace`, the recompute
writing the raw command, the path half of the predicate dropped, and a row with no
command relabelled anyway. The migration test opens the database twice and asserts
the second open changes nothing, per #379.

Left alone deliberately: `X=$( ) echo hi` still yields `)`. There is no row of that
shape in 17,402 recorded, so a guard for it would be speculative.

`make ci` green.

Closes #677
Closes #605




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR introduces a shared quote-aware command-word scanner and migrates stored producer labels by recomputing them from retained commands. The all-assignment fallback remains incomplete when a command substitution appears before the final assignment.

- Shares command tokenization between producer detection and assignment stripping.
- Handles quoted values, escaped quotes, and command-substitution assignments.
- Recomputes stale SQLite `filter_name` values once through a recorded migration.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because a related all-assignment command can still receive an empty label and generic routing instead of the program run by its substitution.

The fallback retains only the final assignment, so `A=$(kubectl get pods) B=2` discards the earlier substitution and resolves to an empty producer rather than `kubectl`.

**Files Needing Attention:** src/pipeline/producer.rs
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/pipeline/producer.rs | Adds quote-aware producer parsing, but all-assignment commands lose substitutions from assignments preceding the final one. |
| src/store/sqlite.rs | Adds a transactional, recorded migration that recomputes stale labels for rows retaining a command. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20fajarhide%2Fomni%20PR%20%23679%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=fajarhide%2Fomni&pr=679&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fpipeline%2Fproducer.rs%3A263%0A**Earlier%20substitutions%20lose%20their%20producer**%0A%0AWhen%20an%20all-assignment%20command%20has%20a%20non-empty%20substitution%20before%20a%20final%20plain%20assignment%2C%20such%20as%20%60A%3D%24%28kubectl%20get%20pods%29%20B%3D2%60%2C%20the%20loop%20retains%20only%20%60B%3D2%60%20and%20returns%20an%20empty%20command%2C%20causing%20an%20empty%20producer%20label%20and%20generic%2Fdefault%20routing%20instead%20of%20selecting%20%60kubectl%60.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni&pr=679&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fajarhide%2Fomni%22%20on%20the%20existing%20branch%20%22fix%2F677-producer-label-fragments%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F677-producer-label-fragments%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fpipeline%2Fproducer.rs%3A263%0A**Earlier%20substitutions%20lose%20their%20producer**%0A%0AWhen%20an%20all-assignment%20command%20has%20a%20non-empty%20substitution%20before%20a%20final%20plain%20assignment%2C%20such%20as%20%60A%3D%24%28kubectl%20get%20pods%29%20B%3D2%60%2C%20the%20loop%20retains%20only%20%60B%3D2%60%20and%20returns%20an%20empty%20command%2C%20causing%20an%20empty%20producer%20label%20and%20generic%2Fdefault%20routing%20instead%20of%20selecting%20%60kubectl%60.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni&pr=679&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Asrc%2Fpipeline%2Fproducer.rs%3A263%0A**Earlier%20substitutions%20lose%20their%20producer**%0A%0AWhen%20an%20all-assignment%20command%20has%20a%20non-empty%20substitution%20before%20a%20final%20plain%20assignment%2C%20such%20as%20%60A%3D%24%28kubectl%20get%20pods%29%20B%3D2%60%2C%20the%20loop%20retains%20only%20%60B%3D2%60%20and%20returns%20an%20empty%20command%2C%20causing%20an%20empty%20producer%20label%20and%20generic%2Fdefault%20routing%20instead%20of%20selecting%20%60kubectl%60.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=679&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fajarhide%2Fomni%22%20on%20the%20existing%20branch%20%22fix%2F677-producer-label-fragments%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F677-producer-label-fragments%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fpipeline%2Fproducer.rs%3A263%0A**Earlier%20substitutions%20lose%20their%20producer**%0A%0AWhen%20an%20all-assignment%20command%20has%20a%20non-empty%20substitution%20before%20a%20final%20plain%20assignment%2C%20such%20as%20%60A%3D%24%28kubectl%20get%20pods%29%20B%3D2%60%2C%20the%20loop%20retains%20only%20%60B%3D2%60%20and%20returns%20an%20empty%20command%2C%20causing%20an%20empty%20producer%20label%20and%20generic%2Fdefault%20routing%20instead%20of%20selecting%20%60kubectl%60.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/pipeline/producer.rs:263
**Earlier substitutions lose their producer**

When an all-assignment command has a non-empty substitution before a final plain assignment, such as `A=$(kubectl get pods) B=2`, the loop retains only `B=2` and returns an empty command, causing an empty producer label and generic/default routing instead of selecting `kubectl`.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(producer): a label is the program, n..."](https://github.com/fajarhide/omni/commit/3c4dc621d44047a01e53aa3d2ff97a2a5fc2825b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56014731)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->