### PR TITLE
docs(benchmarks): publish the current run beside the one whose corpus is gone

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,11 @@ real command executions that reached a model:
   everything here: 286 groups of byte-identical payloads are 80.6% of these bytes, and
   148 of the 5,984 calls carry 64.7% of them. It was a week of building and
   benchmarking OMNI. The same harness over a week of ordinary work reads **14.9%**.
+* **These traces have since been pruned.** `execution_traces` keeps seven days, so this
+  window cannot be replayed again by us or by anyone else. What a later week reads, and
+  why it differs, is in
+  [benchmarks](https://omni.weekndlabs.com/docs/develop/benchmarks.html). Run the harness
+  on your own history for a figure about your workload.
 * **It fires where your bytes are.** File re-reads are the largest class in this
   corpus and the ledger takes **89.6%** off them. Where there is nothing safe to
   take, a two-line `git status` or a JSON payload a later step parses, OMNI hands the

--- a/changelog.d/678.changed.md
+++ b/changelog.d/678.changed.md
@@ -1,0 +1,21 @@
+**The benchmark page publishes two runs, and says why they disagree by a factor of
+fifteen.** Every figure on it came from one replay of one week, 2026-08-11 to 08-14, and
+`execution_traces` prunes at seven days, so that corpus is gone and nobody can re-derive
+those numbers, us included. Re-running the same harness on 2026-08-23 over the following
+week reads **1.0% from the filters and 4.6% with the ledger**, against 32.6% and 69.6%.
+
+Neither figure is wrong and the gap is the useful part: that week was 80.6% duplicate bytes
+from a fortnight of building OMNI, and this one is shell plumbing, 4,598 of 8,934 calls
+beginning with `cd` and a median repeated run of 10 bytes. Both runs are on the page with
+their corpus lines, the older one labelled as unreproducible rather than deleted.
+
+Two things the page now says that it did not. The harness replays `execution_traces`, which
+holds shell commands only, so **no figure on it covers the ledger's file-read path**,
+including the count-preserving fold from #664. And the method snapshots the database before
+replaying, since hooks write to it while the replay reads.
+
+The README and both index pages keep the figures they published and gain one line saying
+those traces have since been pruned, so that window cannot be replayed. The percentages
+there do not move: the later run is lower because its week barely repeats itself, not
+because anything got worse, and swapping one week's corpus for another's on a marketing
+surface would say something the measurement does not.

--- a/docs/website/src-id/index.md
+++ b/docs/website/src-id/index.md
@@ -158,7 +158,7 @@ mempertahankan jumlah baris yang digantikannya, jadi baris yang tidak berpindah 
 di nomor yang diberikan editor Anda.
 
 Angka-angka itu berasal dari satu minggu, dan log trace hanya menyimpan tujuh hari, jadi
-minggu itu tidak bisa diputar ulang lagi. [Benchmarks](develop/benchmarks.md) memuat tiap
+minggu itu tidak bisa diputar ulang lagi. [Benchmarks](https://omni.weekndlabs.com/docs/develop/benchmarks) memuat tiap
 run beserta korpusnya, dan seberapa berharga angka mana pun bagi Anda bergantung pada
 seberapa banyak minggu Anda sendiri mengulang dirinya.
 

--- a/docs/website/src-id/index.md
+++ b/docs/website/src-id/index.md
@@ -157,6 +157,11 @@ File yang berubah di antara dua bacaan tetap dilipat di sekitar perubahannya. Ti
 mempertahankan jumlah baris yang digantikannya, jadi baris yang tidak berpindah tetap ada
 di nomor yang diberikan editor Anda.
 
+Angka-angka itu berasal dari satu minggu, dan log trace hanya menyimpan tujuh hari, jadi
+minggu itu tidak bisa diputar ulang lagi. [Benchmarks](develop/benchmarks.md) memuat tiap
+run beserta korpusnya, dan seberapa berharga angka mana pun bagi Anda bergantung pada
+seberapa banyak minggu Anda sendiri mengulang dirinya.
+
 Ketika tidak ada yang aman untuk diambil, ia tidak mengambil apa pun. `git status`
 dua baris tidak punya basa-basi untuk dibuang dan tidak punya pengulangan untuk
 dilipat, dan payload JSON yang akan diurai langkah berikutnya sama sekali tidak

--- a/docs/website/src/develop/benchmarks.md
+++ b/docs/website/src/develop/benchmarks.md
@@ -1,13 +1,54 @@
 # Benchmarks
 
-One developer's real command history, replayed on 0.7.5. Every figure below comes
-from the same run, including the ones that do not flatter us.
+One developer's real command history, replayed. Every figure in a section comes from the
+same run as the rest of that section, including the ones that do not flatter us.
+
+**Two runs are published here and they disagree by a factor of fifteen.** That is the most
+useful thing on the page: the number OMNI reports is a property of the week it replays, not
+a constant. Read the corpus line before the figure, every time.
+
+## The current run, 2026-08-23
+
+**Corpus**: 8,934 traces, 7,822,947 bytes, 2026-08-17 02:05:18 to 2026-08-23 14:16:41 UTC,
+all `agent_id='claude_code'`, 0 terminal rows, 0 errored. Replayed in 7.5 s on `8a355f9`.
+
+**1.0% from the filters. 4.6% with the ledger.** 98.3% of calls saved nothing, 1.7% shrank,
+and **no call came back larger**.
+
+| class | calls | input | filters | + ledger |
+|---|---|---|---|---|
+| other | 6,050 | 4.45 MB | 0.5% | 4.3% |
+| file read (`cat`, `sed`, `head`, `tail`) | 1,014 | 1.78 MB | 0.0% | 4.5% |
+| search | 788 | 0.73 MB | 2.6% | 3.6% |
+| `git` | 829 | 0.70 MB | 5.0% | 7.9% |
+| infra | 210 | 0.13 MB | 3.3% | 3.9% |
+| build and test | 43 | 0.02 MB | 7.8% | 9.9% |
+| **aggregate** | **8,934** | **7.82 MB** | **1.0%** | **4.6%** |
+
+**Why it is so much lower than the run below: the corpus is mostly one-line shell
+plumbing.** 4,598 of the 8,934 calls begin with `cd`, carrying 3.74 MB at 1.1%, and the
+median repeated run is 10 bytes. This was a week of driving OMNI's own development from a
+terminal, so the payloads are `git`, `gh`, `sed` and `sqlite3` output that is either tiny,
+structured, or seen once. Repetition is 16.3% of raw bytes here against the 80.6% of the
+window below.
+
+**What it does not measure.** The harness replays `execution_traces`, which holds shell
+commands only: zero of these 8,934 rows is a `Read` payload. The ledger's file-read path,
+including the count-preserving fold added in #664, is not exercised by any figure on this
+page. That gap is the honest reason the fold's own numbers live in
+`changelog.d/664.changed.md` with their own corpus instead of here.
+
+## The 0.7.5 run, 2026-08-14, which can no longer be re-derived
+
+`execution_traces` prunes at seven days, so the corpus behind every figure in this section
+is gone. It is kept because deleting a published number is worse than labelling it, and
+because the gap between the two runs is the point.
 
 **Corpus**: 5,984 traces, 23,086,649 bytes, 2026-08-11 11:03:00 to 2026-08-14
 18:11:10 UTC, all `agent_id='claude_code'`, 123 terminal rows excluded from 6,107,
 0 errored. Replayed in 1,238 s.
 
-## The headline
+### That run's headline
 
 **32.6% fewer bytes from the filters. 69.6% with the ledger.**
 23,086,649 to 15,557,823 to 7,026,021.
@@ -34,7 +75,7 @@ repeated to fill. It is the week this machine did nothing but develop and benchm
 OMNI. A corpus of ordinary work reads far lower: the same harness on 6,656 traces in
 August 2026 read 2.7% and 14.9%.
 
-## Which commands benefit
+### Which commands benefit
 
 | class | calls | input | filters | + ledger |
 |---|---:|---:|---:|---:|
@@ -80,7 +121,7 @@ Top commands by input bytes, filters only:
 Byte-sink and token-sink rankings disagree at the tail: `bash` enters the token top
 15 where `kubectl` sits in the byte one.
 
-## Head to head, one corpus
+### Head to head, one corpus
 
 Identical bytes into every arm. Versions: rtk 0.45.0, lean-ctx 3.9.18, caveman 1.1.0
 (binaries `bin-v1.0.0`), headroom at `cross_turn_dedup.py`.
@@ -107,7 +148,7 @@ which is exactly the shape a deep-and-narrow compressor is built for.
 No `lean-ctx + our ledger` row: its preview reports `compressed_bytes` and never emits
 the text, so that row could only be estimated.
 
-## Single fixtures
+### Single fixtures
 
 From `tests/fixtures/`, same build, reproducible by hand. "Delivered" includes the
 marker.
@@ -137,9 +178,19 @@ OMNI_BENCH_DB=~/.omni/omni.db \
   cargo test --release --test bench_replay -- --ignored --nocapture
 ```
 
+Snapshot the database first if the figure has to be quotable: hooks write to it while the
+replay reads, and `execution_traces` prunes at seven days, so a run against the live file
+measures a corpus that is already different from the one anybody else would get.
+
+```sh
+sqlite3 ~/.omni/omni.db ".backup /tmp/bench-corpus.db"
+OMNI_BENCH_DB=/tmp/bench-corpus.db \
+  cargo test --release --test bench_replay -- --ignored --nocapture
+```
+
 | | |
 |---|---|
-| corpus | `execution_traces.raw_input`, real usage, replayed. Not synthetic |
+| corpus | `execution_traces.raw_input`, real usage, replayed. Not synthetic. Shell commands only: no `Read` payload is in this table, so no figure here covers the ledger's file-read path |
 | population | calls whose result reached a model. `OMNI_BENCH_ALL=1` widens it |
 | state | `session: None`, `store: None`, `HOME` at an empty temp dir |
 | path | `run_inner`, the same pipeline the hook and `omni exec` run, markers included |

--- a/docs/website/src/index.md
+++ b/docs/website/src/index.md
@@ -132,6 +132,10 @@ A file that changed between the two reads still folds around the change. Each fo
 the line count of what it replaced, so the lines you did not see moved stay on the numbers
 your editor gives them.
 
+Those figures come from one week, and the trace log keeps seven days, so that week cannot be
+replayed again. [Benchmarks](develop/benchmarks.md) publishes each run with its corpus, and
+what any of them is worth to you depends on how much your own week repeats itself.
+
 Where there is nothing safe to take it takes nothing. A two-line `git status` has no
 ceremony to drop and no repeats to fold, and a JSON payload a later step parses is never
 touched at all, so OMNI hands those straight back rather than inventing a saving to


### PR DESCRIPTION
Re-ran the replay harness on `8a355f9` and the answer is not a new number, it is that the
old one cannot be re-derived.

`execution_traces` prunes at seven days, so the 2026-08-11 to 08-14 corpus behind every
published figure is gone. The same harness over the following week, 8,934 traces snapshotted
at 2026-08-23 14:16 UTC:

| | 08-11 to 08-14 | 08-17 to 08-23 |
| --- | --- | --- |
| filters | 32.6% | **1.0%** |
| with the ledger | 69.6% | **4.6%** |
| calls that saved nothing | 96.1% | 98.3% |
| calls that came back larger | 0 | 0 |

A factor of fifteen, and it is corpus composition rather than a regression: that week was
80.6% duplicate bytes from a fortnight of building OMNI, this one is shell plumbing with
4,598 of 8,934 calls beginning with `cd` and a median repeated run of 10 bytes. Both runs are
published with their corpus lines, the older one labelled unreproducible rather than deleted.

**The harness does not measure the file-read ledger at all.** Zero of the 8,934 rows is a
`Read` payload, `execution_traces` holds shell commands only. So no figure on that page
covers the path #664 landed in, and the page now says so. The published "file read" class is
`cat`, `sed`, `head` and `tail` through Bash.

The method section gained the snapshot step, since hooks write to the database while the
replay reads it.

**README and both index pages keep the figures they published**, and gain one line saying
those traces have been pruned. The percentages do not move: the later run is lower because
its week barely repeats itself, not because anything got worse, and putting one week's
corpus in place of another's on a marketing surface would say something the measurement
does not. The full second run is one click away on the benchmarks page.

`make ci` green, translation gate green.

Closes #678




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR documents a current benchmark run alongside an older run whose trace corpus has expired, clarifying the large corpus-dependent difference and the harness’s scope.
- Adds the 2026-08-23 benchmark results and corpus details.
- Labels the older benchmark corpus as unavailable for replay.
- Documents database snapshotting and clarifies that the harness excludes built-in `Read` payloads.
- Updates the README, English index, Indonesian index, and changelog with retention context.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/website/src/develop/benchmarks.md | Publishes both benchmark runs, explains their corpus differences, and expands the methodology and scope disclosures. |
| docs/website/src-id/index.md | Adds trace-retention context and replaces the previously broken localized relative benchmark link with an absolute English documentation URL. |
| docs/website/src/index.md | Adds a concise warning that the cited benchmark week can no longer be replayed. |
| README.md | Preserves the published figures while clearly noting that their source traces have been pruned. |
| changelog.d/678.changed.md | Records the new benchmark run, the corpus explanation, and the harness limitations. |

</details>

<sub>Reviews (3): Last reviewed commit: ["docs(id): link the benchmark page absolu..."](https://github.com/fajarhide/omni/commit/4fc7515f322c6ebf0a9032e719246109242f7fb6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56014775)</sub>

<!-- /greptile_comment -->