### PR TITLE
fix(producer): the first assignment that ran is the producer, not the last one seen

### DIFF
--- a/changelog.d/677.fixed.md
+++ b/changelog.d/677.fixed.md
@@ -21,5 +21,10 @@ docker, and a substitution's output is captured into the variable rather than
 written to stdout, so as soon as a real command comes after, that command is what
 produced the payload.
 
-The scanner balances `$( )` and honours backslash escapes, so a nested
-substitution and `FOO="a\"b c" kubectl` both stay one word.
+When every word is an assignment, the producer is the first one that actually ran
+something: `A=$(kubectl get pods) B=2` is `kubectl`, and keeping the last one
+instead returned an empty label. An empty substitution has not run anything, so
+`A=$( ) B=$(ls)` is `ls`.
+
+The scanner balances `$( )` and honours backslash escapes, so a nested substitution
+and `FOO="a\"b c" kubectl` both stay one word.

--- a/src/pipeline/producer.rs
+++ b/src/pipeline/producer.rs
@@ -244,14 +244,18 @@ fn is_silent(segment: &str) -> bool {
 /// is what that buys.
 pub(crate) fn strip_assignments(command: &str) -> &str {
     let mut rest = command.trim_start();
-    // The last assignment consumed, kept only for the case below where every word
-    // is an assignment and there is nothing after them to be the producer.
-    let mut last = "";
+    // The first assignment that runs something, kept for the case below where
+    // every word is an assignment and nothing follows them to be the producer.
+    // First rather than last, because that is execution order, and because
+    // keeping the last one returned an empty label for `A=$(kubectl get pods) B=2`.
+    let mut ran = "";
     while let Some((word, tail)) = split_word(rest) {
         if !is_assignment(word) {
             return rest;
         }
-        last = word;
+        if ran.is_empty() && !substitution_body(word).is_empty() {
+            ran = word;
+        }
         rest = tail.trim_start();
     }
 
@@ -262,13 +266,22 @@ pub(crate) fn strip_assignments(command: &str) -> &str {
     // Only in this branch. `TAG=$(git rev-parse HEAD) docker build .` runs
     // *docker*, and reaching into the substitution there would label and route the
     // command as git.
-    if let Some((_, inner)) = last.split_once("$(") {
-        let inner = inner.trim_start().trim_end_matches(')').trim_end();
-        if !inner.is_empty() {
-            return inner;
-        }
+    let inner = substitution_body(ran);
+    if !inner.is_empty() {
+        return inner;
     }
     rest
+}
+
+/// What a `VAR=$(...)` assignment actually runs, empty when it runs nothing.
+///
+/// One function so the loop and the fallback agree on what counts. They did not:
+/// the loop remembered any word containing `$(`, so `A=$( ) B=$(ls)` latched onto
+/// the empty one and the fallback then found nothing to return.
+fn substitution_body(word: &str) -> &str {
+    word.split_once("$(")
+        .map(|(_, inner)| inner.trim_start().trim_end_matches(')').trim_end())
+        .unwrap_or("")
 }
 
 /// Words, counting a quoted run as one word.
@@ -542,6 +555,15 @@ mod label_fragments {
         assert_eq!(producer_label("A=$(ls -1t /tmp/x.gz | head -1)"), "ls");
         // An empty substitution names nothing, so the next segment stands.
         assert_eq!(producer_label("X=$(  ) echo hi"), "echo");
+        // The one that runs is the producer even when a plain assignment follows
+        // it. Keeping the last assignment instead returned an empty label.
+        assert_eq!(producer_label("A=$(kubectl get pods) B=2"), "kubectl");
+        assert_eq!(producer_label("A=1 B=$(ls -l)"), "ls");
+        // Two of them, and the first is the one that ran first.
+        assert_eq!(producer_label("A=$(aws s3 ls) B=$(git log)"), "aws");
+        // An empty substitution runs nothing, so it is not the first that ran.
+        assert_eq!(producer_label("A=$( ) B=$(ls)"), "ls");
+        assert_eq!(producer_label("A=$(ls) B=$( )"), "ls");
     }
 
     /// The substitution is only the producer when nothing follows it. Its output


### PR DESCRIPTION
Follow-up to #679, from a review comment that landed after it merged.

When every word of a command is an assignment, `strip_assignments` kept the last one
it walked past and reached into that for the substitution:

```
A=$(kubectl get pods) B=2   ->  ""      want kubectl
A=1 B=$(ls -l)              ->  "ls"    correct by luck, it was last
```

`B=2` holds no `$(`, so the branch found nothing and returned an empty label. An
empty group key in `omni stats`, and generic routing for a command that plainly ran
kubectl.

It keeps the first assignment holding a substitution now, first rather than last
because that is execution order:

```
A=$(kubectl get pods) B=2       ->  kubectl
A=1 B=$(ls -l)                  ->  ls
A=$(aws s3 ls) B=$(git log)     ->  aws
TAG=$(git rev-parse HEAD) docker build .   ->  docker    unchanged
```

Driven red both ways: keeping the last running assignment, and remembering none.

`make ci` green.

Refs #677




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR updates assignment-only producer detection to retain the first assignment containing an apparent command substitution and documents the behavior.
- Adds coverage for multiple assignments and whitespace-empty substitutions.
- The new predicate remains inconsistent with the quote-aware word parser, causing quoted literal text to be treated as an executed substitution.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because quoted literal `$(` text can mask a later assignment that actually executes the producer command.

The new first-match logic relies on a quote-unaware textual search, so an assignment-only command such as `A='foo$(bar)' B=$(ls)` is labeled and routed as `bar` rather than `ls`.

**Files Needing Attention:** src/pipeline/producer.rs
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/pipeline/producer.rs | Changes producer selection from the last assignment to the first apparently non-empty substitution, but misclassifies single-quoted `$(` literals and can select the wrong producer. |
| changelog.d/677.fixed.md | Documents the intended first-running-assignment behavior and the newly covered empty-substitution case. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20fajarhide%2Fomni%20PR%20%23681%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=fajarhide%2Fomni&pr=681&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fpipeline%2Fproducer.rs%3A256-258%0A**Quoted%20literal%20masks%20real%20producer**%0A%0AWhen%20an%20assignment-only%20command%20contains%20a%20single-quoted%20literal%20%60%24%28%60%20before%20a%20real%20substitution%2C%20such%20as%20%60A%3D'foo%24%28bar%29'%20B%3D%24%28ls%29%60%2C%20%60substitution_body%60%20treats%20the%20literal%20text%20as%20executable%20and%20%60ran%60%20selects%20that%20assignment%2C%20causing%20the%20command%20to%20be%20labeled%20and%20routed%20as%20%60bar%60%20instead%20of%20%60ls%60.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni&pr=681&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fajarhide%2Fomni%22%20on%20the%20existing%20branch%20%22fix%2F677-first-running-assignment%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F677-first-running-assignment%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fpipeline%2Fproducer.rs%3A256-258%0A**Quoted%20literal%20masks%20real%20producer**%0A%0AWhen%20an%20assignment-only%20command%20contains%20a%20single-quoted%20literal%20%60%24%28%60%20before%20a%20real%20substitution%2C%20such%20as%20%60A%3D'foo%24%28bar%29'%20B%3D%24%28ls%29%60%2C%20%60substitution_body%60%20treats%20the%20literal%20text%20as%20executable%20and%20%60ran%60%20selects%20that%20assignment%2C%20causing%20the%20command%20to%20be%20labeled%20and%20routed%20as%20%60bar%60%20instead%20of%20%60ls%60.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni&pr=681&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Asrc%2Fpipeline%2Fproducer.rs%3A256-258%0A**Quoted%20literal%20masks%20real%20producer**%0A%0AWhen%20an%20assignment-only%20command%20contains%20a%20single-quoted%20literal%20%60%24%28%60%20before%20a%20real%20substitution%2C%20such%20as%20%60A%3D'foo%24%28bar%29'%20B%3D%24%28ls%29%60%2C%20%60substitution_body%60%20treats%20the%20literal%20text%20as%20executable%20and%20%60ran%60%20selects%20that%20assignment%2C%20causing%20the%20command%20to%20be%20labeled%20and%20routed%20as%20%60bar%60%20instead%20of%20%60ls%60.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=681&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fajarhide%2Fomni%22%20on%20the%20existing%20branch%20%22fix%2F677-first-running-assignment%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F677-first-running-assignment%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fpipeline%2Fproducer.rs%3A256-258%0A**Quoted%20literal%20masks%20real%20producer**%0A%0AWhen%20an%20assignment-only%20command%20contains%20a%20single-quoted%20literal%20%60%24%28%60%20before%20a%20real%20substitution%2C%20such%20as%20%60A%3D'foo%24%28bar%29'%20B%3D%24%28ls%29%60%2C%20%60substitution_body%60%20treats%20the%20literal%20text%20as%20executable%20and%20%60ran%60%20selects%20that%20assignment%2C%20causing%20the%20command%20to%20be%20labeled%20and%20routed%20as%20%60bar%60%20instead%20of%20%60ls%60.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/pipeline/producer.rs:256-258
**Quoted literal masks real producer**

When an assignment-only command contains a single-quoted literal `$(` before a real substitution, such as `A='foo$(bar)' B=$(ls)`, `substitution_body` treats the literal text as executable and `ran` selects that assignment, causing the command to be labeled and routed as `bar` instead of `ls`.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(producer): the first assignment that..."](https://github.com/fajarhide/omni/commit/f485c458167bc81a07651616d0a6b57fe45915ec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56020800)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->