### PR TITLE
perf(mcp): advertise the two tools that pay for the prefix, not the eight called once

### DIFF
--- a/changelog.d/609c.changed.md
+++ b/changelog.d/609c.changed.md
@@ -1,0 +1,30 @@
+**A Full-tier host is now told about two tools instead of eight, and the surface it
+carries in every request drops from 2,098 B to 467 B.** The rule that picked the set
+was "called at least once in the corpus", and one call is not a price. Measured over
+256 recorded sessions with `mcp_surface.py`:
+
+| tool | bytes | calls | sessions |
+| --- | ---: | ---: | ---: |
+| `omni_retrieve` | 207 | 109 | 24 |
+| `omni_explain_savings` | 260 | 29 | 27 |
+| the other six | 1,631 | 11 | 7 |
+
+The six cost 77.7% of the surface for 7.4% of the calls, in the prefix of every
+request of every session, while 214 of the 256 sessions called nothing at all.
+
+The cut is only on the tier whose shell OMNI already hooks, which is why it is
+affordable there: `omni exec`, `omni remember`, `omni stats` and `omni session`
+answer what `omni_run`, `omni_remember`, `omni_history` and `omni_context_breakdown`
+answer, and `OMNI_MCP_TOOLS=all` puts the tools themselves back. `omni_recall` and
+`omni_find_noise` have no CLI equivalent and are behind the override alone. On a
+Handoff-first host nothing changes: MCP is the only door OMNI has there, so all eight
+stay advertised.
+
+An unregistered host now takes the Handoff-first list rather than the Full one. The
+guarantee that being wrong about a host costs a flag and not a capability did not
+change; the list holding it did, because `FULL` is now priced for a host with a
+hooked shell and an unrecognised id is exactly the case where nobody knows.
+
+This is what #609 was filed to decide. What it does not do is take the surface to
+zero for the 84% of sessions that never call a tool; that needs an opt-in default,
+which would cost the other 16% their tools with no signal.

--- a/changelog.d/609c.changed.md
+++ b/changelog.d/609c.changed.md
@@ -13,9 +13,11 @@ The six cost 77.7% of the surface for 7.4% of the calls, in the prefix of every
 request of every session, while 214 of the 256 sessions called nothing at all.
 
 The cut is only on the tier whose shell OMNI already hooks, which is why it is
-affordable there: `omni exec`, `omni remember`, `omni stats` and `omni session`
-answer what `omni_run`, `omni_remember`, `omni_history` and `omni_context_breakdown`
-answer, and `OMNI_MCP_TOOLS=all` puts the tools themselves back. `omni_recall` and
+affordable there: `omni exec` runs what `omni_run` ran, `omni remember` writes what
+`omni_remember` wrote, `omni stats --view context` prints what
+`omni_context_breakdown` printed, and `omni stats --view detail` carries
+`omni_history`'s rows with repeats folded into a count. `OMNI_MCP_TOOLS=all` puts the
+tools themselves back. `omni_recall` and
 `omni_find_noise` have no CLI equivalent and are behind the override alone. On a
 Handoff-first host nothing changes: MCP is the only door OMNI has there, so all eight
 stay advertised.

--- a/docs/website/src-id/reference/mcp-tools.md
+++ b/docs/website/src-id/reference/mcp-tools.md
@@ -23,10 +23,18 @@ korpus. Host Handoff-first tidak pernah mendapat penulisan ulang pada output per
 bawaannya, jadi MCP adalah satu-satunya pintu OMNI di sana dan tidak ada yang dipangkas.
 
 Perkakas yang tidak diiklankan juga tidak bisa dipanggil di tier itu, jadi jalan kembalinya
-adalah CLI atau override. `omni exec`, `omni remember`, `omni stats` dan `omni session`
-menjawab hal yang sama seperti `omni_run`, `omni_remember`, `omni_history` dan
-`omni_context_breakdown`. `OMNI_MCP_TOOLS=all` mengiklankan seluruh 25 perkakas, dan
-`omni doctor` menyebutkan set mana yang sedang berlaku serta host mana yang terdeteksi:
+adalah CLI atau override:
+
+| perkakas | di host tier Full |
+|---|---|
+| `omni_run` | `omni exec <perintah>` |
+| `omni_remember` | `omni remember '<fakta>'` |
+| `omni_context_breakdown` | `omni stats --view context` |
+| `omni_history` | `omni stats --view detail`, yang menggabung perintah berulang jadi satu baris berhitung, bukan satu baris per panggilan |
+| `omni_recall`, `omni_find_noise` | tidak ada padanan CLI; `OMNI_MCP_TOOLS=all` |
+
+`OMNI_MCP_TOOLS=all` mengiklankan seluruh 25 perkakas, dan `omni doctor` menyebutkan set
+mana yang sedang berlaku serta host mana yang terdeteksi:
 
 ```
   MCP tools:      2 of 25 advertised to claude_code (OMNI_MCP_TOOLS=all restores the rest)

--- a/docs/website/src-id/reference/mcp-tools.md
+++ b/docs/website/src-id/reference/mcp-tools.md
@@ -12,20 +12,24 @@ itu OMNI hanya mengiklankan set yang bisa dipakai oleh tier host Anda:
 
 | tier | yang diiklankan |
 |---|---|
-| Full, dan host apa pun yang tidak dikenali OMNI | sembilan di bawah ini |
-| Handoff-first | sembilan yang sama, `omni_run` selalu termasuk |
+| Full | `omni_retrieve`, `omni_explain_savings` |
+| Handoff-first, dan host apa pun yang tidak dikenali OMNI | dua itu, ditambah `omni_remember`, `omni_recall`, `omni_run`, `omni_find_noise`, `omni_context_breakdown`, `omni_history` |
 | MCP-only | `omni_remember`, `omni_recall`, `omni_retrieve`, `omni_knowledge` |
 
-Yang sembilan itu adalah `omni_retrieve`, `omni_explain_savings`, `omni_remember`,
-`omni_recall`, `omni_run`, `omni_find_noise`, `omni_context_breakdown`, `omni_history`
-dan `omni_history`. Itulah yang benar-benar pernah dipanggil di korpus yang terekam.
+Host tier Full mendapat daftar terpendek justru karena shell-nya sudah dipasangi hook oleh
+OMNI. Diukur pada 256 sesi yang terekam, dua perkakas itu membawa 138 dari 149 panggilan
+dengan 467 byte, sedangkan enam sisanya memakan 1.631 byte untuk 11 panggilan sepanjang
+korpus. Host Handoff-first tidak pernah mendapat penulisan ulang pada output perkakas
+bawaannya, jadi MCP adalah satu-satunya pintu OMNI di sana dan tidak ada yang dipangkas.
 
-Perkakas lain di halaman ini tetap ada di dalam binary dan hanya berjarak satu setelan.
-`OMNI_MCP_TOOLS=all` mengiklankan seluruh 25 perkakas, dan `omni doctor` menyebutkan set
-mana yang sedang berlaku serta host mana yang terdeteksi:
+Perkakas yang tidak diiklankan juga tidak bisa dipanggil di tier itu, jadi jalan kembalinya
+adalah CLI atau override. `omni exec`, `omni remember`, `omni stats` dan `omni session`
+menjawab hal yang sama seperti `omni_run`, `omni_remember`, `omni_history` dan
+`omni_context_breakdown`. `OMNI_MCP_TOOLS=all` mengiklankan seluruh 25 perkakas, dan
+`omni doctor` menyebutkan set mana yang sedang berlaku serta host mana yang terdeteksi:
 
 ```
-  MCP tools:      9 of 25 advertised to claude_code (OMNI_MCP_TOOLS=all restores the rest)
+  MCP tools:      2 of 25 advertised to claude_code (OMNI_MCP_TOOLS=all restores the rest)
 ```
 
 Pastikan daftarnya terhadap binary Anda sendiri, bukan terhadap halaman ini:

--- a/docs/website/src-id/use/memory.md
+++ b/docs/website/src-id/use/memory.md
@@ -44,7 +44,10 @@ omni remember 'The staging database ignores migrations run outside the deploy jo
 
 Agent yang MCP-nya terpasang memanggil `omni_remember` sendiri, dan menarik fakta
 kembali dengan `omni_recall`, sebuah pencarian semantik lintas engram,
-pengetahuan tersimpan dan riwayat penyulingan.
+pengetahuan tersimpan dan riwayat penyulingan. Keduanya diiklankan di tier MCP-only
+dan Handoff-first. Host tier Full seperti Claude Code menulis lewat `omni remember` di
+shell yang sudah dipasangi hook OMNI, dan mencapai `omni_recall`, yang tidak punya
+padanan CLI, dengan `OMNI_MCP_TOOLS=all`.
 
 Simpan yang tidak bisa diturunkan dari kodenya: sebuah keputusan dan alasannya,
 sebuah jebakan, sebuah batasan yang tidak disebut berkas mana pun. Jangan simpan

--- a/docs/website/src-id/use/seeing-savings.md
+++ b/docs/website/src-id/use/seeing-savings.md
@@ -132,8 +132,10 @@ omni patterns                    # galat yang terus kembali
 omni patterns --tool cargo
 ```
 
-`omni_history` memberi baris per panggilan yang sama ke klien MCP. Tidak ada
-subperintah `omni history`; halaman ini sempat mencantumkannya sampai 0.7.4.
+`omni_history` memberi baris per panggilan yang sama ke klien MCP, di tier yang
+mengiklankannya. Di host tier Full biayanya di awal request lebih besar daripada
+hasilnya, jadi jalurnya di sana adalah `omni stats`. Tidak ada subperintah
+`omni history`; halaman ini sempat mencantumkannya sampai 0.7.4.
 
 `omni query` berbicara dalam bahasa kueri kecil yang tetap, bukan teks bebas.
 Bentuk yang didukung ada di bantuannya sendiri.

--- a/docs/website/src-id/use/seeing-savings.md
+++ b/docs/website/src-id/use/seeing-savings.md
@@ -134,8 +134,9 @@ omni patterns --tool cargo
 
 `omni_history` memberi baris per panggilan yang sama ke klien MCP, di tier yang
 mengiklankannya. Di host tier Full biayanya di awal request lebih besar daripada
-hasilnya, jadi jalurnya di sana adalah `omni stats`. Tidak ada subperintah
-`omni history`; halaman ini sempat mencantumkannya sampai 0.7.4.
+hasilnya, jadi jalurnya di sana adalah `omni stats --view detail`, yang menggabung
+perintah berulang jadi satu baris berhitung. Tidak ada subperintah `omni history`;
+halaman ini sempat mencantumkannya sampai 0.7.4.
 
 `omni query` berbicara dalam bahasa kueri kecil yang tetap, bukan teks bebas.
 Bentuk yang didukung ada di bantuannya sendiri.

--- a/docs/website/src/reference/mcp-tools.md
+++ b/docs/website/src/reference/mcp-tools.md
@@ -23,8 +23,16 @@ corpus. A Handoff-first host never has its built-in tool output rewritten, so MC
 only door OMNI has there and nothing is priced away.
 
 An unadvertised tool is not callable on that tier either, so the way back is the CLI or
-the override. `omni exec`, `omni remember`, `omni stats` and `omni session` answer what
-`omni_run`, `omni_remember`, `omni_history` and `omni_context_breakdown` answer.
+the override:
+
+| tool | on a Full-tier host |
+|---|---|
+| `omni_run` | `omni exec <command>` |
+| `omni_remember` | `omni remember '<fact>'` |
+| `omni_context_breakdown` | `omni stats --view context` |
+| `omni_history` | `omni stats --view detail`, which folds repeated commands into one row with a count instead of listing every call |
+| `omni_recall`, `omni_find_noise` | no CLI equivalent; `OMNI_MCP_TOOLS=all` |
+
 `OMNI_MCP_TOOLS=all` advertises all 25, and `omni doctor` says which set is in force and
 which host it resolved:
 

--- a/docs/website/src/reference/mcp-tools.md
+++ b/docs/website/src/reference/mcp-tools.md
@@ -12,20 +12,24 @@ host's tier can use:
 
 | tier | advertised |
 |---|---|
-| Full, and any host OMNI does not recognise | the nine below |
-| Handoff-first | the same nine, with `omni_run` always among them |
+| Full | `omni_retrieve`, `omni_explain_savings` |
+| Handoff-first, and any host OMNI does not recognise | those two, plus `omni_remember`, `omni_recall`, `omni_run`, `omni_find_noise`, `omni_context_breakdown`, `omni_history` |
 | MCP-only | `omni_remember`, `omni_recall`, `omni_retrieve`, `omni_knowledge` |
 
-The nine are `omni_retrieve`, `omni_explain_savings`, `omni_remember`, `omni_recall`,
-`omni_run`, `omni_find_noise`, `omni_context_breakdown`, `omni_history` and
-`omni_history`. They are the ones that were actually called across the recorded corpus.
+Full-tier hosts get the shortest list because they are the ones whose shell OMNI already
+hooks. Measured across 256 recorded sessions, those two tools carry 138 of the 149 calls
+in 467 bytes, while the other six cost 1,631 bytes for 11 calls in the life of the
+corpus. A Handoff-first host never has its built-in tool output rewritten, so MCP is the
+only door OMNI has there and nothing is priced away.
 
-Every other tool on this page is still in the binary and one setting away.
+An unadvertised tool is not callable on that tier either, so the way back is the CLI or
+the override. `omni exec`, `omni remember`, `omni stats` and `omni session` answer what
+`omni_run`, `omni_remember`, `omni_history` and `omni_context_breakdown` answer.
 `OMNI_MCP_TOOLS=all` advertises all 25, and `omni doctor` says which set is in force and
 which host it resolved:
 
 ```
-  MCP tools:      9 of 25 advertised to claude_code (OMNI_MCP_TOOLS=all restores the rest)
+  MCP tools:      2 of 25 advertised to claude_code (OMNI_MCP_TOOLS=all restores the rest)
 ```
 
 Confirm the list against your own binary rather than this page:

--- a/docs/website/src/use/memory.md
+++ b/docs/website/src/use/memory.md
@@ -42,7 +42,10 @@ omni remember 'The staging database ignores migrations run outside the deploy jo
 
 Agents with MCP wired call `omni_remember` themselves, and pull facts back with
 `omni_recall`, which is a semantic search across engrams, stored knowledge and
-distillation history.
+distillation history. Both are advertised on the MCP-only and Handoff-first tiers.
+A Full-tier host such as Claude Code writes through `omni remember` in the shell OMNI
+already hooks, and reaches `omni_recall`, which has no CLI equivalent, with
+`OMNI_MCP_TOOLS=all`.
 
 Store what is not derivable from the code: a decision and its reason, a gotcha, a
 constraint that no file states. Do not store what the repository already records.

--- a/docs/website/src/use/seeing-savings.md
+++ b/docs/website/src/use/seeing-savings.md
@@ -127,8 +127,9 @@ omni patterns --tool cargo
 ```
 
 `omni_history` gives the same per-call rows to an MCP client, on the tiers that advertise
-it. On a Full-tier host it costs more in the prefix than it earns, so `omni stats` is the
-route there. There is no `omni history` subcommand; this page listed one until 0.7.4.
+it. On a Full-tier host it costs more in the prefix than it earns, so the route there is
+`omni stats --view detail`, which folds repeated commands into one row with a count. There
+is no `omni history` subcommand; this page listed one until 0.7.4.
 
 `omni query` speaks a small fixed query language rather than free text. The supported
 forms are listed in its own help.

--- a/docs/website/src/use/seeing-savings.md
+++ b/docs/website/src/use/seeing-savings.md
@@ -126,8 +126,9 @@ omni patterns                    # errors that keep coming back
 omni patterns --tool cargo
 ```
 
-`omni_history` gives the same per-call rows to an MCP client. There is no `omni history`
-subcommand; this page listed one until 0.7.4.
+`omni_history` gives the same per-call rows to an MCP client, on the tiers that advertise
+it. On a Full-tier host it costs more in the prefix than it earns, so `omni stats` is the
+route there. There is no `omni history` subcommand; this page listed one until 0.7.4.
 
 `omni query` speaks a small fixed query language rather than free text. The supported
 forms are listed in its own help.

--- a/src/cli/context.rs
+++ b/src/cli/context.rs
@@ -9,7 +9,9 @@
 //!
 //! Moving it here rather than deleting it keeps the capability and stops charging
 //! for it. A CLI subcommand costs nothing per request, and an agent that wants it
-//! still has `omni_run("omni context <file>")`.
+//! runs it in the shell OMNI already hooks. `omni_run` was the door named here
+//! until it was priced off the Full tier too (#609); it still is on a
+//! Handoff-first host, which is the tier that has no shell of its own.
 
 use crate::graph;
 use crate::pipeline::SessionState;

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -696,7 +696,7 @@ mod tests {
         let line = super::mcp_tool_line("claude_code", false);
         assert_eq!(
             line,
-            "  MCP tools:      8 of 25 advertised to claude_code \
+            "  MCP tools:      2 of 25 advertised to claude_code \
              (OMNI_MCP_TOOLS=all restores the rest)"
         );
     }

--- a/src/mcp/policy.rs
+++ b/src/mcp/policy.rs
@@ -41,12 +41,13 @@ use crate::agents::Tier;
 /// What a cut costs is a door, and only on this tier. `router_from` removes an
 /// unadvertised route rather than hiding it, so the tools are gone here until
 /// `OMNI_MCP_TOOLS=all`; what stands in for them is the shell this tier already
-/// hooks, where `omni exec`, `omni remember`, `omni stats` and `omni session`
-/// answer what `omni_run`, `omni_remember`, `omni_history` and
-/// `omni_context_breakdown` answer. `omni_recall` and `omni_find_noise` have no
-/// CLI equivalent and sit behind the override alone; they are 4 calls in the
-/// whole corpus, and `find_noise` writes TOML filters for a layer #449 retired
-/// (#609).
+/// hooks. `omni exec` runs what `omni_run` ran, `omni remember` writes what
+/// `omni_remember` wrote, `omni stats --view context` prints what
+/// `omni_context_breakdown` printed, and `omni stats --view detail` carries
+/// `omni_history`'s rows with repeats folded into one line and a count rather
+/// than listed per call. `omni_recall` and `omni_find_noise` have no CLI
+/// equivalent and sit behind the override alone; they are 4 calls in the whole
+/// corpus, and `find_noise` writes TOML filters for a layer #449 retired (#609).
 pub const FULL: &[&str] = &["omni_retrieve", "omni_explain_savings"];
 // `omni_context` left before the rule was tightened: it was the only advertised
 // tool with zero calls ever across 253 sessions, and the three places OMNI

--- a/src/mcp/policy.rs
+++ b/src/mcp/policy.rs
@@ -1,21 +1,63 @@
 //! Which of OMNI's MCP tools a host is told about.
 //!
-//! Measured 2026-08-15 across 228 Claude Code transcripts: 25 tools are
-//! advertised in the prefix of every request, 16 of them have never been
-//! called, and those 16 are 4,940 bytes. That is the same size as the 4,942
-//! bytes OMNI removes from tool output in the median of the 35 sessions that
-//! pushed more than 50 KB through the hook, and it sits at
-//! position 0 where it is re-read on every request rather than from the middle
-//! of the session. Advertising them costs about twice what the distillers earn.
+//! An advertised tool sits at position 0 of every request, so it is re-read once
+//! per request for the whole session, while a distilled tool result is re-read a
+//! median of 64 times and then stops. That is why this list is priced rather than
+//! curated: measured 2026-08-15, the 25 tools OMNI used to advertise cost 4,940
+//! bytes for the 16 nobody ever called, about twice what the distillers earned in
+//! the median session that pushed more than 50 KB through the hook.
+//!
+//! `FULL` carries the current measurement. It is re-run with
+//! `docs/internal/transcript-probes/mcp_surface.py`, and a tool added without
+//! re-running it has no price behind it.
 //!
 //! The set is chosen by `Tier`, which already exists and is what `doctor`
 //! prints, so this module adds no second opinion about what a host can do.
 
 use crate::agents::Tier;
 
-/// Called at least once in the corpus, so a host that can use them is told
-/// about them. Ordered as the probe reports them, most-called first.
-pub const FULL: &[&str] = &[
+/// The tools that pay for their place in the prefix of a Full-tier host.
+///
+/// The old rule was "called at least once in the corpus", and one call is not a
+/// price. Re-measured 2026-08-23 over 256 transcripts with
+/// `transcript-probes/mcp_surface.py`, the calls are not spread across the set:
+///
+/// ```text
+/// omni_retrieve          207 B   109 calls   24 sessions
+/// omni_explain_savings   260 B    29 calls   27 sessions
+/// omni_run               417 B     3 calls    2 sessions
+/// omni_find_noise        253 B     2 calls    1 session
+/// omni_recall            236 B     2 calls    2 sessions
+/// omni_context_breakdown 157 B     2 calls    2 sessions
+/// omni_remember          332 B     1 call     1 session
+/// omni_history           236 B     1 call     1 session
+/// ```
+///
+/// The two kept here carry 138 of the 149 calls in 467 B. The six below cost
+/// 1,631 B, 77.7% of the surface, for 11 calls in the life of the corpus, and
+/// 214 of the 256 sessions called nothing at all. Every request of every session
+/// pays for that, and only 7 sessions ever called one of the six.
+///
+/// What a cut costs is a door, and only on this tier. `router_from` removes an
+/// unadvertised route rather than hiding it, so the tools are gone here until
+/// `OMNI_MCP_TOOLS=all`; what stands in for them is the shell this tier already
+/// hooks, where `omni exec`, `omni remember`, `omni stats` and `omni session`
+/// answer what `omni_run`, `omni_remember`, `omni_history` and
+/// `omni_context_breakdown` answer. `omni_recall` and `omni_find_noise` have no
+/// CLI equivalent and sit behind the override alone; they are 4 calls in the
+/// whole corpus, and `find_noise` writes TOML filters for a layer #449 retired
+/// (#609).
+pub const FULL: &[&str] = &["omni_retrieve", "omni_explain_savings"];
+// `omni_context` left before the rule was tightened: it was the only advertised
+// tool with zero calls ever across 253 sessions, and the three places OMNI
+// recommended it appear zero times in 10,578 traces. The capability moved to
+// `omni context <file>` (#609).
+
+/// A Handoff-first host does not rewrite built-in tool output, so MCP is the
+/// only door OMNI has there and `FULL`'s pricing does not transfer: an
+/// unadvertised tool is not one shell command away, it is unreachable. This is
+/// the widest advertised set, and an unregistered host gets it for that reason.
+pub const HANDOFF: &[&str] = &[
     "omni_retrieve",
     "omni_explain_savings",
     "omni_remember",
@@ -25,17 +67,6 @@ pub const FULL: &[&str] = &[
     "omni_context_breakdown",
     "omni_history",
 ];
-// `omni_context` was here and failed the rule above. Across 253 recorded sessions
-// it is the only advertised tool with zero calls ever, and the three places OMNI
-// recommended it appear zero times in 10,578 traces. It cost 189 B in the prefix
-// of every request on this tier. The capability moved to `omni context <file>`,
-// which costs nothing per request and is still reachable from an agent through
-// `omni_run` (#609).
-
-/// Same list today, kept separate so a future edit to `FULL` cannot silently
-/// drop `omni_run` from the one tier that has nothing else. The test is what
-/// makes that guarantee real.
-pub const HANDOFF: &[&str] = FULL;
 
 /// No shell distillation exists on this tier, so the tools that report on it
 /// would describe something that never happens.
@@ -64,19 +95,23 @@ fn integration_id(detected: &str) -> &str {
 /// The tier the host's own integration declares. `Tier` stays the single source
 /// of truth; this only translates the name.
 ///
-/// An id with no registered integration gets `Full`, because being wrong about a
-/// host has to cost a flag rather than a capability. `detect_agent_id` can return
-/// `windsurf`, `vscode_continue`, `aider` and `terminal`, none of which is
-/// registered anywhere; the opposite default also dropped
-/// Codex to four tools whenever `CODEX_SESSION` failed to reach the subprocess,
-/// since its generated config carries no `OMNI_AGENT_ID`. A host that wants the
-/// memory set declares it by registering an integration.
+/// An id with no registered integration gets the tier carrying the widest list,
+/// because being wrong about a host has to cost a flag rather than a capability.
+/// `detect_agent_id` can return `windsurf`, `vscode_continue`, `aider` and
+/// `terminal`, none of which is registered anywhere; the `McpOnly` default
+/// dropped Codex to four tools whenever `CODEX_SESSION` failed to reach the
+/// subprocess, since its generated config carries no `OMNI_AGENT_ID`. A host that
+/// wants the memory set declares it by registering an integration.
+///
+/// That default was `Full` until `FULL` was priced down to two tools (#609).
+/// The guarantee did not change, the list holding it did: `HandoffFirst` is now
+/// the one that assumes nothing about whether the host's shell is hooked.
 pub fn tier_for(agent_id: &str) -> Tier {
     let want = integration_id(agent_id);
     crate::agents::all_integrations()
         .iter()
         .find(|a| a.id() == want)
-        .map_or(Tier::Full, |a| a.tier())
+        .map_or(Tier::HandoffFirst, |a| a.tier())
 }
 
 /// Does `OMNI_MCP_TOOLS` ask for the whole surface?
@@ -124,18 +159,34 @@ mod tests {
         assert_eq!(tier_for("gemini"), Tier::Full);
     }
 
-    /// Being wrong about a host must cost a flag, not a capability. `omni_run`
-    /// works on any host and `omni_explain_savings` merely has nothing to report
-    /// where there is no hook, so an unrecognised id keeps the nine rather than
-    /// losing five of them.
+    /// Being wrong about a host must cost a flag, not a capability. Since #609
+    /// that means the *widest* list rather than `Full`'s: `FULL` is priced for a
+    /// host whose shell OMNI hooks, and an unregistered id is exactly the case
+    /// where nobody knows whether it has one.
     #[test]
-    fn an_unregistered_host_keeps_the_full_set() {
-        assert_eq!(tier_for("something-new"), Tier::Full);
+    fn an_unregistered_host_keeps_the_widest_set() {
+        assert_eq!(tier_for("something-new"), Tier::HandoffFirst);
+        assert_eq!(active_tools("something-new"), HANDOFF);
         // `vscode`, `zed` and `antigravity` are left out on purpose: they are
         // registered in `mcp_host::HOSTS` and so are genuinely MCP-only.
         for id in ["windsurf", "vscode_continue", "aider", "terminal"] {
-            assert_eq!(active_tools(id), FULL, "{id} lost the full set");
+            assert_eq!(active_tools(id), HANDOFF, "{id} lost the widest set");
         }
+    }
+
+    /// `FULL` is a cut of `HANDOFF`, not a different list. Pricing one tier down
+    /// must never introduce a tool the tier that depends on MCP does not get,
+    /// and the two lists are now written out separately, so nothing but this
+    /// keeps them related.
+    #[test]
+    fn the_priced_set_is_a_subset_of_the_widest_one() {
+        for tool in FULL {
+            assert!(HANDOFF.contains(tool), "{tool} is in FULL but not HANDOFF");
+        }
+        assert!(
+            FULL.len() < HANDOFF.len(),
+            "FULL is meant to be the cut one"
+        );
     }
 
     /// `strategy.md` section 5 makes this product law: on a Handoff-first host
@@ -145,6 +196,9 @@ mod tests {
     #[test]
     fn a_handoff_first_host_keeps_omni_run() {
         assert!(active_tools("cursor").contains(&"omni_run"));
+        // And the Full tier is where it stops being worth its 417 bytes, because
+        // there the built-in shell is hooked and `omni exec` is one command away.
+        assert!(!active_tools("claude_code").contains(&"omni_run"));
     }
 
     /// An MCP-only host has no shell distillation to report on, so the read
@@ -159,27 +213,15 @@ mod tests {
         assert!(!tools.contains(&"omni_explain_savings"));
     }
 
-    /// Measured 2026-08-15: nine tools were called across 228 sessions and the
-    /// other sixteen never were. Re-measured 2026-08-23 over 253 sessions, and
-    /// `omni_context` had still never been called once, so it left too (#609).
-    /// If this list grows without the probe being re-run, the design's own
+    /// Measured 2026-08-23 over 256 sessions: these two carry 138 of the 149
+    /// calls in 467 B, and the six that left cost 1,631 B for 11 calls. If this
+    /// list grows without `mcp_surface.py` being re-run, the design's own
     /// justification has stopped being true.
     #[test]
-    fn the_full_set_is_the_ones_that_were_actually_called() {
+    fn the_full_set_is_the_ones_that_pay_for_the_prefix() {
         let mut got = active_tools("claude_code").to_vec();
         got.sort_unstable();
-        let mut want = vec![
-            "omni_context_breakdown",
-            "omni_explain_savings",
-            "omni_find_noise",
-            "omni_history",
-            "omni_recall",
-            "omni_remember",
-            "omni_retrieve",
-            "omni_run",
-        ];
-        want.sort_unstable();
-        assert_eq!(got, want);
+        assert_eq!(got, vec!["omni_explain_savings", "omni_retrieve"]);
     }
 
     /// The escape hatch, driven through the predicate instead of the process

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1853,6 +1853,11 @@ mod tests {
     /// only advertised tool never called once in 253 sessions, and it cost 189 B
     /// of every request. Kept just above the 2,098 that measures today, for the
     /// same reason: a gate with room in it does not notice a regression.
+    ///
+    /// Ratcheted to 500 when the admission rule stopped being "called at least
+    /// once" and started being priced (#609). On this tier the list is
+    /// `omni_retrieve` and `omni_explain_savings`, which carried 138 of the 149
+    /// calls in the 256-session corpus; the six that left cost 1,631 B for 11.
     #[test]
     fn the_advertised_surface_is_smaller_than_it_was() {
         let router = OmniServer::router_from("claude_code", false);
@@ -1864,13 +1869,13 @@ mod tests {
 
         assert_eq!(
             listed.len(),
-            8,
-            "advertised {} tools, expected eight",
+            2,
+            "advertised {} tools, expected two",
             listed.len()
         );
         assert!(
-            bytes <= 2_200,
-            "advertised surface is {bytes} B, gate is 2200 (it measured 2,098 on #609)"
+            bytes <= 500,
+            "advertised surface is {bytes} B, gate is 500 (it measured 467 on #609)"
         );
     }
 

--- a/tests/smoke_test.sh
+++ b/tests/smoke_test.sh
@@ -100,7 +100,7 @@ check "doctor shows binary" "$DOCTOR_OUT" "Binary"
 # combination has reddened CI here before. A subprocess has its own environment, so the
 # escape hatch is verified across the boundary that can actually be wrong.
 LEAN_OUT=$(OMNI_AGENT_ID=claude_code "$OMNI" doctor 2>&1 || true)
-check "doctor reports the lean MCP surface" "$LEAN_OUT" "8 of 25"
+check "doctor reports the lean MCP surface" "$LEAN_OUT" "2 of 25"
 ALL_OUT=$(OMNI_AGENT_ID=claude_code OMNI_MCP_TOOLS=all "$OMNI" doctor 2>&1 || true)
 check "OMNI_MCP_TOOLS=all restores every tool" "$ALL_OUT" "25 of 25"
 


### PR DESCRIPTION
`mcp::policy::FULL` admitted a tool on one rule, "called at least once in the corpus".
An advertised tool sits at position 0 of every request and is re-read once per request
for the whole session, so one call is not a price. Re-measured over 256 recorded
sessions with `mcp_surface.py`:

| tool | bytes | calls | sessions |
| --- | ---: | ---: | ---: |
| `omni_retrieve` | 207 | 109 | 24 |
| `omni_explain_savings` | 260 | 29 | 27 |
| the other six | 1,631 | 11 | 7 |

The Full tier now advertises the first two. That is affordable only there, because it
is the tier whose shell OMNI already hooks: `omni exec` runs what `omni_run` ran,
`omni remember` writes what `omni_remember` wrote, `omni stats --view context` prints
what `omni_context_breakdown` printed, and `omni stats --view detail` carries
`omni_history`'s rows with repeats folded into a count. `OMNI_MCP_TOOLS=all` restores
the tools. A
Handoff-first host keeps all eight, since MCP is the only door OMNI has there. An
unregistered host now resolves to Handoff-first, so "being wrong about a host costs a
flag, not a capability" still holds after `FULL` stopped being the widest list.

Measured through the real server over stdio, not modelled:

```
$ python3 docs/internal/transcript-probes/mcp_surface.py ./target/ci/omni
TOTAL   2,098 B    (before)
TOTAL     467 B    (after)
```

Gates: `cargo fmt`, `clippy 0.1.97 -D warnings`, full `cargo test`, `make security`,
and `tests/smoke_test.sh` at 51/51 including the two `doctor` checks that read the
count out of the binary.

Three mutations to show the tests have teeth: adding `omni_run` back to `FULL` reddens
four tests (the policy set, the Full-tier negative, the 500 B surface gate, the doctor
line), dropping `omni_retrieve` from `HANDOFF` reddens the new subset test, and
restoring the old `Tier::Full` fallback reddens the unregistered-host test.

What this does not do is take the surface to zero for the 84% of sessions that never
call a tool. That needs an opt-in default, which costs the other 16% their tools with
no signal, and it is a separate decision.

Closes #609


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR reduces the MCP surface advertised to Full-tier hosts while retaining the wider tool set for Handoff-first and unregistered hosts.
- Limits the Full tier to `omni_retrieve` and `omni_explain_savings`.
- Preserves all eight measured tools for Handoff-first hosts and makes that tier the fallback for unknown hosts.
- Updates diagnostics, tests, changelog entries, and English and Indonesian documentation.
- Corrects the previously reported replacement guidance by directing context diagnostics to `omni stats --view context` and explicitly documenting that the history replacement aggregates repeated commands.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/mcp/policy.rs | Splits the Full and Handoff-first tool sets, changes the unknown-host fallback, and adds coverage for tier invariants. |
| src/mcp/server.rs | Ratchets the Full-tier advertised-surface test to the new two-tool, 500-byte limit. |
| docs/website/src/reference/mcp-tools.md | Documents the reduced Full-tier surface and accurately qualifies the CLI replacements relevant to the prior review thread. |
| docs/website/src-id/reference/mcp-tools.md | Mirrors the corrected MCP tier and replacement guidance in Indonesian. |
| tests/smoke_test.sh | Updates the doctor smoke assertion for the two-tool Full-tier surface while retaining override coverage. |

</details>

<sub>Reviews (2): Last reviewed commit: ["docs(mcp): name the flag that prints the..."](https://github.com/fajarhide/omni/commit/b4ccee31cff1c942b65e66723a0b40308afbddc0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56028070)</sub>

<!-- /greptile_comment -->