### PR TITLE
fix(pi): read the key OMNI writes, and check that every plugin does

### DIFF
--- a/changelog.d/688.fixed.md
+++ b/changelog.d/688.fixed.md
@@ -1,0 +1,22 @@
+**The Pi plugin threw away every distillation it asked for.** It spawned
+`omni --post-hook`, waited for the answer, and then read
+`hookSpecificOutput.updatedResponse`, a key OMNI stopped emitting in 0.6.5 (#158).
+`updated` was always `undefined`, so the handler always returned `undefined` and Pi
+received raw output on every single tool result while the hook ran and did the work.
+
+Probed rather than reasoned about. A Pi-shaped payload of 29,099 bytes comes back as
+
+```
+updatedToolOutput: { result: <7,365 chars>, status: "success" }
+```
+
+so 74.7% was being removed and discarded, every time, for the whole life of the
+plugin. The `OmniHookOutput` type declared the wrong key too, which is why the
+TypeScript check on that plugin passed: the contract was wrong in the place that
+would otherwise have caught it.
+
+The Rust side has asserted the key it writes since #158. Nothing asserted that
+anyone reads it, and that is the boundary #158 was about. A test scans every plugin
+that spawns `--post-hook` and fails unless it names `updatedToolOutput` and does not
+name `updatedResponse`. Comments are stripped first: the doc comment on this fix
+names both keys, and without stripping, prose about the bug satisfied the guard.

--- a/plugins/pi/index.ts
+++ b/plugins/pi/index.ts
@@ -11,10 +11,23 @@ const EXCLUDE_TOOL_NAMES = new Set(["edit", "write"]);
 
 type JsonObject = Record<string, unknown>;
 
+/**
+ * `updatedToolOutput`, not `updatedResponse`. OMNI stopped emitting the second
+ * one in 0.6.5 (#158), and this file kept reading it, so `updated` was always
+ * undefined and Pi received raw output on every call while the hook ran, spawned
+ * the subprocess and did the work (#688). Probed rather than assumed: a Pi-shaped
+ * payload of 29,099 bytes comes back as
+ * `updatedToolOutput: { result: <7,365 chars>, status: "success" }`.
+ *
+ * `result` because that is the field Pi's own `toolResultPayload` sends the text
+ * in, and OMNI echoes the shape it was given. A host whose tool result names the
+ * field differently gets that name back instead, which is why this is typed as a
+ * record and read by key rather than as a string.
+ */
 type OmniHookOutput = {
   hookSpecificOutput?: {
     systemPromptAddition?: string;
-    updatedResponse?: string;
+    updatedToolOutput?: { result?: string; status?: string };
     additionalContext?: string;
   };
 };
@@ -322,7 +335,7 @@ pi.on("session_start", async (event, ctx) => {
         ctx,
       );
 
-      const updated = out?.hookSpecificOutput?.updatedResponse;
+      const updated = out?.hookSpecificOutput?.updatedToolOutput?.result;
       if (typeof updated === "string" && updated.length > 0) {
         return { content: [{ type: "text" as const, text: updated }] };
       }

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -1732,6 +1732,124 @@ mod tests {
         assert!(marker.contains("bytes omitted"), "got: {marker}");
     }
 
+    /// Line and block comments removed, so the scan sees code rather than prose
+    /// about code. `//` and `/* */` for TypeScript, `#` for Python. Python
+    /// docstrings are left standing, which is a known hole and a smaller one than
+    /// matching on raw text.
+    fn strip_comments(text: &str) -> String {
+        let mut out = String::with_capacity(text.len());
+        let mut in_block = false;
+        for line in text.lines() {
+            let mut rest = line;
+            loop {
+                if in_block {
+                    match rest.find("*/") {
+                        Some(i) => {
+                            in_block = false;
+                            rest = rest.get(i + 2..).unwrap_or("");
+                        }
+                        None => {
+                            rest = "";
+                            break;
+                        }
+                    }
+                } else {
+                    match rest.find("/*") {
+                        Some(i) => {
+                            out.push_str(rest.get(..i).unwrap_or(""));
+                            in_block = true;
+                            rest = rest.get(i + 2..).unwrap_or("");
+                        }
+                        None => break,
+                    }
+                }
+            }
+            let code = match (rest.find("//"), rest.find('#')) {
+                (Some(a), Some(b)) => rest.get(..a.min(b)).unwrap_or(""),
+                (Some(a), None) => rest.get(..a).unwrap_or(""),
+                (None, Some(b)) => rest.get(..b).unwrap_or(""),
+                (None, None) => rest,
+            };
+            out.push_str(code);
+            out.push('\n');
+        }
+        out
+    }
+
+    /// #688. The sibling of the test below, on the far side of the boundary.
+    ///
+    /// That one proves OMNI *writes* `updatedToolOutput`. It cannot prove anyone
+    /// *reads* it, and `plugins/pi/index.ts` read `updatedResponse` for the whole
+    /// life of the plugin: the hook ran, the subprocess was spawned, the work was
+    /// done, and the result was dropped on the floor because the key it looked for
+    /// no longer exists. That is #158 shipped a second time, in a file the Rust
+    /// tests do not compile.
+    ///
+    /// So this scans the plugin sources themselves. Any plugin that spawns
+    /// `--post-hook` is a consumer of that contract and has to name the key OMNI
+    /// actually emits. Cheap, and it covers a plugin written in any language,
+    /// which matters because the three that exist are TypeScript and Python.
+    #[test]
+    fn every_plugin_that_calls_the_hook_reads_the_key_it_writes() {
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("plugins");
+        let mut consumers = Vec::new();
+        let mut offenders = Vec::new();
+
+        let mut stack = vec![root.clone()];
+        while let Some(dir) = stack.pop() {
+            let Ok(entries) = std::fs::read_dir(&dir) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                // Vendored dependencies are not our plugins and contain enough
+                // text to match anything.
+                if path.file_name().is_some_and(|n| n == "node_modules") {
+                    continue;
+                }
+                if path.is_dir() {
+                    stack.push(path);
+                    continue;
+                }
+                let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+                if !matches!(ext, "ts" | "js" | "py") {
+                    continue;
+                }
+                let Ok(text) = std::fs::read_to_string(&path) else {
+                    continue;
+                };
+                if !text.contains("--post-hook") && !text.contains("\"post-hook\"") {
+                    continue;
+                }
+                let rel = path
+                    .strip_prefix(&root)
+                    .unwrap_or(&path)
+                    .display()
+                    .to_string();
+                consumers.push(rel.clone());
+                // Comments are stripped first. The doc comment on this very fix
+                // names both keys, so a scan over raw text is satisfied by prose
+                // about the bug: patching the Pi handler back to `updatedResponse`
+                // left the file still containing the right key and this guard
+                // still green. A guard a comment can satisfy is decorative.
+                let code = strip_comments(&text);
+                if !code.contains("updatedToolOutput") || code.contains("updatedResponse") {
+                    offenders.push(rel);
+                }
+            }
+        }
+
+        assert!(
+            !consumers.is_empty(),
+            "found no plugin calling `--post-hook`; the scan is looking in the wrong place"
+        );
+        assert!(
+            offenders.is_empty(),
+            "these plugins spawn `--post-hook` and never read `updatedToolOutput`, \
+             so whatever OMNI returns is discarded (#688): {offenders:?}"
+        );
+    }
+
     /// #158. The host replaces what the model sees only when it finds
     /// `updatedToolOutput`; any other key is dropped without a word, and the
     /// agent silently keeps the raw output while OMNI records the saving.


### PR DESCRIPTION
The Pi plugin spawned `omni --post-hook`, waited for the answer, and read
`hookSpecificOutput.updatedResponse`. OMNI stopped emitting that key in 0.6.5
(#158), so `updated` was always `undefined`, the handler always returned
`undefined`, and Pi received raw output on every tool result while the hook ran and
did the work.

Probed rather than reasoned about. A Pi-shaped payload of 29,099 bytes comes back as

```
updatedToolOutput: { result: <7,365 chars>, status: "success" }
updatedResponse present: False
```

74.7% removed and then discarded, every time, for the whole life of the plugin.

`result` is the field Pi's own `toolResultPayload` sends the text in, and OMNI
echoes back the shape it was handed. That is why this is typed as a record read by
key rather than as a string, and why the field was taken from a probe instead of
copied from another plugin: `openclaw` reads `.result`, the Claude Code tests read
`.stdout`, and #586 is the standing warning against guessing that shape.

The `OmniHookOutput` type declared the wrong key too, which is why the plugin's own
`typecheck (plugins/pi)` job passed. The contract was wrong in the one place that
would otherwise have caught it.

**The guard, which is the point of the PR.** The Rust side has asserted the key it
writes since #158:

```rust
fn serialises_the_key_the_host_actually_reads()
```

Nothing asserted that anyone *reads* it, and that is exactly the boundary #158 was
about. It was crossed a second time in a file the Rust tests do not compile. A test
now scans every plugin that spawns `--post-hook` and fails unless it names
`updatedToolOutput` and does not name `updatedResponse`.

Comments are stripped before that scan. Without stripping, the doc comment on this
fix names both keys, so patching the handler back to the dead key left the guard
green. That was the first version, and it is the failure the guard exists to catch,
one level up. Driven red on all three plugins, each naming the offending file.

Not in this PR: Pi stays `McpOnly` until this ships, because promoting it would make
the declaration true of the code and false of the behaviour, which is the #351
failure the tier default exists to prevent. #687 covers the promotion of all three.

`make ci` green.

Closes #688


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR fixes the Pi plugin’s consumption of transformed post-hook output and adds a repository-level regression guard for plugin consumers.
- Changes Pi’s response contract from the obsolete `updatedResponse` field to `updatedToolOutput.result`.
- Adds a Rust test that discovers post-hook consumers, strips comments, and checks their response-key usage.
- Documents the fixed output-discarding behavior in the changelog.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking limitation in how the new regression test discovers plugin consumers.

The runtime Pi fix matches OMNI’s emitted nested result shape; the remaining concern is that the test silently omits post-hook consumers implemented outside its hard-coded TypeScript, JavaScript, and Python extensions.

**Files Needing Attention:** src/hooks/post_tool.rs
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| plugins/pi/index.ts | Correctly updates Pi’s declared and runtime response shape to consume `updatedToolOutput.result`. |
| src/hooks/post_tool.rs | Adds a useful consumer-contract guard, but its hard-coded source extensions do not fully support its every-plugin coverage claim. |
| changelog.d/688.fixed.md | Accurately documents the fixed Pi response-key mismatch and the added regression guard. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Pi as Pi plugin
    participant Omni as omni --post-hook
    participant Hook as Post-tool hook
    Pi->>Omni: "toolResponse { result, isError }"
    Omni->>Hook: Normalize and distill result
    Hook-->>Omni: "updatedToolOutput { status, result }"
    Omni-->>Pi: hookSpecificOutput.updatedToolOutput
    Pi->>Pi: Read updatedToolOutput.result
    Pi-->>Pi: Return transformed text to host
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20fajarhide%2Fomni%20PR%20%23690%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=fajarhide%2Fomni&pr=690&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fhooks%2Fpost_tool.rs%3A1814-1817%0A**Scanner%20omits%20plugin%20extensions**%0A%0AThe%20new%20guard%20checks%20only%20%60.ts%60%2C%20%60.js%60%2C%20and%20%60.py%60%20files%2C%20so%20post-hook%20consumers%20implemented%20as%20%60.mjs%60%2C%20%60.cjs%60%2C%20%60.mts%60%2C%20or%20another%20supported%20source%20type%20are%20silently%20excluded.%20Such%20a%20plugin%20can%20read%20the%20obsolete%20response%20key%20while%20this%20regression%20test%20remains%20green%2C%20undermining%20its%20stated%20every-plugin%20coverage.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni&pr=690&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fajarhide%2Fomni%22%20on%20the%20existing%20branch%20%22fix%2F688-pi-reads-the-key-omni-writes%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F688-pi-reads-the-key-omni-writes%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fhooks%2Fpost_tool.rs%3A1814-1817%0A**Scanner%20omits%20plugin%20extensions**%0A%0AThe%20new%20guard%20checks%20only%20%60.ts%60%2C%20%60.js%60%2C%20and%20%60.py%60%20files%2C%20so%20post-hook%20consumers%20implemented%20as%20%60.mjs%60%2C%20%60.cjs%60%2C%20%60.mts%60%2C%20or%20another%20supported%20source%20type%20are%20silently%20excluded.%20Such%20a%20plugin%20can%20read%20the%20obsolete%20response%20key%20while%20this%20regression%20test%20remains%20green%2C%20undermining%20its%20stated%20every-plugin%20coverage.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni&pr=690&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Asrc%2Fhooks%2Fpost_tool.rs%3A1814-1817%0A**Scanner%20omits%20plugin%20extensions**%0A%0AThe%20new%20guard%20checks%20only%20%60.ts%60%2C%20%60.js%60%2C%20and%20%60.py%60%20files%2C%20so%20post-hook%20consumers%20implemented%20as%20%60.mjs%60%2C%20%60.cjs%60%2C%20%60.mts%60%2C%20or%20another%20supported%20source%20type%20are%20silently%20excluded.%20Such%20a%20plugin%20can%20read%20the%20obsolete%20response%20key%20while%20this%20regression%20test%20remains%20green%2C%20undermining%20its%20stated%20every-plugin%20coverage.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=690&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fajarhide%2Fomni%22%20on%20the%20existing%20branch%20%22fix%2F688-pi-reads-the-key-omni-writes%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F688-pi-reads-the-key-omni-writes%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fhooks%2Fpost_tool.rs%3A1814-1817%0A**Scanner%20omits%20plugin%20extensions**%0A%0AThe%20new%20guard%20checks%20only%20%60.ts%60%2C%20%60.js%60%2C%20and%20%60.py%60%20files%2C%20so%20post-hook%20consumers%20implemented%20as%20%60.mjs%60%2C%20%60.cjs%60%2C%20%60.mts%60%2C%20or%20another%20supported%20source%20type%20are%20silently%20excluded.%20Such%20a%20plugin%20can%20read%20the%20obsolete%20response%20key%20while%20this%20regression%20test%20remains%20green%2C%20undermining%20its%20stated%20every-plugin%20coverage.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/hooks/post_tool.rs:1814-1817
**Scanner omits plugin extensions**

The new guard checks only `.ts`, `.js`, and `.py` files, so post-hook consumers implemented as `.mjs`, `.cjs`, `.mts`, or another supported source type are silently excluded. Such a plugin can read the obsolete response key while this regression test remains green, undermining its stated every-plugin coverage.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(pi): read the key OMNI writes, and c..."](https://github.com/fajarhide/omni/commit/2d6d05a5314c01cc11db98dc2be134b7bf47274e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56032975)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->