### PR TITLE
fix(hooks): the plugin scan reads the whole JS and TS family

### DIFF
--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -1811,8 +1811,15 @@ mod tests {
                     stack.push(path);
                     continue;
                 }
+                // The whole JS and TS family, not the three spellings that
+                // happen to exist today: a plugin written as `.mjs` would have
+                // been skipped in silence, which is the same shape of hole this
+                // test exists to close.
                 let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
-                if !matches!(ext, "ts" | "js" | "py") {
+                if !matches!(
+                    ext,
+                    "ts" | "tsx" | "mts" | "cts" | "js" | "jsx" | "mjs" | "cjs" | "py"
+                ) {
                     continue;
                 }
                 let Ok(text) = std::fs::read_to_string(&path) else {


### PR DESCRIPTION
Follow-up to #690, from the review comment on it.

The guard that checks every plugin reads `updatedToolOutput` filtered on `.ts`,
`.js` and `.py`. Those are the three spellings that happen to exist in `plugins/`
today, so a plugin written as `.mjs`, `.cjs`, `.mts` or `.tsx` was skipped in
silence and could read the dead key with the test still green.

Same shape of hole the test exists to close, one level up: a check whose coverage is
decided by what is already in the tree cannot see what arrives next.

Driven red with an `.mjs` plugin that spawns `--post-hook` and reads
`updatedResponse`, named in the failure, and green again once removed.

`make ci` green.

Refs #688


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR broadens a test-only plugin source scanner to cover the full JavaScript and TypeScript extension families, preventing new plugin variants from silently bypassing the legacy-key guard.
- Adds `.tsx`, `.mts`, `.cts`, `.jsx`, `.mjs`, and `.cjs` to the scanned extensions.
- Retains Python coverage and the existing recursive traversal and validation behavior.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the expanded test coverage matching its stated purpose.

The change is confined to a test helper’s source-extension filter and correctly includes additional JavaScript and TypeScript module variants without altering production behavior.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/hooks/post_tool.rs | Broadens the test scanner’s extension allowlist without changing runtime hook behavior; no actionable defect was identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(hooks): the plugin scan reads the wh..."](https://github.com/fajarhide/omni/commit/9c5e54c6438ab8d44ba6ca95c7ed11afb37211b0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56034457)</sub>

<!-- /greptile_comment -->