### PR TITLE
fix(init): name the tier when reporting a successful install

### DIFF
--- a/changelog.d/684.fixed.md
+++ b/changelog.d/684.fixed.md
@@ -1,0 +1,27 @@
+**`omni init` says what the host lets OMNI do, instead of a green tick that means
+different things.** Configuring an MCP-only host printed the same success as a Full
+one:
+
+```
+🤖 Antigravity IDE Setup
+  ✓ Configured MCP Server in Antigravity IDE settings
+```
+
+Antigravity exposes no hook, so nothing is ever distilled and no row is ever
+recorded there. On the machine that hit it the config had been in place twelve days
+and every table held zero rows under that host. The user's conclusion was that
+`omni stats` was broken.
+
+The tier is now printed on every successful install, on every tier rather than only
+the disappointing one:
+
+```
+  ✓ Configured MCP Server in Antigravity IDE settings
+  ℹ MCP-only: memory and session state, no shell distill
+
+  ℹ Full: model-facing distill active
+```
+
+`AgentIntegration::tier()` has carried this since #351 and `doctor` has printed it
+correctly all along. Installation is simply where the expectation is formed, and it
+was the one surface that never asked.

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -426,8 +426,24 @@ pub fn run_init(args: &[String]) -> anyhow::Result<()> {
         if target_ids.contains(&agent.id()) {
             println!("{}", format!("🤖 {} Setup", agent.name()).bold().cyan());
 
-            if let Err(e) = agent.install(&exe_path) {
-                eprintln!("  {} Failed: {}", "✗".red(), e);
+            match agent.install(&exe_path) {
+                Err(e) => eprintln!("  {} Failed: {}", "✗".red(), e),
+                // #684. The success line was the same shape on every host, so
+                // configuring an MCP-only one read as "OMNI is now shortening
+                // your tool output". It is not, and the user found out from an
+                // empty `omni stats` days later. `doctor` says this correctly and
+                // is the wrong place to say it first: installation is the moment
+                // the expectation is set.
+                //
+                // Printed for every tier, not only the one that disappoints. A
+                // line that appears only on bad news is a line users learn to
+                // read as bad news, and `Full` is worth confirming.
+                Ok(()) => println!(
+                    "  {} {}: {}",
+                    "ℹ".blue(),
+                    agent.tier().name().bold(),
+                    agent.tier().label().bright_black()
+                ),
             }
 
             if agent.id() == "claude" {
@@ -479,6 +495,41 @@ mod tests {
         for agent in ["terminal", "windsurf", "aider", "vscode_continue"] {
             assert_eq!(init_id_for_agent(agent), None, "{agent}");
         }
+    }
+
+    /// #684. `omni init --antigravity` printed a green tick and nothing else, so
+    /// the expectation it set was distillation. Antigravity has no hook, records
+    /// nothing, and the user found out from an empty `omni stats` twelve days
+    /// later. `doctor` had said so all along, correctly, and is the wrong place
+    /// to say it first: installation is when the expectation is formed.
+    ///
+    /// Asserted on the source of the install loop rather than on a `Tier` value,
+    /// because the thing that broke was a caller that never asked. A test that
+    /// calls `tier()` itself passes while the loop ignores it, which is the same
+    /// shape as #663's `measurement_method` and #688's plugin key: the contract
+    /// holds and nobody reads it.
+    #[test]
+    fn the_install_loop_reports_the_tier_it_already_knows() {
+        let src = include_str!("init.rs");
+        let loop_start = src
+            .find("for agent in integrations {")
+            .expect("the install loop moved; this test is looking for the wrong thing");
+        let loop_body = src.get(loop_start..).unwrap_or("");
+        let install = loop_body
+            .find("agent.install(&exe_path)")
+            .expect("the install call moved");
+        // Everything the loop does after installing, up to its own end.
+        let after = loop_body.get(install..).unwrap_or("");
+        let reports = after
+            .split("\n    }\n")
+            .next()
+            .unwrap_or(after)
+            .contains("agent.tier()");
+        assert!(
+            reports,
+            "the install loop does not consult `agent.tier()` after installing, \
+             so every host gets the same success line whatever OMNI can do there"
+        );
     }
 
     /// `AGENT_FLAGS` is a hand-maintained index into `FLAGS`. Getting it wrong


### PR DESCRIPTION
Configuring an MCP-only host printed the same success as a Full one:

```
🤖 Antigravity IDE Setup
  ✓ Configured MCP Server in Antigravity IDE settings
```

Antigravity exposes no hook, so nothing is distilled there and no row is ever
recorded. On the machine that found it the config had been in place twelve days:

```
~/.gemini/antigravity/mcp_config.json   written 2026-08-11, OMNI_AGENT_ID=antigravity
rows under 'antigravity', all tables    0
```

The conclusion drawn was that `omni stats` was broken. It was not.

`AgentIntegration::tier()` has carried the answer since #351, and `doctor` prints it
correctly, per host, with a legend. Installation is simply where the expectation is
formed, and it was the one surface that never asked:

```
🤖 Antigravity IDE Setup
  ✓ Configured MCP Server in Antigravity IDE settings
  ℹ MCP-only: memory and session state, no shell distill

🤖 Claude Code Setup
  ℹ Full: model-facing distill active
```

Both verified by running `omni init` against a throwaway `HOME`.

Printed on every tier rather than only the disappointing one. A line that appears
only on bad news is one users learn to read as bad news, and `Full` is worth
confirming.

**On the test.** It asserts the install loop consults `tier()` after installing,
rather than asserting on a `Tier` value. What broke here was a caller that never
asked, and a test that calls `tier()` itself passes while the loop ignores it. That
is the same shape as #663's `measurement_method` and #688's plugin key: the contract
held and nobody read it. Driven red twice, by dropping the line and by printing a
line that does not consult the tier.

Not in this PR: #687 corrects the tier three hosts declare, and is held by another
session.

`make ci` green.

Closes #684


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes `omni init` print an integration’s tier after a successful installation so users can distinguish full, handoff-first, and MCP-only capabilities.

- Adds tier name and explanatory label output to the successful-install path.
- Adds a regression test intended to ensure the install loop consults `tier()`.
- Documents the user-facing correction in the changelog.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with one non-blocking weakness in the regression test’s ability to detect future output regressions.

The runtime change reports the stable integration tier only after successful installation; the remaining concern is that the test checks for any later textual tier call rather than tying that call to the success output.

**Files Needing Attention:** src/cli/init.rs
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/cli/init.rs | Adds correct tier-aware success output, but the source-text regression test can pass when an unrelated tier call remains in the loop. |
| changelog.d/684.fixed.md | Accurately documents the new tier-aware installation output and its motivation. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20fajarhide%2Fomni%20PR%20%23693%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=fajarhide%2Fomni&pr=693&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fcli%2Finit.rs%3A527%0A**Tier%20test%20accepts%20unrelated%20calls**%0A%0AThe%20test%20accepts%20any%20textual%20%60agent.tier%28%29%60%20call%20after%20the%20install%20expression%2C%20including%20calls%20in%20unrelated%20branches%20or%20statements.%20The%20success%20message%20can%20therefore%20stop%20reporting%20the%20tier%20while%20this%20regression%20test%20continues%20to%20pass.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni&pr=693&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fajarhide%2Fomni%22%20on%20the%20existing%20branch%20%22fix%2F684-init-names-the-tier%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F684-init-names-the-tier%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fcli%2Finit.rs%3A527%0A**Tier%20test%20accepts%20unrelated%20calls**%0A%0AThe%20test%20accepts%20any%20textual%20%60agent.tier%28%29%60%20call%20after%20the%20install%20expression%2C%20including%20calls%20in%20unrelated%20branches%20or%20statements.%20The%20success%20message%20can%20therefore%20stop%20reporting%20the%20tier%20while%20this%20regression%20test%20continues%20to%20pass.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni&pr=693&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Asrc%2Fcli%2Finit.rs%3A527%0A**Tier%20test%20accepts%20unrelated%20calls**%0A%0AThe%20test%20accepts%20any%20textual%20%60agent.tier%28%29%60%20call%20after%20the%20install%20expression%2C%20including%20calls%20in%20unrelated%20branches%20or%20statements.%20The%20success%20message%20can%20therefore%20stop%20reporting%20the%20tier%20while%20this%20regression%20test%20continues%20to%20pass.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=693&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fajarhide%2Fomni%22%20on%20the%20existing%20branch%20%22fix%2F684-init-names-the-tier%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F684-init-names-the-tier%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fcli%2Finit.rs%3A527%0A**Tier%20test%20accepts%20unrelated%20calls**%0A%0AThe%20test%20accepts%20any%20textual%20%60agent.tier%28%29%60%20call%20after%20the%20install%20expression%2C%20including%20calls%20in%20unrelated%20branches%20or%20statements.%20The%20success%20message%20can%20therefore%20stop%20reporting%20the%20tier%20while%20this%20regression%20test%20continues%20to%20pass.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/cli/init.rs:527
**Tier test accepts unrelated calls**

The test accepts any textual `agent.tier()` call after the install expression, including calls in unrelated branches or statements. The success message can therefore stop reporting the tier while this regression test continues to pass.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(init): name the tier when reporting ..."](https://github.com/fajarhide/omni/commit/9031da21d73847d9ce17c64befa916ea973a3c42) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56036813)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->