### PR TITLE
fix(agents): declare the tier the post-hook already earns

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,9 @@ resolve. Hold the shortest window open while measuring with
 
 | Tier | Hosts | What you get |
 |---|---|---|
-| **Full** | Claude Code, Codex CLI, Gemini CLI, Aider (pipe) | The host applies OMNI's rewrite, so the model reads distilled output from its own built-in tools. |
+| **Full** | Claude Code, Codex CLI, Gemini CLI, OpenClaw, Hermes, Pi, Aider (pipe) | The host applies OMNI's rewrite, so the model reads distilled output from its own built-in tools. |
 | **Handoff-first** | Cursor, Windsurf | The host cannot rewrite built-in tool output. `omni_run` distils anything you route through it, and `omni init --cursor` installs the rule that makes the agent reach for it. |
-| **MCP-only** | Cline, Roo, OpenCode, VS Code, Zed, Copilot, Antigravity, Hermes, Pi | Memory, recall and session state. No shell distillation, and no claim of it. |
+| **MCP-only** | Cline, Roo, OpenCode, VS Code, Zed, Copilot, Antigravity | Memory, recall and session state. No shell distillation, and no claim of it. |
 
 `omni doctor` prints the tier for every installed host. Savings are only ever counted
 where the model actually received less.

--- a/changelog.d/687.fixed.md
+++ b/changelog.d/687.fixed.md
@@ -1,0 +1,22 @@
+**OMNI told three hosts it could not do the thing it was already doing.** OpenClaw,
+Hermes and Pi all hand every tool result to `omni --post-hook`, which is the path that
+applies the ledger, so the model reads distilled bytes on all three. None of them
+overrode the tier, so `doctor` printed "memory and session state, no shell distill"
+under their names and the MCP surface was cut to the memory tools, withholding
+`omni_explain_savings` from the hosts that had finally acquired something to explain.
+
+The default is deliberate and stays: a new integration has to claim distillation rather
+than inherit the claim, after three of them printed `[OK] installed` and recorded
+nothing (#351). This is the same root failing the other way, so the guard is not "check
+that OpenClaw declares Full", which is the same hand-maintenance one layer down. A test
+derives the floor from the plugin sources in the tree: anything that spawns
+`--post-hook` is asking OMNI to replace what the model reads, so the integration that
+installs it cannot be the tier whose whole meaning is that nothing is replaced.
+
+OpenClaw's Full is narrower than Claude Code's and the docs now say so.
+`tool_result_persist` rewrites the result OpenClaw persists rather than the one in
+flight, so the saving lands on every later turn that re-reads the transcript while the
+turn that ran the command still sees the raw bytes.
+
+The Hermes guide's "expect 25 tools" went with it. That was the whole surface, not the
+advertised one, and the advertised set has been priced since #609.

--- a/docs/website/src-id/integrations/hermes.md
+++ b/docs/website/src-id/integrations/hermes.md
@@ -76,7 +76,7 @@ keduanya yang berarti.
 omni doctor
 
 hermes plugins list | grep omni        # harapkan: omni-signal-engine enabled
-hermes tools list | grep mcp_omni_     # harapkan 25 perkakas, setelah restart
+hermes tools list | grep mcp_omni_     # himpunan yang diiklankan, setelah restart
 ```
 
 Lalu satu pemeriksaan fungsional pada fixture sungguhan:
@@ -90,10 +90,13 @@ Untuk uji langsung, jalankan sesuatu yang berisik lewat tool `terminal` milik
 Hermes (`terminal("npm install", timeout=120)`) lalu bandingkan ukuran hasil
 tool-nya dengan keluaran npm mentah. Pastikan dengan `omni stats`.
 
-> Hitung perkakasnya, jangan percaya angka yang tertulis. Versi sebelumnya dari
-> panduan ini menyebut 27, yang datang dari mem-`grep` kode sumber server; salah
-> satu string itu nama penyaring, bukan perkakas. `hermes tools list` di atas
-> yang menjadi hitungannya.
+> Baca daftarnya, jangan percaya angka yang tertulis. Panduan ini pernah
+> menyebut 27, yang datang dari mem-`grep` kode sumber server dan menghitung nama
+> penyaring sebagai perkakas, lalu 25, yang adalah seluruh permukaannya dan bukan
+> yang diberitahukan ke host. Hermes host tingkat Penuh, jadi yang diiklankan
+> kepadanya `omni_retrieve` dan `omni_explain_savings`, dua yang membayar
+> tempatnya di prefiks setiap permintaan. `OMNI_MCP_TOOLS=all` menyajikan seluruh
+> permukaannya.
 
 ## Di mana OMNI membantu dan di mana tidak
 

--- a/docs/website/src-id/reference/agents.md
+++ b/docs/website/src-id/reference/agents.md
@@ -8,9 +8,9 @@ sebelum menilai apakah OMNI layak berada di sana.
 
 | tingkat | host | yang Anda dapat |
 |---|---|---|
-| **Penuh** | Claude Code, Codex CLI, Gemini CLI, Aider (pipa) | Host menerapkan tulis ulang OMNI, jadi model membaca keluaran sulingan dari tool bawaannya sendiri. |
+| **Penuh** | Claude Code, Codex CLI, Gemini CLI, OpenClaw, Hermes, Pi, Aider (pipa) | Host menerapkan tulis ulang OMNI, jadi model membaca keluaran sulingan dari tool bawaannya sendiri. |
 | **Handoff dulu** | Cursor, Windsurf | Host tidak bisa menulis ulang keluaran tool bawaannya. `omni_run` menyuling apa pun yang dilewatkan melaluinya, dan `omni init --cursor` memasang aturan yang membuat agent meraihnya. |
-| **MCP saja** | Cline, Roo, OpenCode, VS Code, Zed, Copilot, Antigravity, Hermes, Pi | Ingatan, pemanggilan kembali dan keadaan sesi. Tanpa penyulingan shell, dan tanpa klaim soal itu. |
+| **MCP saja** | Cline, Roo, OpenCode, VS Code, Zed, Copilot, Antigravity | Ingatan, pemanggilan kembali dan keadaan sesi. Tanpa penyulingan shell, dan tanpa klaim soal itu. |
 
 ```sh
 omni doctor     # mencetak tingkat untuk setiap host yang terpasang
@@ -53,8 +53,17 @@ berkas, pencarian dan pengambilan web berjalan sama sekali. Tiga di antaranya
 sudah ditulis dan diuji sepenuhnya dan tidak pernah sekali pun berjalan di sesi
 sungguhan.
 
-**Hermes** punya halaman integrasinya sendiri:
-[Hermes Agent](../integrations/hermes.md).
+**OpenClaw** Penuh di giliran berikutnya, bukan giliran saat ini. Hook
+`tool_result_persist`-nya menulis ulang hasil tool yang disimpan OpenClaw, jadi model
+membaca byte sulingan setiap kali transkrip dibaca ulang, sementara giliran yang
+menjalankan perintahnya masih melihat keluaran mentah. Di situlah biaya sebuah hasil
+tool sebenarnya berada, karena ia dibaca ulang berkali-kali, tetapi ini Penuh yang lebih
+sempit daripada milik Claude Code.
+
+**Hermes** menyerahkan setiap hasil tool ke OMNI, bukan hanya terminal, dan itu
+jangkauan terluas di antara host di sini: ia yang menjalankan distiller baca berkas,
+pencarian dan fetch di host yang punya ketiganya. Ia juga punya halaman integrasinya
+sendiri: [Hermes Agent](../integrations/hermes.md).
 
 **Windows** didukung. Jalur, akhiran baris dan imbuhan `.exe` sudah ditangani,
 dan matriks CI-nya menyertakan `windows-latest`.

--- a/docs/website/src/integrations/hermes.md
+++ b/docs/website/src/integrations/hermes.md
@@ -73,7 +73,7 @@ with every other host's and no figure about either is meaningful.
 omni doctor
 
 hermes plugins list | grep omni        # expect: omni-signal-engine enabled
-hermes tools list | grep mcp_omni_     # expect 25 tools, after a restart
+hermes tools list | grep mcp_omni_     # the advertised set, after a restart
 ```
 
 Then a functional check on a real fixture:
@@ -87,9 +87,11 @@ For a live test, run something noisy through Hermes' `terminal` tool
 (`terminal("npm install", timeout=120)`) and compare the tool result size against raw
 npm output. Confirm with `omni stats`.
 
-> Count the tools rather than trusting a number written down. Earlier versions of this
-> guide said 27, which came from grepping the server source; one of those strings is a
-> filter name, not a tool. The `hermes tools list` above is the count.
+> Read the list rather than a number written down. This guide has said 27, which came
+> from grepping the server source and counted a filter name as a tool, and then 25, which
+> is the whole surface and not what a host is told about. Hermes is a Full-tier host, so
+> it is advertised `omni_retrieve` and `omni_explain_savings`, the two that pay for their
+> place in the prefix of every request. `OMNI_MCP_TOOLS=all` serves the whole surface.
 
 ## Where OMNI helps and where it does not
 

--- a/docs/website/src/reference/agents.md
+++ b/docs/website/src/reference/agents.md
@@ -8,9 +8,9 @@ place.
 
 | tier | hosts | what you get |
 |---|---|---|
-| **Full** | Claude Code, Codex CLI, Gemini CLI, Aider (pipe) | The host applies OMNI's rewrite, so the model reads distilled output from its own built-in tools. |
+| **Full** | Claude Code, Codex CLI, Gemini CLI, OpenClaw, Hermes, Pi, Aider (pipe) | The host applies OMNI's rewrite, so the model reads distilled output from its own built-in tools. |
 | **Handoff-first** | Cursor, Windsurf | The host cannot rewrite built-in tool output. `omni_run` distils anything routed through it, and `omni init --cursor` installs the rule that makes the agent reach for it. |
-| **MCP-only** | Cline, Roo, OpenCode, VS Code, Zed, Copilot, Antigravity, Hermes, Pi | Memory, recall and session state. No shell distillation, and no claim of it. |
+| **MCP-only** | Cline, Roo, OpenCode, VS Code, Zed, Copilot, Antigravity | Memory, recall and session state. No shell distillation, and no claim of it. |
 
 ```sh
 omni doctor     # prints the tier for every installed host
@@ -49,7 +49,16 @@ execution semantics into OMNI, and bypasses the host's approval flow.
 distillers run at all. Three of them had been fully written and tested and had never
 executed on a real session.
 
-**Hermes** has its own integration page: [Hermes Agent](../integrations/hermes.md).
+**OpenClaw** is Full on a later turn, not the current one. Its `tool_result_persist`
+hook rewrites the tool result OpenClaw persists, so the model reads the distilled bytes
+every time the transcript is re-read, while the turn that ran the command still sees the
+raw output. That is where a tool result's cost sits anyway, since it is re-read many
+times, but it is a narrower Full than Claude Code's.
+
+**Hermes** hands OMNI every tool result, not only the terminal, which is the widest
+reach of any host here: it is what runs the file-read, search and fetch distillers on a
+host that has them. It also has its own integration page:
+[Hermes Agent](../integrations/hermes.md).
 
 **Windows** is supported. Paths, line endings and the `.exe` suffix are handled, and
 the CI matrix includes `windows-latest`.

--- a/i18n/README-ar.md
+++ b/i18n/README-ar.md
@@ -30,9 +30,9 @@ brew install fajarhide/tap/omni && omni init
 
 | المستوى | المضيف | ما تحصل عليه |
 |---|---|---|
-| **Full** | Claude Code, Codex CLI, Gemini CLI, Aider (pipe) | المضيف يطبّق إعادة كتابة OMNI، لذا يقرأ النموذج مخرجات مقطّرة من أدواته المدمجة. |
+| **Full** | Claude Code, Codex CLI, Gemini CLI, OpenClaw, Hermes, Pi, Aider (pipe) | المضيف يطبّق إعادة كتابة OMNI، لذا يقرأ النموذج مخرجات مقطّرة من أدواته المدمجة. |
 | **Handoff-first** | Cursor, Windsurf | لا يستطيع المضيف إعادة كتابة مخرجات الأدوات المدمجة. يقطّر `omni_run` أي أمر تمرّره عبره، ويثبّت `omni init --cursor` القاعدة التي تجعل الوكيل يختاره. |
-| **MCP-only** | Cline, Roo, OpenCode, VS Code, Zed, Copilot, Antigravity, Hermes, Pi | الذاكرة والاسترجاع وحالة الجلسة فقط. لا تقطير للأوامر، ولا ادّعاء بوجوده. |
+| **MCP-only** | Cline, Roo, OpenCode, VS Code, Zed, Copilot, Antigravity | الذاكرة والاسترجاع وحالة الجلسة فقط. لا تقطير للأوامر، ولا ادّعاء بوجوده. |
 
 يطبع `omni doctor` المستوى لكل مضيف مثبّت. لا تُحتسب الوفورات إلا عندما يتلقى النموذج فعليًا قدرًا أقل.
 

--- a/i18n/README-id.md
+++ b/i18n/README-id.md
@@ -31,9 +31,9 @@ Mendistilasi output perintah di Claude Code, Codex CLI, dan Gemini CLI, yaitu ho
 
 | Tier | Host | Yang kamu dapat |
 |---|---|---|
-| **Full** | Claude Code, Codex CLI, Gemini CLI, Aider (pipe) | Host menerapkan penulisan ulang OMNI, jadi model membaca output terdistilasi dari tool bawaannya sendiri. |
+| **Full** | Claude Code, Codex CLI, Gemini CLI, OpenClaw, Hermes, Pi, Aider (pipe) | Host menerapkan penulisan ulang OMNI, jadi model membaca output terdistilasi dari tool bawaannya sendiri. |
 | **Handoff-first** | Cursor, Windsurf | Host tidak bisa menulis ulang output tool bawaan. `omni_run` mendistilasi apa pun yang kamu lewatkan melaluinya, dan `omni init --cursor` memasang aturan yang membuat agent memilihnya. |
-| **MCP-only** | Cline, Roo, OpenCode, VS Code, Zed, Copilot, Antigravity, Hermes, Pi | Memori, recall, dan state sesi. Tidak ada distilasi shell, dan tidak diklaim ada. |
+| **MCP-only** | Cline, Roo, OpenCode, VS Code, Zed, Copilot, Antigravity | Memori, recall, dan state sesi. Tidak ada distilasi shell, dan tidak diklaim ada. |
 
 `omni doctor` mencetak tier tiap host yang terpasang. Penghematan hanya dihitung ketika model benar-benar menerima lebih sedikit.
 

--- a/i18n/README-ja.md
+++ b/i18n/README-ja.md
@@ -31,9 +31,9 @@ Claude Code、Codex CLI、Gemini CLI ではコマンド出力を蒸留します�
 
 | ティア | ホスト | 得られるもの |
 |---|---|---|
-| **Full** | Claude Code, Codex CLI, Gemini CLI, Aider (pipe) | ホストが OMNI の書き換えを適用するため、モデルは組み込みツールの蒸留済み出力を読みます。 |
+| **Full** | Claude Code, Codex CLI, Gemini CLI, OpenClaw, Hermes, Pi, Aider (pipe) | ホストが OMNI の書き換えを適用するため、モデルは組み込みツールの蒸留済み出力を読みます。 |
 | **Handoff-first** | Cursor, Windsurf | ホストは組み込みツールの出力を書き換えられません。`omni_run` を通したコマンドは蒸留され、`omni init --cursor` がエージェントにそれを選ばせるルールを導入します。 |
-| **MCP-only** | Cline, Roo, OpenCode, VS Code, Zed, Copilot, Antigravity, Hermes, Pi | メモリ、リコール、セッション状態のみ。シェルの蒸留はなく、あるとも主張しません。 |
+| **MCP-only** | Cline, Roo, OpenCode, VS Code, Zed, Copilot, Antigravity | メモリ、リコール、セッション状態のみ。シェルの蒸留はなく、あるとも主張しません。 |
 
 `omni doctor` が導入済みホストごとにティアを表示します。削減量はモデルが実際に受け取る量が減った場合にのみ計上されます。
 

--- a/i18n/README-ko.md
+++ b/i18n/README-ko.md
@@ -31,9 +31,9 @@ Claude Code, Codex CLI, Gemini CLI에서 명령 출력을 증류합니다. 이 �
 
 | 티어 | 호스트 | 무엇을 얻는가 |
 |---|---|---|
-| **Full** | Claude Code, Codex CLI, Gemini CLI, Aider (pipe) | 호스트가 OMNI의 재작성을 적용하므로 모델은 내장 도구의 증류된 출력을 읽습니다. |
+| **Full** | Claude Code, Codex CLI, Gemini CLI, OpenClaw, Hermes, Pi, Aider (pipe) | 호스트가 OMNI의 재작성을 적용하므로 모델은 내장 도구의 증류된 출력을 읽습니다. |
 | **Handoff-first** | Cursor, Windsurf | 호스트가 내장 도구 출력을 재작성할 수 없습니다. `omni_run`으로 실행한 명령은 증류되며, `omni init --cursor`가 에이전트로 하여금 그것을 선택하게 하는 규칙을 설치합니다. |
-| **MCP-only** | Cline, Roo, OpenCode, VS Code, Zed, Copilot, Antigravity, Hermes, Pi | 메모리, 리콜, 세션 상태만. 셸 증류는 없으며 있다고 주장하지도 않습니다. |
+| **MCP-only** | Cline, Roo, OpenCode, VS Code, Zed, Copilot, Antigravity | 메모리, 리콜, 세션 상태만. 셸 증류는 없으며 있다고 주장하지도 않습니다. |
 
 `omni doctor`가 설치된 호스트마다 티어를 출력합니다. 절감은 모델이 실제로 더 적게 받았을 때만 집계됩니다.
 

--- a/i18n/README-vi.md
+++ b/i18n/README-vi.md
@@ -31,9 +31,9 @@ Chưng cất đầu ra lệnh trên Claude Code, Codex CLI và Gemini CLI, nhữ
 
 | Tier | Host | Bạn nhận được gì |
 |---|---|---|
-| **Full** | Claude Code, Codex CLI, Gemini CLI, Aider (pipe) | Host áp dụng bản ghi đè của OMNI, nên mô hình đọc đầu ra đã chưng cất từ công cụ tích hợp của chính nó. |
+| **Full** | Claude Code, Codex CLI, Gemini CLI, OpenClaw, Hermes, Pi, Aider (pipe) | Host áp dụng bản ghi đè của OMNI, nên mô hình đọc đầu ra đã chưng cất từ công cụ tích hợp của chính nó. |
 | **Handoff-first** | Cursor, Windsurf | Host không thể ghi đè đầu ra công cụ tích hợp. `omni_run` chưng cất mọi lệnh bạn chạy qua nó, và `omni init --cursor` cài quy tắc khiến agent chọn nó. |
-| **MCP-only** | Cline, Roo, OpenCode, VS Code, Zed, Copilot, Antigravity, Hermes, Pi | Chỉ bộ nhớ, recall và trạng thái phiên. Không chưng cất shell, và không tuyên bố là có. |
+| **MCP-only** | Cline, Roo, OpenCode, VS Code, Zed, Copilot, Antigravity | Chỉ bộ nhớ, recall và trạng thái phiên. Không chưng cất shell, và không tuyên bố là có. |
 
 `omni doctor` in ra tier của từng host đã cài. Tiết kiệm chỉ được tính khi mô hình thực sự nhận ít hơn.
 

--- a/i18n/README-zh.md
+++ b/i18n/README-zh.md
@@ -31,9 +31,9 @@ brew install fajarhide/tap/omni && omni init
 
 | 层级 | 宿主 | 你得到什么 |
 |---|---|---|
-| **Full** | Claude Code, Codex CLI, Gemini CLI, Aider (pipe) | 宿主会应用 OMNI 的重写，因此模型读取的是其内置工具的蒸馏输出。 |
+| **Full** | Claude Code, Codex CLI, Gemini CLI, OpenClaw, Hermes, Pi, Aider (pipe) | 宿主会应用 OMNI 的重写，因此模型读取的是其内置工具的蒸馏输出。 |
 | **Handoff-first** | Cursor, Windsurf | 宿主无法重写内置工具输出。`omni_run` 会蒸馏你经它执行的任何命令，`omni init --cursor` 会安装让代理主动选择它的规则。 |
-| **MCP-only** | Cline, Roo, OpenCode, VS Code, Zed, Copilot, Antigravity, Hermes, Pi | 仅记忆、召回与会话状态。没有 shell 蒸馏，也不宣称有。 |
+| **MCP-only** | Cline, Roo, OpenCode, VS Code, Zed, Copilot, Antigravity | 仅记忆、召回与会话状态。没有 shell 蒸馏，也不宣称有。 |
 
 `omni doctor` 会为每个已安装宿主打印层级。只有模型确实收到更少内容时才计入节省。
 

--- a/src/agents/hermes.rs
+++ b/src/agents/hermes.rs
@@ -289,6 +289,15 @@ fn render_plugin(exe_path: &str) -> String {
 }
 
 impl AgentIntegration for HermesIntegration {
+    /// `transform_tool_result` fires for every tool, not only the terminal, so
+    /// this is the host with the widest reach of any: it is what finally runs
+    /// the Read, Grep and WebFetch distillers that Claude Code's Bash-only
+    /// matcher never reaches (#172). #628 wired it and left the tier at the
+    /// default, so `doctor` reported "no shell distill" for it (#687).
+    fn tier(&self) -> crate::agents::Tier {
+        crate::agents::Tier::Full
+    }
+
     fn id(&self) -> &'static str {
         "hermes"
     }

--- a/src/agents/mod.rs
+++ b/src/agents/mod.rs
@@ -279,3 +279,107 @@ mod fix_reporting_tests {
         assert!(warnings.is_empty(), "{warnings:?}");
     }
 }
+
+#[cfg(test)]
+mod tier_tests {
+    use super::{Tier, all_integrations};
+    use std::path::Path;
+
+    /// A plugin source file. Prose is excluded on purpose: a README naming
+    /// `--post-hook` documents the contract, it does not invoke it.
+    fn is_source(path: &Path) -> bool {
+        matches!(
+            path.extension().and_then(|e| e.to_str()).unwrap_or(""),
+            "ts" | "tsx" | "mts" | "cts" | "js" | "jsx" | "mjs" | "cjs" | "py"
+        )
+    }
+
+    /// Whether anything this plugin installs spawns `omni --post-hook`.
+    fn calls_the_post_hook(dir: &Path) -> bool {
+        let mut stack = vec![dir.to_path_buf()];
+        while let Some(d) = stack.pop() {
+            let Ok(entries) = std::fs::read_dir(&d) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                // Vendored dependencies are not our plugins and contain enough
+                // text to match anything.
+                if path.file_name().is_some_and(|n| n == "node_modules") {
+                    continue;
+                }
+                if path.is_dir() {
+                    stack.push(path);
+                } else if is_source(&path)
+                    && std::fs::read_to_string(&path).is_ok_and(|t| t.contains("--post-hook"))
+                {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    /// #687. The tier is hand-maintained beside the thing it describes, and #628
+    /// moved one without the other: OpenClaw and Hermes gained the post-hook and
+    /// kept the `McpOnly` default, so `doctor` printed "no shell distill" for two
+    /// hosts doing the full job, and `active_tools` withheld exactly the
+    /// reporting tools that had finally acquired something to report.
+    ///
+    /// Asserting "openclaw declares Full" would be the same hand-maintenance one
+    /// layer down. This derives the floor instead: a plugin that spawns
+    /// `--post-hook` is asking OMNI to replace what the model reads, so the
+    /// integration that installs it cannot be the tier whose whole meaning is
+    /// that nothing is replaced. Which of `Full` and `HandoffFirst` it is stays
+    /// a judgement, and is written down in each integration's own `tier`.
+    ///
+    /// Comments are not stripped, unlike the key scan in `post_tool.rs`. A plugin
+    /// whose only mention of the flag is prose would be asked for a tier it has
+    /// not earned, and that direction fails loudly rather than quietly.
+    #[test]
+    fn a_host_whose_plugin_calls_the_post_hook_is_not_mcp_only() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("plugins");
+        let integrations = all_integrations();
+        let mut checked = Vec::new();
+
+        for entry in std::fs::read_dir(&root)
+            .expect("plugins/ ships with the repo")
+            .flatten()
+        {
+            let path = entry.path();
+            if !path.is_dir() || !calls_the_post_hook(&path) {
+                continue;
+            }
+            let dir = entry.file_name().to_string_lossy().to_string();
+
+            // `plugins/claude-code` belongs to the integration whose id is
+            // `claude`, so a directory carries the id or the id plus a suffix.
+            let hosts: Vec<_> = integrations
+                .iter()
+                .filter(|i| dir == i.id() || dir.starts_with(&format!("{}-", i.id())))
+                .collect();
+            assert_eq!(
+                hosts.len(),
+                1,
+                "plugins/{dir} resolves to {} integrations rather than one, so this \
+                 scan can no longer say whose tier it is checking",
+                hosts.len()
+            );
+
+            assert_ne!(
+                hosts[0].tier(),
+                Tier::McpOnly,
+                "plugins/{dir} spawns `--post-hook`, so {} rewrites what the model \
+                 reads, and `{}` claims it does not (#687)",
+                hosts[0].name(),
+                Tier::McpOnly.label()
+            );
+            checked.push(dir);
+        }
+
+        assert!(
+            !checked.is_empty(),
+            "found no plugin calling `--post-hook`; the scan is looking in the wrong place"
+        );
+    }
+}

--- a/src/agents/openclaw.rs
+++ b/src/agents/openclaw.rs
@@ -61,6 +61,17 @@ fn register_plugin_path(config: &mut Value, dir: &str) -> bool {
 }
 
 impl AgentIntegration for OpenClawIntegration {
+    /// `tool_result_persist` replaces the result of every built-in tool, which
+    /// is the whole point of the plugin #628 shipped. It rewrites the message
+    /// OpenClaw persists rather than the one already in flight, so the model
+    /// reads OMNI's bytes on every turn that re-reads the transcript and the
+    /// current turn still sees the raw output. Narrower than Claude Code's
+    /// `Full`, and nowhere near the default `McpOnly` this inherited for two
+    /// releases while `doctor` told the user there was no shell distill (#687).
+    fn tier(&self) -> crate::agents::Tier {
+        crate::agents::Tier::Full
+    }
+
     fn id(&self) -> &'static str {
         "openclaw"
     }

--- a/src/agents/pi.rs
+++ b/src/agents/pi.rs
@@ -153,6 +153,14 @@ fn collect_omni_sources_recursive(val: &Value, out: &mut Vec<String>) {
 pub struct PiIntegration;
 
 impl AgentIntegration for PiIntegration {
+    /// Pi's `tool_result` handler returns replacement content, so the model
+    /// reads distilled bytes on the turn it is on. It read the wrong key until
+    /// #688 and applied nothing, which is why the default outlived the hook.
+    /// Derived from the plugin by the test in `mod.rs` now, not remembered.
+    fn tier(&self) -> crate::agents::Tier {
+        crate::agents::Tier::Full
+    }
+
     fn id(&self) -> &'static str {
         "pi"
     }


### PR DESCRIPTION
Closes #687

OpenClaw and Hermes got a plugin that hands tool results to `omni --post-hook` in #628 and neither overrode `tier()`, so both kept the `McpOnly` default and `doctor` printed "memory and session state, no shell distill" for two hosts running the whole pipeline. Pi is the third: its plugin has spawned `--post-hook` since it shipped and read a dead key until #688, so it applied nothing and the stale default was never visible.

The default stays. What changes is that the tier is no longer only hand-maintained: a test derives the floor from the plugin sources, since anything spawning `--post-hook` is asking OMNI to replace what the model reads and cannot be the tier whose whole meaning is that nothing is replaced. Which of `Full` and `HandoffFirst` it is stays a judgement, written in each integration's own `tier`.

Worth knowing before merge: all three leave `MEMORY` (4 tools) for `FULL` (2 tools since #609). They gain `omni_explain_savings` and lose `omni_remember`, `omni_recall` and `omni_knowledge`. Only the first has a CLI equivalent, so these hosts lose recall behind `OMNI_MCP_TOOLS=all`. OpenClaw's `Full` is also narrower than Claude Code's: `tool_result_persist` rewrites the persisted message, so the saving lands on later turns and the docs say so.

Verification:

```
make ci                      -> 0, smoke test 51/51 passed
cargo test (after rebase)    -> 0, 23 test binaries green
```

The guard was driven red four times, not once: removing `tier` from each of the three integrations, each failing with that host named, plus the scan's extension list blinded so an empty scan fails instead of passing as a clean one.

```
plugins/openclaw spawns `--post-hook`, so OpenClaw rewrites what the model reads,
and `memory and session state, no shell distill` claims it does not (#687)
...
found no plugin calling `--post-hook`; the scan is looking in the wrong place
```


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR aligns OpenClaw, Hermes, and Pi with the Full tier already implied by their post-hook integrations and adds a source-derived regression test.
- Adds explicit `Tier::Full` implementations for the three integrations.
- Adds a test that detects plugin sources invoking `--post-hook` and rejects `McpOnly` classifications.
- Updates English, Indonesian, and translated tier documentation, including OpenClaw’s persisted-result timing and Hermes’s advertised MCP surface.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the tier declarations, plugin behavior, regression guard, and updated documentation remaining consistent.

The changed integrations already invoke the model-facing post-hook path, and the new classifications correctly expose the corresponding Full-tier reporting surface without an unacknowledged reachable failure.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/agents/mod.rs | Adds a repository-source regression test that maps post-hook plugin directories to integrations and enforces a non-MCP-only tier. |
| src/agents/hermes.rs | Declares Hermes Full-tier, matching its installed plugin’s all-tool-result post-hook behavior. |
| src/agents/openclaw.rs | Declares OpenClaw Full-tier while documenting that rewriting affects persisted results and later transcript reads. |
| src/agents/pi.rs | Declares Pi Full-tier, matching its replacement-producing tool-result hook. |
| docs/website/src/reference/agents.md | Updates the tier table and clearly qualifies OpenClaw’s later-turn rewrite semantics. |
| docs/website/src/integrations/hermes.md | Replaces the obsolete fixed tool-count guidance with the Full-tier advertised tool set and override behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(agents): declare the tier the post-h..."](https://github.com/fajarhide/omni/commit/86bceb756cad32c3a715a32b7d25a90d0e22d4b7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56036850)</sub>

<!-- /greptile_comment -->