### PR TITLE
feat(mcp): offer omni_run on the one tier that cannot hook a shell

### DIFF
--- a/changelog.d/686.changed.md
+++ b/changelog.d/686.changed.md
@@ -1,0 +1,34 @@
+**The one tier that cannot hook a shell now gets the tool that runs one.** An
+MCP-only host gave OMNI no hook, so nothing was ever distilled there, and
+`omni_run` was withheld with this reason:
+
+```rust
+/// No shell distillation exists on this tier, so the tools that report on it
+/// would describe something that never happens.
+```
+
+That is right about `omni_explain_savings` and the other three reporters. It was
+circular about `omni_run`, which does not report distillation, it performs it: the
+tier had no distillation partly because the only tool that could produce any was
+held back on the grounds that the tier had no distillation.
+
+The file already made the argument one tier up, for Handoff-first, and every word
+of it applies: MCP is the only door OMNI has there, and an unadvertised tool is not
+one shell command away, it is unreachable. The difference between the two tiers is
+an installed rule nudging the agent toward `omni_run`, which is a nudge and not a
+capability.
+
+Only `omni_run`. It costs 417 B in the prefix of every request; the four reporting
+tools are 803 B more, and this file's own rule is that a tool added without a
+measurement has no price behind it. They become arguable once there are recorded
+runs on this tier to report on.
+
+The tier's own description moves with it. `Tier::label()` said "no shell distill",
+which #684 had just started printing at install time, so two changes in this release
+would have contradicted each other. A test now checks the label against the tool set
+rather than trusting it: a tier offering `omni_run` may not claim it does not distil.
+The manual's tool table moves too, in both languages.
+
+Cross-turn folding still does not reach these hosts, because the ledger runs in the
+hooks and `omni_run` never builds one. That half of #686 stays open: it needs a
+session identity MCP does not carry, and inventing one is how #118 happened.

--- a/docs/website/src-id/reference/mcp-tools.md
+++ b/docs/website/src-id/reference/mcp-tools.md
@@ -14,7 +14,7 @@ itu OMNI hanya mengiklankan set yang bisa dipakai oleh tier host Anda:
 |---|---|
 | Full | `omni_retrieve`, `omni_explain_savings` |
 | Handoff-first, dan host apa pun yang tidak dikenali OMNI | dua itu, ditambah `omni_remember`, `omni_recall`, `omni_run`, `omni_find_noise`, `omni_context_breakdown`, `omni_history` |
-| MCP-only | `omni_remember`, `omni_recall`, `omni_retrieve`, `omni_knowledge` |
+| MCP-only | keempatnya, ditambah `omni_run`: tanpa hook, output tool milik host tidak pernah ditulis ulang, jadi `omni_run` satu-satunya jalan agar model membaca lebih sedikit |
 
 Host tier Full mendapat daftar terpendek justru karena shell-nya sudah dipasangi hook oleh
 OMNI. Diukur pada 256 sesi yang terekam, dua perkakas itu membawa 138 dari 149 panggilan

--- a/docs/website/src/reference/mcp-tools.md
+++ b/docs/website/src/reference/mcp-tools.md
@@ -14,7 +14,7 @@ host's tier can use:
 |---|---|
 | Full | `omni_retrieve`, `omni_explain_savings` |
 | Handoff-first, and any host OMNI does not recognise | those two, plus `omni_remember`, `omni_recall`, `omni_run`, `omni_find_noise`, `omni_context_breakdown`, `omni_history` |
-| MCP-only | `omni_remember`, `omni_recall`, `omni_retrieve`, `omni_knowledge` |
+| MCP-only | `omni_remember`, `omni_recall`, `omni_retrieve`, `omni_knowledge`, plus `omni_run`: no hook means the host's own tool output is never rewritten, so `omni_run` is the only path by which the model reads less |
 
 Full-tier hosts get the shortest list because they are the ones whose shell OMNI already
 hooks. Measured across 256 recorded sessions, those two tools carry 138 of the 149 calls

--- a/src/agents/mod.rs
+++ b/src/agents/mod.rs
@@ -134,7 +134,10 @@ impl Tier {
         match self {
             Tier::Full => "model-facing distill active",
             Tier::HandoffFirst => "nothing is rewritten unless omni_run ran it",
-            Tier::McpOnly => "memory and session state, no shell distill",
+            // "no shell distill" until #686 put `omni_run` on this tier. The
+            // host's own tool output is still never rewritten, which is the
+            // difference that matters and the one this has to keep saying.
+            Tier::McpOnly => "memory and session state; only omni_run distils",
         }
     }
 }

--- a/src/mcp/policy.rs
+++ b/src/mcp/policy.rs
@@ -69,13 +69,28 @@ pub const HANDOFF: &[&str] = &[
     "omni_history",
 ];
 
-/// No shell distillation exists on this tier, so the tools that report on it
-/// would describe something that never happens.
+/// An MCP-only host gives OMNI no hook, so the tools that *report* on shell
+/// distillation would describe something that never happens. `omni_run` is not one
+/// of them: it is the tool that performs it, and withholding it was circular. The
+/// tier had no distillation partly because the one tool that could produce any was
+/// held back on the grounds that the tier had no distillation (#686).
+///
+/// `HANDOFF` above already makes the argument, and every word of it applies here:
+/// MCP is the only door OMNI has, `FULL`'s pricing does not transfer because an
+/// unadvertised tool is not one shell command away, it is unreachable. The
+/// difference between the two tiers is that a Handoff-first host has an installed
+/// rule nudging the agent toward `omni_run`. That is a nudge, not a capability.
+///
+/// Only `omni_run`, not the rest of `HANDOFF`. It costs 417 B in the prefix of
+/// every request, and the four reporting tools are 803 B more that this file's own
+/// rule says nobody may add without measuring first. They become arguable once
+/// there are recorded runs on this tier to report on, which today there are none of.
 pub const MEMORY: &[&str] = &[
     "omni_remember",
     "omni_recall",
     "omni_retrieve",
     "omni_knowledge",
+    "omni_run",
 ];
 
 /// Every tool the binary can serve. Kept here so `doctor` does not have to
@@ -188,6 +203,72 @@ mod tests {
             FULL.len() < HANDOFF.len(),
             "FULL is meant to be the cut one"
         );
+    }
+
+    /// #686. The tier with no hook is the one tier where `omni_run` is the only
+    /// way OMNI can shorten anything, and it was the one tier that did not
+    /// advertise it. The reason recorded in the source was circular: no
+    /// distillation exists here, so the tool that would create it is withheld.
+    ///
+    /// Asserted as a property rather than as a list, because a list assertion is
+    /// the same hand-maintenance one layer down. Every tier that cannot rewrite
+    /// built-in tool output has to offer the tool that runs the command itself.
+    #[test]
+    fn every_hookless_tier_offers_the_tool_that_runs_the_command() {
+        for (id, tier) in [
+            ("antigravity", Tier::McpOnly),
+            ("cursor", Tier::HandoffFirst),
+        ] {
+            assert_eq!(tier_for(id), tier, "{id} changed tier");
+            assert!(
+                active_tools(id).contains(&"omni_run"),
+                "{id} is {tier:?} and cannot rewrite its host's tool output, so \
+                 `omni_run` is the only path by which the model reads less. \
+                 Advertised: {:?}",
+                active_tools(id)
+            );
+        }
+    }
+
+    /// #686 made the old label false. `Tier::label()` said "no shell distill" for
+    /// a tier that now advertises the tool that distils, and #684 had just put
+    /// that sentence in front of the user at install time. Two changes landing in
+    /// the same release contradicted each other.
+    ///
+    /// So the label is checked against the tool set rather than being read once
+    /// and trusted: any tier offering `omni_run` may not claim it does not distil.
+    #[test]
+    fn no_tier_offering_omni_run_claims_it_does_not_distil() {
+        for id in ["antigravity", "cursor", "claude_code"] {
+            let tier = tier_for(id);
+            if active_tools(id).contains(&"omni_run") {
+                assert!(
+                    !tier.label().contains("no shell distill"),
+                    "{id} advertises omni_run and its label denies distilling: {:?}",
+                    tier.label()
+                );
+            }
+        }
+    }
+
+    /// The reporting tools stay out of `MEMORY` on purpose, and this is what
+    /// stops that decision drifting into "add them, they seem useful". They cost
+    /// 803 B in the prefix of every request and this file's own rule is that a
+    /// tool added without a measurement has no price behind it.
+    #[test]
+    fn the_mcp_only_tier_gains_the_performer_and_not_the_reporters() {
+        let tools = active_tools("antigravity");
+        for reporter in [
+            "omni_explain_savings",
+            "omni_find_noise",
+            "omni_context_breakdown",
+            "omni_history",
+        ] {
+            assert!(
+                !tools.contains(&reporter),
+                "{reporter} was added to the MCP-only set without a measurement"
+            );
+        }
     }
 
     /// `strategy.md` section 5 makes this product law: on a Handoff-first host


### PR DESCRIPTION
An MCP-only host gives OMNI no hook, so nothing is distilled there, and `omni_run`
was withheld with this reason:

```rust
/// No shell distillation exists on this tier, so the tools that report on it
/// would describe something that never happens.
```

Right about `omni_explain_savings` and the other three reporters. Circular about
`omni_run`, which does not report distillation, it performs it: the tier had no
distillation partly because the only tool that could produce any was held back on
the grounds that the tier had no distillation.

`policy.rs` already makes the argument one tier up, for Handoff-first, and every
word of it applies here:

> MCP is the only door OMNI has there and `FULL`'s pricing does not transfer: an
> unadvertised tool is not one shell command away, it is unreachable.

The difference between the two tiers is an installed rule nudging the agent toward
`omni_run`. That is a nudge, not a capability.

**Only `omni_run`,** and the second test exists to hold that line. It costs 417 B in
the prefix of every request; the four reporters are 803 B more, and this file's own
rule is that a tool added without a measurement has no price behind it. They become
arguable once there are recorded runs on this tier to report on.

Both tests assert properties rather than lists, because a list assertion is the same
hand-maintenance one layer down: every tier that cannot rewrite its host's tool
output has to offer the tool that runs the command itself. Driven red by withholding
`omni_run` again, and by adding a reporter unmeasured.

**The other half of #686 stays open,** so this closes nothing. Cross-turn folding
still does not reach these hosts: the ledger runs in the three hooks,
`run_and_distill` never builds one, and it needs a session identity MCP does not
carry. `SessionState` mints its own, and using that is how one id came to cover 16
project paths and 3,739 commands in #118.

`make ci` green.

Refs #686




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR advertises the existing `omni_run` tool to MCP-only hosts and updates the tier’s runtime label and MCP-tool references.
- Adds `omni_run` to the MCP-only policy while retaining the reporter exclusions.
- Adds policy tests for hookless tiers, labels, and reporter scope.
- Updates the English and Indonesian MCP-tool documentation and changelog.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/mcp/policy.rs | Adds `omni_run` to the MCP-only tool set and introduces property-based coverage for the intended tier policy. |
| src/agents/mod.rs | Updates the MCP-only diagnostic label to distinguish `omni_run` distillation from rewriting host-owned tool output. |
| docs/website/src/reference/mcp-tools.md | Updates the English MCP tool table to list `omni_run` for MCP-only hosts. |
| docs/website/src-id/reference/mcp-tools.md | Updates the Indonesian MCP tool table consistently with the English reference. |
| changelog.d/686.changed.md | Documents the MCP-only capability change and its intentionally limited scope. |

</details>

<sub>Reviews (2): Last reviewed commit: ["feat(mcp): offer omni\_run on the one tie..."](https://github.com/fajarhide/omni/commit/ee31cc1269ee12faa19833b3e3878fed9e0f5637) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56040504)</sub>

<!-- /greptile_comment -->