### PR TITLE
docs: the tier table stops saying MCP-only hosts distil nothing

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ resolve. Hold the shortest window open while measuring with
 |---|---|---|
 | **Full** | Claude Code, Codex CLI, Gemini CLI, OpenClaw, Hermes, Pi, Aider (pipe) | The host applies OMNI's rewrite, so the model reads distilled output from its own built-in tools. |
 | **Handoff-first** | Cursor, Windsurf | The host cannot rewrite built-in tool output. `omni_run` distils anything you route through it, and `omni init --cursor` installs the rule that makes the agent reach for it. |
-| **MCP-only** | Cline, Roo, OpenCode, VS Code, Zed, Copilot, Antigravity | Memory, recall and session state. No shell distillation, and no claim of it. |
+| **MCP-only** | Cline, Roo, OpenCode, VS Code, Zed, Copilot, Antigravity | Memory, recall and session state, plus `omni_run`. The host's own tool output is never rewritten, so `omni_run` is the only path by which the model reads less. |
 
 `omni doctor` prints the tier for every installed host. Savings are only ever counted
 where the model actually received less.

--- a/changelog.d/687b.fixed.md
+++ b/changelog.d/687b.fixed.md
@@ -1,0 +1,12 @@
+**The tier table stopped saying MCP-only hosts distil nothing.** #686 put `omni_run`
+on that tier, so "Memory, recall and session state. No shell distillation, and no
+claim of it." became false in the README and in the manual's agents page, both
+languages.
+
+The row now says what is actually true there: memory, recall and session state plus
+`omni_run`, and the host's own tool output is never rewritten, which is why
+`omni_run` is the only path by which the model reads less.
+
+The sentence in `troubleshooting.md` was already precise enough to survive, because
+it says a Handoff-first or MCP-only host cannot rewrite its *built-in shell tool's*
+output. That is still exactly right.

--- a/docs/website/src-id/reference/agents.md
+++ b/docs/website/src-id/reference/agents.md
@@ -10,7 +10,7 @@ sebelum menilai apakah OMNI layak berada di sana.
 |---|---|---|
 | **Penuh** | Claude Code, Codex CLI, Gemini CLI, OpenClaw, Hermes, Pi, Aider (pipa) | Host menerapkan tulis ulang OMNI, jadi model membaca keluaran sulingan dari tool bawaannya sendiri. |
 | **Handoff dulu** | Cursor, Windsurf | Host tidak bisa menulis ulang keluaran tool bawaannya. `omni_run` menyuling apa pun yang dilewatkan melaluinya, dan `omni init --cursor` memasang aturan yang membuat agent meraihnya. |
-| **MCP saja** | Cline, Roo, OpenCode, VS Code, Zed, Copilot, Antigravity | Ingatan, pemanggilan kembali dan keadaan sesi. Tanpa penyulingan shell, dan tanpa klaim soal itu. |
+| **MCP saja** | Cline, Roo, OpenCode, VS Code, Zed, Copilot, Antigravity | Ingatan, pemanggilan kembali dan keadaan sesi, ditambah `omni_run`. Keluaran tool milik host tidak pernah ditulis ulang, jadi `omni_run` satu-satunya jalan agar model membaca lebih sedikit. |
 
 ```sh
 omni doctor     # mencetak tingkat untuk setiap host yang terpasang

--- a/docs/website/src/reference/agents.md
+++ b/docs/website/src/reference/agents.md
@@ -10,7 +10,7 @@ place.
 |---|---|---|
 | **Full** | Claude Code, Codex CLI, Gemini CLI, OpenClaw, Hermes, Pi, Aider (pipe) | The host applies OMNI's rewrite, so the model reads distilled output from its own built-in tools. |
 | **Handoff-first** | Cursor, Windsurf | The host cannot rewrite built-in tool output. `omni_run` distils anything routed through it, and `omni init --cursor` installs the rule that makes the agent reach for it. |
-| **MCP-only** | Cline, Roo, OpenCode, VS Code, Zed, Copilot, Antigravity | Memory, recall and session state. No shell distillation, and no claim of it. |
+| **MCP-only** | Cline, Roo, OpenCode, VS Code, Zed, Copilot, Antigravity | Memory, recall and session state, plus `omni_run`. The host's own tool output is never rewritten, so `omni_run` is the only path by which the model reads less. |
 
 ```sh
 omni doctor     # prints the tier for every installed host


### PR DESCRIPTION
Found by sweeping the manual after cutting 0.7.7, which is the third surface the
release rule names alongside Discord and the blog.

#686 put `omni_run` on the MCP-only tier. Three places still described that tier as
distilling nothing:

```
README.md
docs/website/src/reference/agents.md
docs/website/src-id/reference/agents.md

| **MCP-only** | ... | Memory, recall and session state. No shell distillation,
                       and no claim of it. |
```

That last clause was the honest part when it was written, and #686 made it false.
The row now says what is true there: memory, recall and session state plus
`omni_run`, and the host's own tool output is never rewritten, which is precisely
why `omni_run` is the only path by which the model reads less.

`use/troubleshooting.md` needed no change and is worth noting for the next sweep. It
says a Handoff-first or MCP-only host cannot rewrite its **built-in shell tool's**
output, which is still exactly right: `omni_run` is a separate tool, not a rewrite
of the host's.

`cargo test --test docs_match_the_code` green, 5 passed. `make ci` failed once on
`cargo audit` unable to reach the RustSec advisory database, which is network and
not this change; re-run on its own it exits 0.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR corrects the documented capabilities of MCP-only hosts after `omni_run` became available on that tier.
- Updates the English and Indonesian tier tables to distinguish `omni_run` distillation from rewriting host-owned tool output.
- Applies the same correction to the root README.
- Adds a changelog fragment explaining the documentation fix.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the revised documentation matches the implemented MCP-only tool set and distillation boundary.

The listed MCP-only hosts receive `omni_run`, while their built-in tool output remains outside OMNI’s rewrite path, so the updated wording accurately reflects current behavior.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | Correctly updates the MCP-only tier description to include `omni_run` while preserving the built-in-tool limitation. |
| docs/website/src/reference/agents.md | Keeps the English reference tier table consistent with the implemented MCP tool policy. |
| docs/website/src-id/reference/agents.md | Applies the equivalent capability correction to the Indonesian reference documentation. |
| changelog.d/687b.fixed.md | Accurately explains why the previous MCP-only tier wording became stale and what was corrected. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: the tier table stops saying MCP-on..."](https://github.com/fajarhide/omni/commit/de062a083424ae7acca4e38d149bc803b5d1bf65) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56105484)</sub>

<!-- /greptile_comment -->