### PR TITLE
refactor(format): one gate, two named questions

### DIFF
--- a/changelog.d/699.changed.md
+++ b/changelog.d/699.changed.md
@@ -1,0 +1,26 @@
+**One gate, two named questions.** `format::sniff` was asked the same thing at five
+call sites, and each decided for itself what a `Some` meant:
+
+```
+src/hooks/pipe.rs:130        passthrough on structured
+src/hooks/pipe.rs:355        ledger gate, pipe path
+src/hooks/post_tool.rs:317   the all-or-nothing decline
+src/hooks/post_tool.rs:425   ledger gate, fold_cross_turn
+src/hooks/post_tool.rs:793   ledger gate, Bash path
+```
+
+Three of those five were the same ledger decision written out three times, twice in
+one file. #452, #454 and #456 each fixed one copy of a duplicated predicate in this
+codebase and left the other standing.
+
+`refuses_lossy_stages` and `refuses_the_ledger` both answer `sniff(..).is_some()`
+today, so nothing changes: the suite passes without a snapshot moving. The point is
+that they are two questions rather than one. Folding a run of already-seen lines
+leaves a marker and a recoverable handle rather than rewriting content, which is why
+#608 proposes letting the ledger in where nothing downstream parses the payload
+while lossy stages stay refused. That decision now lands as a one-line edit to one
+function instead of three copies, one of which would be missed.
+
+A test forbids the gate shape returning to the hooks. Calling `sniff` for its
+`Structured` value is untouched and still happens, because the passthrough reason is
+built from it.

--- a/src/hooks/pipe.rs
+++ b/src/hooks/pipe.rs
@@ -127,7 +127,9 @@ pub fn run_inner<R: Read, W: Write, E: Write>(
     // Phase 2.5: Format-safe gate. Structured payloads are machine-read downstream
     // (`jq`, `json.load`, `kubectl apply`); collapse and the distillers would leave
     // them unparseable. Emit the input verbatim, byte for byte.
-    if let Some(kind) = crate::pipeline::format::sniff(&input_text) {
+    if crate::pipeline::format::refuses_lossy_stages(&input_text)
+        && let Some(kind) = crate::pipeline::format::sniff(&input_text)
+    {
         output.write_all(input_text.as_bytes())?;
         output.flush()?;
         if let Some(s) = &store {
@@ -352,7 +354,7 @@ fn distill(
     // which is a wall-clock stamp that covered 16 projects in one value (#118).
     // No forwarded id, no ledger, which is why the pre-hook now passes one.
     if let (Some(s), Some(scope)) = (store, host_session())
-        && crate::pipeline::format::sniff(&output).is_none()
+        && !crate::pipeline::format::refuses_the_ledger(&output)
         && let Some(view) = crate::ledger::Ledger::new(s, scope)
             .with_project(crate::paths::project_key(std::path::Path::new(
                 &project_path,

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -314,7 +314,13 @@ fn declined(normalized: &crate::hooks::normalize::NormalizedInput, store: Option
     // Format-safe gate: structured payloads are parsed by whatever reads them next,
     // so every lossy stage below, including the >2MB head/tail trim, would corrupt
     // them. Emit nothing: the host keeps the original bytes at zero marker cost.
-    if let Some(kind) = format::sniff(&normalized.content) {
+    // `refuses_lossy_stages`, not `sniff`, so the reason this declines is the
+    // question being asked rather than a classifier's return value. `kind` is
+    // still needed for the recorded reason, so the classifier is called for that
+    // and the gate is the predicate (#699).
+    if crate::pipeline::format::refuses_lossy_stages(&normalized.content)
+        && let Some(kind) = format::sniff(&normalized.content)
+    {
         if let Some(s) = store {
             s.record_passthrough(
                 &normalized.command,
@@ -422,7 +428,7 @@ fn fold_cross_turn(
         return (text, 0);
     };
     let scope = crate::ledger::scope_for(session, normalized.host_agent_id.as_deref());
-    if crate::pipeline::format::sniff(&text).is_some() {
+    if crate::pipeline::format::refuses_the_ledger(&text) {
         return (text, 0);
     }
     // The repository, not the directory this ran in: a worktree or a second
@@ -790,7 +796,7 @@ pub fn process_payload(
     let distilled_len = final_out.len();
 
     if let (Some(s), Some(session)) = (store.as_ref(), normalized.host_session_id.as_deref())
-        && crate::pipeline::format::sniff(&final_out).is_none()
+        && !crate::pipeline::format::refuses_the_ledger(&final_out)
         && let scope = crate::ledger::scope_for(session, normalized.host_agent_id.as_deref())
         && let Some(view) = crate::ledger::Ledger::new(s, &scope)
             .with_project(crate::paths::project_key(std::path::Path::new(

--- a/src/pipeline/format.rs
+++ b/src/pipeline/format.rs
@@ -57,6 +57,31 @@ pub fn passthrough_reason(kind: Structured) -> String {
     format!("structured:{}", kind)
 }
 
+/// Whether a lossy stage must decline this payload.
+///
+/// Distillers, collapse and the head/tail trim all rewrite content, and a
+/// structured payload is parsed by whatever reads it next, so any of them would
+/// corrupt it. Unsure means structured: a missed compression is cheap and a
+/// corrupted payload is not.
+pub fn refuses_lossy_stages(text: &str) -> bool {
+    sniff(text).is_some()
+}
+
+/// Whether the ledger must decline this payload.
+///
+/// Today the same answer as `refuses_lossy_stages`, and deliberately a separate
+/// function rather than a call to it. The two questions are not the same question:
+/// folding a run of already-seen lines leaves a marker and a recoverable handle
+/// rather than rewriting content, which is why #608 proposes letting the ledger in
+/// where nothing downstream parses the payload while lossy stages stay refused.
+///
+/// It exists now, before that decision, because the answer was written out at three
+/// separate call sites, twice in one file. #452, #454 and #456 each fixed one copy
+/// of a duplicated predicate in this codebase and left the other standing (#699).
+pub fn refuses_the_ledger(text: &str) -> bool {
+    sniff(text).is_some()
+}
+
 /// Classify `input`. `None` means plain text, safe to compress.
 pub fn sniff(input: &str) -> Option<Structured> {
     let trimmed = input.trim();
@@ -415,5 +440,69 @@ mod tests {
     fn reason_label_names_the_kind() {
         assert_eq!(passthrough_reason(Structured::Json), "structured:json");
         assert_eq!(passthrough_reason(Structured::Yaml), "structured:yaml");
+    }
+}
+
+#[cfg(test)]
+mod gate_is_named_once {
+    /// #699. `sniff` was asked the same question at five call sites, three of them
+    /// the same ledger decision written out three times, twice in one file. #452,
+    /// #454 and #456 each fixed one copy of a duplicated predicate here and left
+    /// the other standing, so the fix is to have the question exist once.
+    ///
+    /// This forbids the *gate* shape, `sniff(..).is_some()` or `.is_none()`, in the
+    /// hooks. Calling `sniff` for its `Structured` value is still fine and still
+    /// happens: the passthrough reason is built from it. What may not come back is
+    /// a site deciding for itself what a `Some` means, because #608 will change
+    /// that answer for one of the two questions and must not have to find copies.
+    #[test]
+    fn no_hook_decides_for_itself_what_structured_means() {
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/hooks");
+        let mut offenders = Vec::new();
+
+        let mut stack = vec![root.clone()];
+        while let Some(dir) = stack.pop() {
+            let Ok(entries) = std::fs::read_dir(&dir) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    stack.push(path);
+                    continue;
+                }
+                if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+                    continue;
+                }
+                let Ok(text) = std::fs::read_to_string(&path) else {
+                    continue;
+                };
+                for (n, line) in text.lines().enumerate() {
+                    let code = line.trim_start();
+                    if code.starts_with("//") {
+                        continue;
+                    }
+                    if !code.contains("sniff(") {
+                        continue;
+                    }
+                    if code.contains(".is_some()") || code.contains(".is_none()") {
+                        let rel = path
+                            .strip_prefix(&root)
+                            .unwrap_or(&path)
+                            .display()
+                            .to_string();
+                        offenders.push(format!("{rel}:{}: {}", n + 1, code));
+                    }
+                }
+            }
+        }
+
+        assert!(
+            offenders.is_empty(),
+            "a hook is deciding for itself what a structured payload means. Use \
+             `refuses_lossy_stages` or `refuses_the_ledger` so #608 changes one \
+             answer in one place (#699):\n{}",
+            offenders.join("\n")
+        );
     }
 }


### PR DESCRIPTION
`format::sniff` was asked the same thing at five call sites, and each decided for
itself what a `Some` meant:

```
src/hooks/pipe.rs:130        passthrough on structured
src/hooks/pipe.rs:355        ledger gate, pipe path
src/hooks/post_tool.rs:317   the all-or-nothing decline
src/hooks/post_tool.rs:425   ledger gate, fold_cross_turn
src/hooks/post_tool.rs:793   ledger gate, Bash path
```

**Three of those five were the same ledger decision, written out three times, twice
in one file.** #452, #454 and #456 each fixed one copy of a duplicated predicate in
this codebase and left the other standing. #608 spotted two of these and called it
"exactly the two-copies-of-one-predicate shape"; it is five.

`refuses_lossy_stages` and `refuses_the_ledger` both answer `sniff(..).is_some()`
today, so **nothing changes**: the full suite passes without a snapshot moving, which
is the only interesting result a rename can have.

The point is that they are two questions. Folding a run of already-seen lines leaves
a marker and a recoverable handle rather than rewriting content, which is why #608
proposes letting the ledger in where nothing downstream parses the payload while
lossy stages stay refused. After this, that decision is a one-line edit to one
function rather than three copies with one missed.

`refuses_the_ledger` deliberately does not call `refuses_lossy_stages`. Delegating
would save a line and rebuild exactly the coupling this removes.

**The guard.** A test forbids the gate shape, `sniff(..).is_some()` or `.is_none()`,
from returning to `src/hooks`. Calling `sniff` for its `Structured` value is
untouched and still happens at two sites, because the passthrough reason is built
from it, so the test targets the shape rather than the symbol. Driven red twice, by
restoring each of two gates, each failure naming the file and line.

Out of scope, on purpose: what the gate answers. That is #608's decision and this
must not pre-empt it.

`make ci` green.

Closes #699


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR separates structured-format policy into named predicates for lossy pipeline stages and ledger folding while preserving existing behavior.
- Replaces duplicated inline `sniff(...).is_some()` and `.is_none()` gates in pipe and post-tool processing.
- Adds `refuses_lossy_stages` and `refuses_the_ledger` as independently evolvable policy functions.
- Adds a source-scanning regression test to discourage hooks from reintroducing inline gate decisions.
- Documents the refactor in the changelog.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the refactor preserves every existing structured-payload decision while centralizing the two distinct policy questions.

Each replaced condition is logically equivalent to its new predicate, and the remaining direct `sniff` calls only obtain the structured kind used in passthrough diagnostics.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/pipeline/format.rs | Adds two behaviorally equivalent named policy predicates and a regression test preventing hook code from duplicating the underlying gate shape. |
| src/hooks/pipe.rs | Replaces direct structured-format checks with the appropriate named lossy-stage and ledger predicates without changing branch behavior. |
| src/hooks/post_tool.rs | Routes structured-payload decline and three ledger decisions through their corresponding named predicates while retaining classification for passthrough diagnostics. |
| changelog.d/699.changed.md | Accurately explains the predicate deduplication, unchanged current behavior, and intended separation of future policy decisions. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Hook payload] --> B{Which policy question?}
    B -->|Lossy stage| C[refuses_lossy_stages]
    B -->|Ledger fold| D[refuses_the_ledger]
    C --> E[sniff payload]
    D --> E
    E --> F{Structured?}
    F -->|Yes| G[Decline stage]
    F -->|No| H[Continue processing]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(format): one gate, two named qu..."](https://github.com/fajarhide/omni/commit/5925b074dc13e1102bfb2b9fa721d708caa76086) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56119860)</sub>

<!-- /greptile_comment -->