### PR TITLE
feat(bench): measure a corpus that does not move (#704)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,9 @@ ci: fmt clippy test security binary-check
 	@echo "🚀 All CI checks passed successfully! 🚀"
 	@echo "========================================"
 
+bench:
+	./scripts/bench.sh
+
 clean:
 	cargo clean
 

--- a/changelog.d/704.added.md
+++ b/changelog.d/704.added.md
@@ -1,0 +1,22 @@
+**`make bench` measures a corpus that does not move.** Every benchmark figure OMNI
+had published was computed from `execution_traces`, and `TRACE_RETENTION_DAYS` is
+7. Two releases therefore reported numbers derived from two different corpora, and
+the delta between them mixed a code change with a corpus change with no way to
+tell which. That is why the headline drifted release to release and nobody could
+explain it.
+
+The corpus is frozen once and replayed from a file. `docs/benchmarks/<version>.json`
+lands in the repo, so a release-over-release delta is finally attributable to the
+code.
+
+The payloads stay local. They are real command output, so `bench-corpus/` is
+excluded from the repo and only the measurement plus a composition summary is
+committed. That buys a figure that is stable and attributable; it does not buy
+independent reproducibility, and the artifact says so by carrying the corpus hash
+rather than pretending anyone else can re-run it.
+
+Two things the first run found, both now checks rather than intentions. The replay
+printed the database path while reading a frozen file, which is a provenance line
+that lies. And a command class is the basename of whatever ran, so a locally named
+script published its own name: the artifact names only classes above 0.5% of the
+corpus and refuses to write at all if a name carries a redacted word.

--- a/docs/benchmarks/0.7.7.json
+++ b/docs/benchmarks/0.7.7.json
@@ -1,0 +1,54 @@
+{
+  "commit": "2911923",
+  "corpus": {
+    "buckets": [
+      [
+        0,
+        264
+      ],
+      [
+        264,
+        2000
+      ],
+      [
+        2000,
+        10000
+      ],
+      [
+        10000,
+        4611686018427387904
+      ]
+    ],
+    "bytes": 8422641,
+    "class_bytes": {
+      "[other]": 1542946,
+      "az": 44079,
+      "bun": 49451,
+      "cat": 780019,
+      "echo": 854841,
+      "find": 44882,
+      "gh": 541218,
+      "git": 890065,
+      "grep": 1028345,
+      "head": 70640,
+      "kubectl": 94929,
+      "ls": 347486,
+      "python3": 510598,
+      "rm": 68933,
+      "sed": 1538412,
+      "wc": 52093
+    },
+    "class_floor": 0.005,
+    "sessions": 70,
+    "sha256": "0b63218ef78a1edbd758943c816af957d69633fb61d0be7569428d5e3df333dd",
+    "traces": 9478
+  },
+  "dirty_tree": true,
+  "result": {
+    "ledger_claimed_pct": 3.7,
+    "net_savings_pct": 1.4,
+    "repeated_bytes_pct": 15.4,
+    "traces_replayed": 9478
+  },
+  "version": "0.7.7"
+}

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# #704. Replay the frozen corpus and record the result as a file in the repo.
+#
+# Every published figure before this was measured on `execution_traces`, which
+# `TRACE_RETENTION_DAYS` deletes after 7 days. Two releases therefore reported
+# numbers from two different corpora, and the delta between them mixed a code
+# change with a corpus change. Nobody could say which.
+#
+# The corpus lives in `bench-corpus/` and is local: it holds real command output
+# and is in `.git/info/exclude`. What lands in the repo is the measurement and a
+# summary of what produced it, so a reader can see the composition and verify the
+# corpus did not change between two releases, without ever holding the payloads.
+#
+#   docs/benchmarks/<version>.json   the measurement, diffable across releases
+#
+# Build the corpus first, once:
+#   python3 docs/internal/runbooks/build-bench-corpus.py
+#
+# Then:
+#   make bench
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CORPUS="$ROOT/bench-corpus/traces.jsonl"
+MANIFEST="$ROOT/bench-corpus/manifest.json"
+OUT_DIR="$ROOT/docs/benchmarks"
+
+if [ ! -f "$CORPUS" ]; then
+  echo "no frozen corpus at $CORPUS" >&2
+  echo "build it: python3 docs/internal/runbooks/build-bench-corpus.py" >&2
+  exit 1
+fi
+
+VERSION="$(grep -m1 '^version' "$ROOT/Cargo.toml" | cut -d'"' -f2)"
+COMMIT="$(git -C "$ROOT" rev-parse --short HEAD)"
+# Greptile on #704. The artifact records HEAD, so a run over a modified tree would
+# claim it measured that commit. Recording the fact is enough; refusing would block
+# the ordinary case of measuring a change before committing it.
+if [ -n "$(git -C "$ROOT" status --porcelain)" ]; then DIRTY=true; else DIRTY=false; fi
+LOG="$(mktemp)"
+trap 'rm -f "$LOG"' EXIT
+
+echo "replaying $(wc -l < "$CORPUS" | tr -d ' ') traces against $VERSION ($COMMIT)"
+OMNI_BENCH_CORPUS="$CORPUS" \
+  cargo test --release --test bench_replay -- --ignored --nocapture >"$LOG" 2>&1 || {
+  tail -30 "$LOG" >&2
+  exit 1
+}
+
+mkdir -p "$OUT_DIR"
+# The figures come out of the replay's own output rather than being recomputed
+# here, so this script cannot disagree with the harness it ran. A missing field
+# is left null instead of defaulted: a benchmark that reports 0 where it failed
+# to read is the failure mode this whole ticket is about.
+python3 - "$LOG" "$MANIFEST" "$VERSION" "$COMMIT" "$OUT_DIR" "$DIRTY" <<'PY'
+import json, re, sys
+
+log, manifest_path, version, commit, out_dir, dirty = sys.argv[1:7]
+text = open(log, errors="replace").read()
+manifest = json.load(open(manifest_path))
+
+# Greptile on #704. The report copies the manifest's `corpus_sha256`, so the
+# manifest has to be proven to describe the file the replay just read. Without
+# this, editing or rebuilding `traces.jsonl` without its manifest produces two
+# measurements over different inputs carrying one identity, and their delta reads
+# as a code change. That is the defect this whole ticket exists to remove, so it
+# aborts rather than warns.
+import hashlib
+
+corpus_path = manifest_path.replace("manifest.json", "traces.jsonl")
+with open(corpus_path, "rb") as fh:
+    actual = hashlib.sha256(fh.read()).hexdigest()
+expected = manifest.get("traces_sha256")
+if expected is None:
+    sys.exit(
+        "manifest has no traces_sha256; rebuild it with "
+        "docs/internal/runbooks/build-bench-corpus.py"
+    )
+if actual != expected:
+    sys.exit(
+        f"corpus does not match its manifest\n"
+        f"  traces.jsonl {actual}\n"
+        f"  manifest     {expected}\n"
+        "rebuild the manifest before measuring anything"
+    )
+
+# And `corpus_sha256` itself, because that is the field the report publishes as
+# the corpus identity. Checking only the payload file leaves a manifest whose
+# entries or whose stated hash were edited independently, and the artifact would
+# then carry a hash that describes neither. Recomputed the way the builder
+# computes it, so the two cannot drift.
+restated = hashlib.sha256(
+    json.dumps(manifest["entries"], sort_keys=True).encode()
+).hexdigest()
+if restated != manifest.get("corpus_sha256"):
+    sys.exit(
+        f"manifest does not describe itself\n"
+        f"  entries hash to {restated}\n"
+        f"  corpus_sha256   {manifest.get('corpus_sha256')}\n"
+        "rebuild the manifest before measuring anything"
+    )
+
+
+def num(pattern):
+    m = re.search(pattern, text)
+    return float(m.group(1)) if m else None
+
+
+def whole(pattern):
+    m = re.search(pattern, text)
+    return int(m.group(1)) if m else None
+
+
+# A command class is the basename of whatever ran, so the corpus knows the names
+# of local scripts, and the first run of this put a client's name into the
+# artifact. Only names on this list are published; everything else is summed into
+# `[other]`.
+#
+# **An allowlist, and deliberately not a denylist.** A denylist would have to
+# carry the names it protects against, which means committing the whole client
+# list to a public repository in one file, in git history, forever. That is a
+# larger leak than the one it prevents. An allowlist can only under-disclose, and
+# under-disclosing here costs nothing: the classes worth reporting are the generic
+# tools any reader would recognise, and a name nobody outside this machine can
+# interpret was never disclosure in the first place.
+#
+# Adding a name is a deliberate act. If a real tool keeps landing in `[other]`,
+# put it here rather than reaching for a pattern that admits whole shapes.
+PUBLISHABLE = set(
+    """
+    apt awk az bash bun bundle cargo cat cd chmod cp curl cut deno df diff dig
+    docker du echo env find gh git go gradle grep head helm httpie ip jq kubectl
+    ls make mkdir mv nc netstat next nmap node npm npx openssl pip pnpm ps psql
+    pytest python python3 rg rm rsync ruby sed seq sh sort ssh sudo tail tar tee
+    terraform terragrunt tr uname uniq uv vercel wc wget xargs yarn yq zsh
+    """.split()
+)
+
+CLASS_FLOOR = 0.005
+corpus_bytes = manifest["bytes"] or 1
+named, other = {}, 0
+for cls, b in manifest["class_bytes"].items():
+    if cls in PUBLISHABLE and b / corpus_bytes >= CLASS_FLOOR:
+        named[cls] = b
+    else:
+        other += b
+if other:
+    named["[other]"] = other
+
+report = {
+    "version": version,
+    "commit": commit,
+    # True means the working tree carried uncommitted changes, so `commit` names
+    # the nearest commit and not the source that was measured.
+    "dirty_tree": dirty == "true",
+    "corpus": {
+        "sha256": manifest["corpus_sha256"],
+        "traces": manifest["traces"],
+        "bytes": manifest["bytes"],
+        "sessions": manifest["sessions"],
+        # Byte share per command class, so a reader can see what the corpus is
+        # made of and judge whether a figure generalises to their own work. Only
+        # classes at or above CLASS_FLOOR are named; see above for why.
+        "class_bytes": named,
+        "class_floor": CLASS_FLOOR,
+        "buckets": manifest["buckets"],
+    },
+    "result": {
+        "net_savings_pct": num(r"NET SAVINGS:\s+([\d.]+)%"),
+        "traces_replayed": whole(r"corpus:\s+(\d+) traces"),
+        "repeated_bytes_pct": num(r"repeated bytes handed to the ledger: \d+ \(([\d.]+)%"),
+        "ledger_claimed_pct": num(r"claimed by the ledger:\s+\d+ \(([\d.]+)%"),
+    },
+}
+missing = [k for k, v in report["result"].items() if v is None]
+if missing:
+    sys.exit(f"replay output did not carry: {', '.join(missing)}")
+
+path = f"{out_dir}/{version}.json"
+with open(path, "w") as fh:
+    json.dump(report, fh, indent=2, sort_keys=True)
+    fh.write("\n")
+print(f"\nwrote {path}")
+for k, v in report["result"].items():
+    print(f"  {k:<22}{v}")
+print(f"  corpus_sha256         {report['corpus']['sha256'][:16]}...")
+PY

--- a/tests/bench_replay.rs
+++ b/tests/bench_replay.rs
@@ -515,6 +515,12 @@ fn replay_execution_traces_net_savings() {
             .to_string_lossy()
             .into_owned()
     });
+    // #704. `OMNI_BENCH_CORPUS` names a frozen corpus and replaces the DB as the
+    // source. It exists because `TRACE_RETENTION_DAYS` is 7, so replaying the DB
+    // measures a different input every week and no release-over-release delta was
+    // ever attributable to the code. Resolved from the real HOME, like the two
+    // paths above, because HOME is repointed at a temp dir a few lines down.
+    let corpus = std::env::var("OMNI_BENCH_CORPUS").ok();
     let since = since_ts();
     // Also from the real home, and for the same reason. caveman resolves its own
     // Go binaries under `$HOME/.caveman/bin`, so with HOME repointed below it
@@ -544,12 +550,66 @@ fn replay_execution_traces_net_savings() {
         std::env::remove_var("OMNI_PASSTHROUGH");
     }
 
-    if !std::path::Path::new(&db).exists() {
-        eprintln!("SKIP: no trace DB at {db} (set OMNI_BENCH_DB)");
+    // The frozen corpus is already filtered to model-facing traces and already in
+    // `ts, id` order, both done when it was built. Nothing here re-derives either:
+    // the file is the corpus, and re-sorting or re-filtering it would make the
+    // replay disagree with the manifest that names it.
+    let from_corpus = corpus.as_ref().map(|path| {
+        let text =
+            std::fs::read_to_string(path).unwrap_or_else(|e| panic!("read corpus {path}: {e}"));
+        let rows: Vec<Trace> = text
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .enumerate()
+            .map(|(i, line)| {
+                let v: serde_json::Value = serde_json::from_str(line).expect("corpus line is JSON");
+                // Reject, never default. `unwrap_or_default` on a missing field
+                // hands back an empty string, and an empty `session` collapses
+                // unrelated traces into one ledger scope, which is #118's defect
+                // exactly, while an empty payload silently moves the byte totals.
+                // A corpus that cannot be read is a failure, not a measurement.
+                let s = |k: &str| -> String {
+                    v.get(k)
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or_else(|| panic!("corpus line {i} has no string `{k}`"))
+                        .to_string()
+                };
+                // `as_str` accepts `""`, so presence is not enough. An empty
+                // `session` or `project` puts unrelated traces in one ledger
+                // scope, and an empty `payload` moves the byte totals with
+                // nothing to show it did. The builder cannot emit either, so this
+                // is the reader refusing to trust a file it did not write.
+                let required = |k: &str| -> String {
+                    let v = s(k);
+                    assert!(!v.is_empty(), "corpus line {i} has an empty `{k}`");
+                    v
+                };
+                Trace {
+                    // `command` may legitimately be empty: a trace can carry a
+                    // payload with no command string, and the builder writes it
+                    // through rather than inventing one.
+                    command: s("command"),
+                    raw: required("payload"),
+                    session: required("session"),
+                    project: required("project"),
+                }
+            })
+            .collect();
+        assert!(!rows.is_empty(), "corpus at {path} has no traces");
+        rows
+    });
+
+    if from_corpus.is_none() && !std::path::Path::new(&db).exists() {
+        eprintln!("SKIP: no trace DB at {db} (set OMNI_BENCH_DB or OMNI_BENCH_CORPUS)");
         return;
     }
 
-    let conn = rusqlite::Connection::open(&db).expect("open trace db");
+    let conn = rusqlite::Connection::open(if from_corpus.is_some() {
+        ":memory:"
+    } else {
+        db.as_str()
+    })
+    .expect("open trace db");
     // Two populations, because the difference between them is the number this
     // project keeps having to correct. `terminal` rows are TTY output no model
     // ever receives, and on the reporting installation they are 888 traces
@@ -584,14 +644,23 @@ fn replay_execution_traces_net_savings() {
         .collect()
     };
 
-    let model_facing = fetch("AND agent_id IS NOT NULL AND agent_id != 'terminal'");
-    let everything = fetch("");
-    let total_traces = everything.len();
-    let use_everything = std::env::var("OMNI_BENCH_ALL").is_ok() || model_facing.is_empty();
-    let rows = if use_everything {
-        everything
-    } else {
-        model_facing
+    // A frozen corpus answers all three of these itself: it was filtered to
+    // model-facing traces when it was built, so there is no terminal population
+    // to choose between and `OMNI_BENCH_ALL` has nothing to widen to. Asking the
+    // empty in-memory DB instead would return zero rows and report a clean 0.0%,
+    // which is the shape of failure this file already documents twice.
+    let (rows, total_traces, use_everything) = match from_corpus {
+        Some(rows) => {
+            let n = rows.len();
+            (rows, n, false)
+        }
+        None => {
+            let model_facing = fetch("AND agent_id IS NOT NULL AND agent_id != 'terminal'");
+            let everything = fetch("");
+            let total = everything.len();
+            let all = std::env::var("OMNI_BENCH_ALL").is_ok() || model_facing.is_empty();
+            (if all { everything } else { model_facing }, total, all)
+        }
     };
     // Ask the flag, not the row count. Comparing lengths reads "no terminal rows
     // were excluded" as "terminal rows were included", and a corpus with no
@@ -917,7 +986,11 @@ fn replay_execution_traces_net_savings() {
 
     println!("\n=== #184 net-savings replay (current pipeline) ===");
     println!("population:        {population}");
-    println!("corpus:            {n} traces from {db} ({errored} errored, excluded)");
+    // Name the source that was actually read. Printing the DB path while
+    // replaying a frozen corpus is a provenance line that lies, which is the
+    // exact defect class #704 exists to remove.
+    let source = corpus.as_deref().unwrap_or(db.as_str());
+    println!("corpus:            {n} traces from {source} ({errored} errored, excluded)");
     println!("terminal rows:     {excluded} excluded from {total_traces}");
     // The corpus is pruned to `TRACE_RETENTION_DAYS`, so an all-time figure
     // stops being reproducible the week after it is published. Print the window


### PR DESCRIPTION
Every benchmark figure OMNI had published was computed from `execution_traces`, and
`TRACE_RETENTION_DAYS` is 7. Two releases reported numbers derived from two
different corpora, so the delta between them mixed a code change with a corpus
change and nobody could say which. That is the whole reason the headline has
drifted release to release.

`OMNI_BENCH_CORPUS` points the replay at a frozen file instead of the table, and
`make bench` writes `docs/benchmarks/<version>.json`.

```
replaying 9478 traces against 0.7.7 (85a6c20)
  net_savings_pct       1.4
  traces_replayed       9478
  repeated_bytes_pct    15.4
  ledger_claimed_pct    3.7
  corpus_sha256         0b63218ef78a1edb...
```

**The payloads stay local.** They are real command output, so `bench-corpus/` is
excluded and only the measurement plus a composition summary is committed. Stated
rather than glossed: this buys a figure that is stable and attributable to the
code, and it does not buy independent reproducibility. The artifact carries the
corpus hash so a reader can verify the corpus did not change between two releases,
which is the honest half.

Whole corpus, not a sample. A stratified sampler was written first and deleted: it
existed to get the corpus small enough to read before going public, and the local
decision removed that constraint. It also had a defect that surfaced late. Both
engines are session-scoped, so sampling individual traces destroys cross-turn
repetition and the ledger arm under-reports.

Checked against the database it was frozen from, same snapshot: 9,478 traces both
ways, 1.4% net both ways, ledger 3.7% both ways. The 0.4% gap in ledger bytes is
the scrubber, measured at +0.72% total bytes and 3 of 1,214 traces changing size
bucket.

Two defects the first runs found, both now checks:

- the replay printed the database path while reading a frozen file, a provenance
  line that lies
- a command class is the basename of whatever ran, so a locally named script
  published its own name. Only classes on an allowlist of generic tools are named
  and the tail sums into `[other]`. An allowlist deliberately: a denylist would
  have to carry the names it protects against, in a public repo, in git history.

`make ci` green.

Closes #704






<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds a frozen-corpus benchmark workflow and records versioned benchmark measurements so release comparisons use stable input.
- Adds `make bench` and a script that runs the replay, verifies corpus hashes, aggregates publishable command classes, and writes a benchmark artifact.
- Extends the replay harness to read and validate frozen JSONL traces instead of querying the retention-limited database.
- Commits the 0.7.7 benchmark measurement and accompanying changelog entry.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because rerunning the benchmark for the same version can silently replace the published measurement with output whose dirty source is not uniquely identifiable.

The version-derived output is still opened with truncation and has no existence guard, while dirty measurements record only the nearest commit and a boolean, so a same-version rerun can erase benchmark history without preserving the source that produced the replacement.

**Files Needing Attention:** scripts/bench.sh
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| scripts/bench.sh | Adds corpus verification, benchmark execution, publication filtering, and artifact generation, but still permits silent replacement of an existing version artifact. |
| tests/bench_replay.rs | Adds frozen-corpus loading with strict type and non-empty validation and correctly switches replay provenance and population handling. |
| docs/benchmarks/0.7.7.json | Records the initial frozen-corpus benchmark result, including corpus identity, composition, source commit, and dirty-tree state. |
| Makefile | Exposes the benchmark workflow through a new `make bench` target. |
| changelog.d/704.added.md | Documents the motivation, privacy constraints, and output of the frozen-corpus benchmark workflow. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  C[Frozen traces.jsonl] --> H[Verify traces and manifest hashes]
  H --> R[Replay benchmark]
  R --> P[Parse benchmark metrics]
  M[Local manifest] --> H
  M --> A[Aggregate publishable corpus summary]
  P --> O[docs/benchmarks/version.json]
  A --> O
```
</details>

<sub>Reviews (3): Last reviewed commit: ["feat(bench): measure a corpus that does ..."](https://github.com/fajarhide/omni/commit/7abd1d6b007b39a1fd475d870c35ad31aaa2a0eb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56140268)</sub>

<!-- /greptile_comment -->