### PR TITLE
feat(bench): report capture rate against the repetition ceiling (#708)

### DIFF
--- a/changelog.d/708.changed.md
+++ b/changelog.d/708.changed.md
@@ -1,0 +1,37 @@
+**The benchmark reports what share of the available repetition OMNI captures, not
+only what share of bytes it removed.** #704 stopped a figure moving when the code
+changed. It did nothing about a figure moving when the *workload* changed, and that
+turned out to be the larger source of the drift.
+
+Replaying the frozen corpus against the table in the README, four of six classes
+reproduce and two do not. One of the two is the hero line: file reads read 89.6%
+saved on the corpus that number was taken from, and 4.5% here. Not a regression.
+That corpus averaged 12.4 KB per file read against 2.1 KB here, the same large
+files read again and again, so both numbers are true of their own week.
+
+That is the problem with the metric rather than with either number. "89.6% off file
+reads" reads as a property of OMNI and is a property of one week's work.
+
+Two columns per class now, and the second is the one that holds still:
+
+```
+class              calls        input    filters   + ledger  available  captured
+file read           1056      1891398       0.0%       4.5%      17.7%     25.3%
+git                  899       858631       5.1%       8.8%      18.4%     20.8%
+search               810       765443       3.4%       4.2%       6.5%     13.7%
+aggregate           9478      8486830       1.4%       5.1%      15.6%     24.1%
+```
+
+`available` is the share of bytes whose line had already been delivered in that
+scope, which is the ceiling: the ledger cannot fold what was never repeated.
+`captured` is what it took of that ceiling. Savings swing about twentyfold across
+these two corpora; capture stays between 10.5% and 25.3%.
+
+Computed inside the replay with the replay's own class definition, on purpose. A
+first estimate using a separate script put the ceiling at 6.3% and capture at 71%,
+against 17.7% and 25.3% measured properly, because the two classifiers disagreed
+about which traces were file reads. Two numbers from two classifiers is the
+mistake, and the fix is one classifier rather than a footnote.
+
+A ledger that claims more bytes than were repeated has a broken denominator, so
+that is asserted rather than printed.

--- a/docs/benchmarks/0.7.7.json
+++ b/docs/benchmarks/0.7.7.json
@@ -1,5 +1,5 @@
 {
-  "commit": "2911923",
+  "commit": "ae5b0a9",
   "corpus": {
     "buckets": [
       [
@@ -45,6 +45,64 @@
   },
   "dirty_tree": true,
   "result": {
+    "by_class": {
+      "aggregate": {
+        "calls": 9478,
+        "capture_rate_pct": 24.1,
+        "filters_pct": 1.4,
+        "input_bytes": 8486830,
+        "repetition_available_pct": 15.6,
+        "with_ledger_pct": 5.1
+      },
+      "build and test": {
+        "calls": 41,
+        "capture_rate_pct": 10.8,
+        "filters_pct": 9.0,
+        "input_bytes": 20778,
+        "repetition_available_pct": 21.7,
+        "with_ledger_pct": 11.1
+      },
+      "file read": {
+        "calls": 1056,
+        "capture_rate_pct": 25.3,
+        "filters_pct": 0.0,
+        "input_bytes": 1891398,
+        "repetition_available_pct": 17.7,
+        "with_ledger_pct": 4.5
+      },
+      "git": {
+        "calls": 899,
+        "capture_rate_pct": 20.8,
+        "filters_pct": 5.1,
+        "input_bytes": 858631,
+        "repetition_available_pct": 18.4,
+        "with_ledger_pct": 8.8
+      },
+      "infra": {
+        "calls": 215,
+        "capture_rate_pct": 10.5,
+        "filters_pct": 3.2,
+        "input_bytes": 135669,
+        "repetition_available_pct": 5.5,
+        "with_ledger_pct": 3.8
+      },
+      "other": {
+        "calls": 6457,
+        "capture_rate_pct": 25.1,
+        "filters_pct": 0.8,
+        "input_bytes": 4814911,
+        "repetition_available_pct": 15.9,
+        "with_ledger_pct": 4.8
+      },
+      "search": {
+        "calls": 810,
+        "capture_rate_pct": 13.7,
+        "filters_pct": 3.4,
+        "input_bytes": 765443,
+        "repetition_available_pct": 6.5,
+        "with_ledger_pct": 4.2
+      }
+    },
     "ledger_claimed_pct": 3.7,
     "net_savings_pct": 1.4,
     "repeated_bytes_pct": 15.4,

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -111,6 +111,40 @@ def whole(pattern):
     return int(m.group(1)) if m else None
 
 
+def by_class():
+    """The per-class table the replay prints, parsed rather than recomputed.
+
+    Class names come from `trace_class` in the harness, which is a fixed set of
+    generic buckets (`file read`, `search`, `git`, `infra`, `build and test`,
+    `other`), so unlike command classes they carry nothing local and need no
+    allowlist. Rows are read by shape; a table that stops printing a column shows
+    up as an empty dict and fails the missing-field check below.
+    """
+    block = re.search(
+        r"by command class.*?\n(.*?)\nledger arm:", text, re.S
+    )
+    if not block:
+        return {}
+    out = {}
+    for line in block.group(1).splitlines():
+        m = re.match(
+            r"^(\S.*?)\s{2,}(\d+)\s+(\d+)\s+([\d.]+)%\s+([\d.]+)%"
+            r"\s+([\d.]+)%\s+([\d.]+)%",
+            line,
+        )
+        if not m:
+            continue
+        out[m.group(1).strip()] = {
+            "calls": int(m.group(2)),
+            "input_bytes": int(m.group(3)),
+            "filters_pct": float(m.group(4)),
+            "with_ledger_pct": float(m.group(5)),
+            "repetition_available_pct": float(m.group(6)),
+            "capture_rate_pct": float(m.group(7)),
+        }
+    return out
+
+
 # A command class is the basename of whatever ran, so the corpus knows the names
 # of local scripts, and the first run of this put a client's name into the
 # artifact. Only names on this list are published; everything else is summed into
@@ -170,9 +204,15 @@ report = {
         "traces_replayed": whole(r"corpus:\s+(\d+) traces"),
         "repeated_bytes_pct": num(r"repeated bytes handed to the ledger: \d+ \(([\d.]+)%"),
         "ledger_claimed_pct": num(r"claimed by the ledger:\s+\d+ \(([\d.]+)%"),
+        # #708. Per class, and `captured` is the one that does not move with the
+        # workload: on this corpus file reads save 4.5% where a week of large
+        # repeated reads read 89.6%, while the share of available repetition the
+        # ledger takes stays in a narrow band. A savings percentage describes the
+        # week; this describes OMNI.
+        "by_class": by_class(),
     },
 }
-missing = [k for k, v in report["result"].items() if v is None]
+missing = [k for k, v in report["result"].items() if v is None or v == {}]
 if missing:
     sys.exit(f"replay output did not carry: {', '.join(missing)}")
 

--- a/tests/bench_replay.rs
+++ b/tests/bench_replay.rs
@@ -752,7 +752,12 @@ fn replay_execution_traces_net_savings() {
     // shell shape -> (calls, raw_bytes, out_bytes), the P2 gate
     let mut per_form: BTreeMap<&'static str, (u64, u64, u64)> = BTreeMap::new();
     // command class -> (calls, raw, after filters, after ledger), the P1 gate
-    let mut per_class: BTreeMap<&'static str, (u64, u64, u64, u64)> = BTreeMap::new();
+    // (calls, raw, post-filter, post-ledger, repeated bytes available, accounted).
+    // The last two are the ceiling #708 reports against: the ledger cannot fold a
+    // line that was never delivered before, so a savings percentage swings with how
+    // repetitive the week was while the ratio against the ceiling does not.
+    type ClassRow = (u64, u64, u64, u64, u64, u64);
+    let mut per_class: BTreeMap<&'static str, ClassRow> = BTreeMap::new();
     let started = std::time::Instant::now();
 
     for t in &rows {
@@ -815,6 +820,17 @@ fn replay_execution_traces_net_savings() {
         {
             let lines = gap_seen.account(t, &distilled);
             let repeated: u64 = lines.iter().filter(|(s, _)| *s).map(|(_, l)| l).sum();
+            // #708's ceiling, accumulated here rather than in a second pass so it
+            // uses `GapSeen`'s keys and `trace_class`'s definition, the same two
+            // the columns beside it use. Measuring the ceiling with a separate
+            // classifier is how 4.5% and 6.3% ended up describing populations of
+            // 1,056 and 672 traces and being divided anyway.
+            {
+                let accounted: u64 = lines.iter().map(|(_, l)| l).sum();
+                let c = per_class.entry(trace_class(&t.command)).or_default();
+                c.4 += repeated;
+                c.5 += accounted;
+            }
             if omni::pipeline::format::sniff(&distilled).is_some() {
                 gap_structured += repeated;
                 n_structured += 1;
@@ -1064,22 +1080,50 @@ fn replay_execution_traces_net_savings() {
     // the second one adds on top of the first.
     println!("\n--- by command class, filters then ledger (the P1 gate) ---");
     println!(
-        "{:<16} {:>7} {:>12} {:>10} {:>10}",
-        "class", "calls", "input", "filters", "+ ledger"
+        "{:<16} {:>7} {:>12} {:>10} {:>10} {:>10} {:>9}",
+        "class", "calls", "input", "filters", "+ ledger", "available", "captured"
     );
+    // `available` is the share of accounted bytes whose line had already been
+    // delivered in that scope, and `captured` is what the ledger took of it.
+    // `captured` is the figure that does not move with the workload, which is the
+    // whole of #708: on this corpus file reads read 4.5% saved against 89.6% in a
+    // week of large repeated reads, while the ratio against the ceiling holds.
+    let ratio = |part: u64, whole: u64| 100.0 * part as f64 / whole.max(1) as f64;
     let mut classes: Vec<_> = per_class.into_iter().collect();
     classes.sort_by_key(|(_, v)| std::cmp::Reverse(v.1));
-    for (class, (calls, r, f, l)) in classes {
+    let (mut avail_total, mut acct_total) = (0u64, 0u64);
+    for (class, (calls, r, f, l, avail, acct)) in classes {
+        avail_total += avail;
+        acct_total += acct;
+        // The ledger only ever substitutes lines it has already delivered, so it
+        // cannot remove more bytes than were repeated. Claiming more means the
+        // two are measured over different populations, which is the defect that
+        // produced a 71% estimate where the answer was 25%. Asserted rather than
+        // printed: a capture rate over 100% is not a surprising number, it is a
+        // broken denominator, and nothing else in this file would catch it.
+        assert!(
+            f.saturating_sub(l) <= avail,
+            "{class}: ledger claimed {} bytes but only {avail} were repeated",
+            f.saturating_sub(l)
+        );
+        // The ledger runs after the filters, so its claim is `f - l`, and the
+        // denominator is the class's own repeated bytes rather than its input:
+        // what was actually foldable, not what happened to arrive.
+        let captured = ratio(f.saturating_sub(l), avail);
         println!(
-            "{class:<16} {calls:>7} {r:>12} {:>9.1}% {:>9.1}%",
+            "{class:<16} {calls:>7} {r:>12} {:>9.1}% {:>9.1}% {:>9.1}% {:>8.1}%",
             saved(r, f),
-            saved(r, l)
+            saved(r, l),
+            ratio(avail, acct),
+            captured
         );
     }
     println!(
-        "aggregate        {n:>7} {raw_total:>12} {:>9.1}% {:>9.1}%  ({ledger_calls} calls projected)",
+        "aggregate        {n:>7} {raw_total:>12} {:>9.1}% {:>9.1}% {:>9.1}% {:>8.1}%  ({ledger_calls} calls projected)",
         saved(raw_total, out_total),
-        saved(raw_total, ledger_total)
+        saved(raw_total, ledger_total),
+        ratio(avail_total, acct_total),
+        ratio(out_total.saturating_sub(ledger_total), avail_total)
     );
     println!(
         "ledger arm:      project_scope={project_scope} floor_mult={} bytes={ledger_total} markers: {mark_session} session, {mark_project} project",


### PR DESCRIPTION
#704 stopped a figure moving when the code changed. It did nothing about a figure
moving when the **workload** changed, and that is the larger source of the drift.

Replaying the frozen corpus against the table in `README.md`, four of six classes
reproduce and two do not:

| class | README, its own corpus | frozen corpus |
|---|---|---|
| search | 2.3% / 4.3% | 3.4% / 4.2% |
| git | 2.5% / 7.0% | 5.1% / 8.8% |
| build and test | 10.8% / 10.8% | 9.0% / 11.1% |
| infra | 0.0% / 6.8% | 3.2% / 3.8% |
| file read | 39.2% / **89.6%** | 0.0% / **4.5%** |
| other | 29.1% / 56.2% | 0.8% / 4.8% |

**Not a regression.** That corpus averaged 12.4 KB per file read against 2.1 KB
here, the same large files read again and again. Both numbers are true of their own
week, and one of them is the README's first line.

So the defect is in the metric. "89.6% off file reads" reads as a property of OMNI
and is a property of one week's work.

```
class              calls        input    filters   + ledger  available  captured
other               6457      4814911       0.8%       4.8%      15.9%     25.1%
file read           1056      1891398       0.0%       4.5%      17.7%     25.3%
git                  899       858631       5.1%       8.8%      18.4%     20.8%
search              810        765443       3.4%       4.2%       6.5%     13.7%
infra                215       135669       3.2%       3.8%       5.5%     10.5%
build and test        41        20778       9.0%      11.1%      21.7%     10.8%
aggregate           9478      8486830       1.4%       5.1%      15.6%     24.1%
```

`available` is the share of bytes whose line had already been delivered in that
scope: the ceiling, because the ledger cannot fold what was never repeated.
`captured` is what it took of that ceiling. Savings swing about twentyfold across
the two corpora; capture stays in 10.5% to 25.3%. It is not constant, and it is far
closer to a property of OMNI than the other column.

Both go into `docs/benchmarks/<version>.json` per class.

**A correction to the issue.** Its own estimate, from a separate script, said the
ceiling was 6.3% and capture 71%. Measured inside the replay with the replay's own
classifier it is 17.7% and 25.3%: the two classifiers disagreed about which traces
were file reads, 1,056 against 672, and the ratio was taken anyway. The issue
flagged that as indicative rather than a result, and the result is worse. The ledger
takes about a quarter of what is available, not three quarters.

A ledger claiming more bytes than were repeated has a broken denominator, so that is
asserted rather than printed. Break-tested, and the second arm had to be rewritten:
dropping a column failed at compile time, which proves the compiler works and not
the parser. Renaming the header the parser anchors on is what actually exercised it.

```
other: ledger claimed 190613 bytes but only 0 were repeated
replay output did not carry: by_class
```

Not in scope: changing the README. That waits on a second corpus (PD) showing
whether the ratio holds across machines, which is the claim being made for it.

`make ci` green.

Closes #708
