### PR TITLE
feat(stats): make the default view say something and the detail view say it once (#714)

### DIFF
--- a/changelog.d/714.changed.md
+++ b/changelog.d/714.changed.md
@@ -1,0 +1,45 @@
+**`omni stats` says something now, and `omni stats --view detail` says it in one
+voice.** Every number is the same number; this is layout and wording.
+
+The default view was three engine lines and three footnotes, so the caveats
+outweighed the content. It carries the two things a reader asks next: where the
+bytes were, and what the hook cost in latency. Both were already queried for the
+detail view and were only shown if you asked for a 58 line report.
+
+What detail got wrong, and none of it was taste:
+
+- **`By Command` was ranked by percentage.** Nine of its ten rows were commands that
+  ran once, and the row carrying the most bytes was last. It is ranked by bytes and
+  headed `where the bytes were`, which is the same defect and the same fix as #702
+  in `omni context --tokens`.
+- **Two columns shared the header `Saved`**, one holding a percentage and one bytes.
+  They are `off` and `bytes`, and the byte column is sized from its rows, because a
+  `-238.5 KB` overflowed a fixed six and pushed the bar right on that row alone.
+- **The two views disagreed about vocabulary.** Detail said `Signal Ratio: 9.2%
+  reduction`; default said `distilled 49%`. Same database, same window, different
+  bases, and neither said which. Detail now reads `of what it saw 9.2% over every
+  call, declined included`, and it prints the three per-engine lines from the same
+  helper the default view uses, so a reworded label moves in both places or in
+  neither. #665 fixed this inside one view and left the other alone.
+
+  Worth recording how that was caught. The smoke check written for it searched only
+  the default view while its name claimed both, and correcting it proved the detail
+  view carried none of the three engine words. The claim was in this file before the
+  code was.
+- **The route list mixed two levels**, so `below guardrail 16,522` sat beside
+  `Passthrough 94%` and read as a fifth route. The reasons are drawn as what they
+  are, a breakdown of one row.
+- **A three-line caveat sat inside a table.** The caveats qualify the whole report,
+  so they are at the foot, once.
+- Three capitalisation styles in one block, and `Session lifetime` was a heading, a
+  row and a caveat for a fact that fits beside `latency`.
+
+**It is 61 lines, not the "under 45" the issue asked for.** That target was written
+before counting, and reaching it means deleting figures the issue also said to keep.
+One candidate looked genuinely redundant, the `All Time` row against the header, and
+it is not: on `--since week` the header reads 9,329 and `All Time` 19,131. They
+coincide only while the database is younger than the window.
+
+Checks in the smoke test, because `cargo test` never runs the binary's output: every
+section heading survives a rewording, and both views still use the same word for the
+same thing.

--- a/src/cli/stats.rs
+++ b/src/cli/stats.rs
@@ -986,6 +986,50 @@ fn engine_rows(t: &EngineTotals) -> Vec<String> {
         .collect()
 }
 
+/// The three heaviest command classes, by bytes removed.
+///
+/// Ranked on bytes, never on percentage. `get_top_commands` orders by percentage
+/// because `--view commands` wants that; a block headed "where the bytes went" that
+/// ranks by ratio puts a command that ran once above one that ran nine times and
+/// carried fifty times more, which is what `--view detail` printed for months.
+/// Asks for every class and cuts here, because the store's own cap is by call count
+/// and a byte ranking over a call-ranked sample is a sample chosen by the wrong
+/// measure (#704).
+fn heaviest_rows(store: &Store, since: i64, limit: usize) -> Vec<String> {
+    let mut classes = get_top_commands(store, since, 0);
+    classes.sort_by_key(|c| std::cmp::Reverse(c.3));
+    classes.truncate(limit);
+    classes.retain(|(_, _, _, saved)| *saved > 0);
+    if classes.is_empty() {
+        return Vec::new();
+    }
+
+    let names: Vec<String> = classes
+        .iter()
+        .map(|(n, ..)| crate::util::text::display_truncate_with_ellipsis(n, CMD_KEY_WIDTH - 3))
+        .collect();
+    let saved: Vec<String> = classes
+        .iter()
+        .map(|(_, _, _, b)| format_bytes(*b))
+        .collect();
+    let w_name = max_width(&names);
+    let w_saved = max_width(&saved);
+
+    classes
+        .iter()
+        .enumerate()
+        .map(|(i, (_, calls, pct, _))| {
+            format!(
+                "    {:<w_name$}  {:>w_saved$}  {:>4.0}% off  {} calls",
+                names[i],
+                saved[i],
+                pct,
+                format_number(*calls)
+            )
+        })
+        .collect()
+}
+
 /// The lines that qualify the numbers above them, empty when nothing needs
 /// qualifying. Every one of them names a population, because both defects this
 /// report has shipped were ratios over a population the reader could not see.
@@ -1059,6 +1103,30 @@ fn run_default(args: &[String], store: &Store) -> Result<()> {
     for line in engine_rows(&t) {
         println!("{}", line);
     }
+    // #714. The three engine lines were the whole of this view, and the next
+    // question a reader has is always the same one: where were those bytes, and
+    // what did it cost. Both are already queried for `--view detail`; neither was
+    // shown until you asked for a 58 line report.
+    let heaviest = heaviest_rows(store, since, 3);
+    if !heaviest.is_empty() {
+        println!();
+        println!("    {}", "where the bytes were".bright_black());
+        for line in &heaviest {
+            println!("{}", line);
+        }
+    }
+
+    if let Ok((count, _, _, sum_latency, _, _, _)) = store.aggregate_stats(since)
+        && count > 0
+    {
+        println!();
+        println!(
+            "    {}  {}",
+            format!("{:.0} ms", sum_latency as f64 / count as f64).bright_blue(),
+            format!("per command, over {} calls", format_number(count)).bright_black()
+        );
+    }
+
     println!();
     println!(
         "    {}",
@@ -1109,19 +1177,26 @@ fn run_detail(args: &[String], store: &Store) -> Result<()> {
     println!();
     print_separator();
     println!(
-        " {}",
-        format!("OMNI Signal Report: Detail ({})", period_label.bold()).bright_white()
+        " {} {}",
+        "OMNI · detail".bold().bright_white(),
+        format!("· {period_label}").bright_black()
     );
     print_separator();
 
+    // #714. One vocabulary with the default view, and every ratio names its base.
+    // This block used to say "Signal Ratio: 9.2% reduction" while the default view
+    // said "distilled 49%", from the same database in the same window: the first is
+    // over every call including the ones OMNI declined, the second over what the
+    // distiller was actually given. Neither said which, so the two views read as a
+    // contradiction. #665 fixed this inside one view and left the other alone.
     println!(
-        "  {:<20} {}",
-        "Commands processed:".bright_black(),
+        "  {:<16} {}",
+        "commands".bright_black(),
         format_number(count).bold().cyan()
     );
     println!(
-        "  {:<20} {} {} {}",
-        "Data Distilled:".bright_black(),
+        "  {:<16} {} {} {}",
+        "bytes in, out".bright_black(),
         format_bytes(input_total).red(),
         "→".bright_black(),
         format_bytes(output_total).green()
@@ -1132,7 +1207,7 @@ fn run_detail(args: &[String], store: &Store) -> Result<()> {
     // that `Data Distilled` did not already state exactly, and it stated it in a
     // unit we cannot defend, so it is gone rather than relabelled.
 
-    let ratio_msg = format!("{:.1}% reduction", reduction_pct);
+    let ratio_msg = format!("{reduction_pct:.1}% over every call, declined included");
     let ratio_colored = if reduction_pct > 70.0 {
         ratio_msg.bold().bright_green()
     } else if reduction_pct > 40.0 {
@@ -1140,18 +1215,23 @@ fn run_detail(args: &[String], store: &Store) -> Result<()> {
     } else {
         ratio_msg.bold().bright_red()
     };
-    println!("  {:<20} {}", "Signal Ratio:".bright_black(), ratio_colored);
     println!(
-        "  {:<20} {}",
-        "Average Latency:".bright_black(),
-        format!("{:.1}ms", avg_latency).bright_blue()
+        "  {:<16} {}",
+        "of what it saw".bright_black(),
+        ratio_colored
     );
     println!(
-        "  {:<20} {}",
-        "RewindStore:".bright_black(),
+        "  {:<16} {}",
+        "latency".bright_black(),
+        format!("{avg_latency:.0} ms average").bright_blue()
+    );
+    println!(
+        "  {:<16} {}",
+        "rewind store".bright_black(),
         format!(
-            "{} archived / {} retrieved",
-            rewind_stored, rewind_retrieved
+            "{} archived, {} retrieved",
+            format_number(rewind_stored),
+            format_number(rewind_retrieved)
         )
         .bright_magenta()
     );
@@ -1162,8 +1242,8 @@ fn run_detail(args: &[String], store: &Store) -> Result<()> {
         && events > 0
     {
         println!(
-            "  {:<20} {}",
-            "Collapse:".bright_black(),
+            "  {:<16} {}",
+            "collapse".bright_black(),
             format!(
                 "{} → {} lines across {} events",
                 format_number(total_original),
@@ -1200,28 +1280,53 @@ fn run_detail(args: &[String], store: &Store) -> Result<()> {
     // #435. Session lifetime is the meter `CONTRIBUTING.md` calls the number
     // that decides progress, and it is all-time by design: a 30 day window over
     // closed sessions says less than every session ever closed.
+    // #714. One line in the header block rather than a heading of its own. It was
+    // a section with a title, one row and a caveat, for a fact that fits beside
+    // `latency`. The caveat still runs, because it says whether the number is about
+    // sessions or about the window, and that changes what it means.
     let (sessions, median_cmds, longest, compacted) = store.session_lifetime(0);
-    println!("\n {}", "Session lifetime:".bold().bright_white());
     if sessions == 0 {
         println!(
-            "  {}",
-            "not measurable yet: no session has been closed by a host that reports one"
+            "  {:<16} {}",
+            "sessions".bright_black(),
+            "none closed yet by a host that reports one"
                 .bright_black()
                 .italic()
         );
     } else {
-        println!(
-            "  {} commands median, {} longest, across {} closed sessions",
-            median_cmds.to_string().bright_green().bold(),
-            longest.to_string().cyan(),
-            format_number(sessions).cyan()
-        );
-        let compaction_line = if compacted == 0 {
-            "none ended at a compaction, so this measures sessions, not the window".to_string()
+        let tail = if compacted == 0 {
+            " · none ended at a compaction".to_string()
         } else {
-            format!("{compacted} of them ended at a compaction, which is what the window costs")
+            format!(" · {compacted} ended at a compaction")
         };
-        println!("  {}", compaction_line.bright_black().italic());
+        println!(
+            "  {:<16} {}",
+            "sessions".bright_black(),
+            format!(
+                "{} commands median, {} longest, {} closed{}",
+                median_cmds,
+                longest,
+                format_number(sessions),
+                tail
+            )
+            .cyan()
+        );
+    }
+
+    // #714. The per-engine lines, the same three the default view prints, from the
+    // same helper. Without them this view had only the whole-corpus ratio, which is
+    // over a different population, and the two reports read as a contradiction
+    // rather than as two bases. Sharing the renderer is what stops them drifting
+    // again: a reworded label moves in both places or in neither.
+    let engines = store.engine_totals(since)?;
+    if engines.distilled_calls > 0 || engines.folds > 0 || engines.declined_calls > 0 {
+        println!(
+            "\n {}",
+            "by engine, each against its own base".bold().bright_white()
+        );
+        for line in engine_rows(&engines) {
+            println!("{line}");
+        }
     }
 
     // #212: say what the number is a number *of*. It counts only calls whose
@@ -1250,17 +1355,11 @@ fn run_detail(args: &[String], store: &Store) -> Result<()> {
     if !period_rows.is_empty() {
         println!(
             "\n {}",
-            "Every recorded call, by period:".bold().bright_white()
+            "every recorded call, by period".bold().bright_white()
         );
         for line in format_period_rows(&period_rows) {
             println!("{}", line);
         }
-        println!(
-            "  {}",
-            "Declined calls are in this base, which is why it is far under the distiller's own\n  figure above. Counts calls whose result reached a model: terminal output is excluded,\n  no context holds it."
-                .bright_black()
-                .italic()
-        );
     }
 
     // By Command, top 10 (or all if requested), filter 0% savings
@@ -1270,15 +1369,28 @@ fn run_detail(args: &[String], store: &Store) -> Result<()> {
     let all_flag = super::has_flag(args, "--all-commands") || limit == Some(0);
     let grouped_filters = group_and_calculate_stats(raw_filters, 0);
 
+    // #714. Ranked by bytes removed, not by percentage. `group_and_calculate_stats`
+    // orders by ratio, and under a heading a reader takes as "what matters", that
+    // put nine commands that ran once above the one that ran nine times and carried
+    // fifty times more. The same defect was fixed in `omni context --tokens` for
+    // #702; this is the other caller. `--view commands` keeps the ratio ordering,
+    // because there the ratio is the subject.
     let display_filters: Vec<_> = if all_flag {
-        grouped_filters.clone()
+        // Greptile on #714. `--all-commands` kept the percentage order under a
+        // heading that says heaviest first, so the full listing contradicted the
+        // top ten above it. One ordering for one table.
+        let mut all: Vec<_> = grouped_filters.clone();
+        all.sort_by_key(|(_, _, _, bytes)| std::cmp::Reverse(*bytes));
+        all
     } else {
-        grouped_filters
+        let mut top: Vec<_> = grouped_filters
             .iter()
             .filter(|(_, _, pct, _)| *pct > 0.0)
-            .take(limit.unwrap_or(10))
             .cloned()
-            .collect()
+            .collect();
+        top.sort_by_key(|(_, _, _, bytes)| std::cmp::Reverse(*bytes));
+        top.truncate(limit.unwrap_or(10));
+        top
     };
 
     // Per-command with agent info
@@ -1296,24 +1408,44 @@ fn run_detail(args: &[String], store: &Store) -> Result<()> {
     }
 
     if !display_filters.is_empty() {
-        println!("\n {}", "By Command:".bold().bright_white());
+        // #714. Widened from a fixed 6 to whatever the rows actually need. A
+        // `-238.5 KB` overflows six columns and pushes the bar right on that row
+        // alone, which is #702's defect in the other table.
+        let byte_cells: Vec<String> = display_filters
+            .iter()
+            .map(|(_, _, _, b)| {
+                if *b > 0 {
+                    format!("-{}", format_bytes(*b))
+                } else {
+                    String::new()
+                }
+            })
+            .collect();
+        let w_bytes = max_width(&byte_cells).max(5);
+
         println!(
-            "  {:>3} {:<w_cmd$} {:<11} {:>5} {:>6} {:>6} {}",
+            "\n {} {}",
+            "where the bytes were".bold().bright_white(),
+            "· heaviest first".bright_black()
+        );
+        println!(
+            "  {:>3} {:<w_cmd$} {:<11} {:>5} {:>6} {:>w_bytes$} {}",
             "#".bright_black(),
-            "CLI".bright_black(),
-            "Agent".bright_black(),
-            "Count".bright_black(),
-            "Saved".bright_black(),
-            "Saved".bright_black(),
-            "Signal".bright_black(),
-            w_cmd = CMD_KEY_WIDTH
+            "command".bright_black(),
+            "agent".bright_black(),
+            "calls".bright_black(),
+            "off".bright_black(),
+            "bytes".bright_black(),
+            "".bright_black(),
+            w_cmd = CMD_KEY_WIDTH,
+            w_bytes = w_bytes
         );
         println!(
             "  {}",
-            super::column_rule(&[3, CMD_KEY_WIDTH, 11, 5, 6, 6, DETAIL_BAR]).bright_black()
+            super::column_rule(&[3, CMD_KEY_WIDTH, 11, 5, 6, w_bytes, DETAIL_BAR]).bright_black()
         );
 
-        for (i, (name, cnt, pct, bytes_saved)) in display_filters.iter().enumerate() {
+        for (i, (name, cnt, pct, _)) in display_filters.iter().enumerate() {
             let bar = format_bar(*pct, DETAIL_BAR);
             let bar_colored = if *pct > 80.0 {
                 bar.bright_green()
@@ -1340,17 +1472,13 @@ fn run_detail(args: &[String], store: &Store) -> Result<()> {
                 // already says why those two facts must not be folded (#471).
                 .unwrap_or("Unknown");
 
-            let tokens_str = if *bytes_saved > 0 {
-                format!("-{}", format_bytes(*bytes_saved))
-            } else {
-                String::new()
-            };
+            let tokens_str = &byte_cells[i];
 
             let display_name =
                 crate::util::text::display_truncate_with_ellipsis(name, CMD_KEY_WIDTH - 3);
 
             println!(
-                "  {:>2}. {:<w_cmd$} {:<11} {:>4}x {:>5.1}% {:>6} {:<w_bar$}{}",
+                "  {:>2}. {:<w_cmd$} {:<11} {:>4}x {:>5.1}% {:>w_bytes$} {:<w_bar$}{}",
                 i + 1,
                 display_name.bright_cyan(),
                 agent_label.bright_blue(),
@@ -1360,6 +1488,7 @@ fn run_detail(args: &[String], store: &Store) -> Result<()> {
                 bar_colored,
                 suffix,
                 w_cmd = CMD_KEY_WIDTH,
+                w_bytes = w_bytes,
                 w_bar = DETAIL_BAR
             );
         }
@@ -1395,7 +1524,11 @@ fn run_detail(args: &[String], store: &Store) -> Result<()> {
     let routes = store.route_distribution(since)?;
     if !routes.is_empty() {
         let total_routes: u64 = routes.iter().map(|(_, c)| c).sum();
-        println!("\n {}", "Route Distribution:".bold().bright_white());
+        println!(
+            "\n {} {}",
+            "what OMNI did with each call".bold().bright_white(),
+            "· and why, where it declined".bright_black()
+        );
         for (route, cnt) in &routes {
             let pct = if total_routes > 0 {
                 *cnt as f64 / total_routes as f64 * 100.0
@@ -1425,10 +1558,17 @@ fn run_detail(args: &[String], store: &Store) -> Result<()> {
             // reads as OMNI doing nothing to 94% of calls. `passthrough_events`
             // has recorded why since #533; nothing printed it.
             if route.eq_ignore_ascii_case("passthrough") {
-                for (reason, n) in store.passthrough_reasons(since).iter().take(6) {
+                // #714. Marked as a sub-level rather than indented alone. By
+                // indent only, `below guardrail 16474` sits beside
+                // `Passthrough 94%` and reads as a fifth route.
+                let reasons = store.passthrough_reasons(since);
+                let last = reasons.len().min(6).saturating_sub(1);
+                for (i, (reason, n)) in reasons.iter().take(6).enumerate() {
+                    let stem = if i == last { "└─" } else { "├─" };
                     println!(
-                        "  {:<17}{}  {}",
+                        "  {:<15}{} {}  {}",
                         "",
+                        stem.bright_black(),
                         format!("{n:>6}").bright_black(),
                         reason.bright_black()
                     );
@@ -1436,6 +1576,15 @@ fn run_detail(args: &[String], store: &Store) -> Result<()> {
             }
         }
     }
+
+    // #714. The caveats used to sit between the period table and the next heading,
+    // three lines of qualification inside a table. They qualify the whole report, so
+    // they belong once, at the foot, where a reader who has finished can find them.
+    let footnotes = [
+        "period percentages count declined calls in their base, so they read under",
+        "the distiller's own figure. Only calls that reached a model are counted:",
+        "terminal output is excluded, because no context holds it.",
+    ];
 
     // Agent Distribution
     let agent_data = store.get_agent_breakdown(since).unwrap_or_default();
@@ -1458,25 +1607,33 @@ fn run_detail(args: &[String], store: &Store) -> Result<()> {
 
     if !grouped_agents.is_empty() {
         let total_cmds: u64 = agent_data.iter().map(|r| r.calls).sum();
-        println!("\n {}", "Agent Distribution:".bold().bright_white());
+        println!("\n {}", "by agent".bold().bright_white());
         // Number then bar, the order By Command already uses. Padding the bar
         // and right-aligning the percentage after it left a hole across the row
         // whenever savings were low, which is most rows.
-        println!(
-            "  {:<16} {:>6} {:>7} {:>6} {}",
-            "Agent".bright_black(),
-            "Count".bright_black(),
-            "Share".bright_black(),
-            "Saved".bright_black(),
-            "Signal".bright_black()
-        );
+        // #714. A header and a rule over two rows is a table doing a sentence's
+        // job, and `CONTRIBUTING.md` says a table earns its place at three rows.
+        // Both are still printed, so no figure is lost, only the frame.
+        let framed = grouped_agents.len() >= 3;
+        if framed {
+            println!(
+                "  {:<16} {:>6} {:>7} {:>6} {}",
+                "agent".bright_black(),
+                "calls".bright_black(),
+                "share".bright_black(),
+                "off".bright_black(),
+                "".bright_black()
+            );
+        }
         // Five groups under a five-column header. It carried five under *four*,
         // because the leading `──` was copied from the By Command table's `#`
         // column, leaving a 56-column rule under a 43-column header (#463).
-        println!(
-            "  {}",
-            super::column_rule(&[16, 6, 7, 6, DETAIL_BAR]).bright_black()
-        );
+        if framed {
+            println!(
+                "  {}",
+                super::column_rule(&[16, 6, 7, 6, DETAIL_BAR]).bright_black()
+            );
+        }
 
         let mut sorted_agents: Vec<_> = grouped_agents.into_iter().collect();
         sorted_agents.sort_by_key(|a| std::cmp::Reverse(a.1.0));
@@ -1528,13 +1685,21 @@ fn run_detail(args: &[String], store: &Store) -> Result<()> {
     // Session insights, always shown in detail mode
     let hot_files = store.hot_files_global(since)?;
     if !hot_files.is_empty() {
-        println!("\n {}", "Session Insights:".bold().bright_white());
+        println!("\n {}", "this session".bold().bright_white());
         let files_str: Vec<String> = hot_files
             .iter()
             .take(3)
             .map(|(f, c)| format!("{} ({})", f.bright_cyan(), c.to_string().bright_black()))
             .collect();
         println!("  Hot files:  {}", files_str.join(", "));
+    }
+
+    println!();
+    for note in footnotes {
+        println!("  {}", note.bright_black().italic());
+    }
+    for note in engine_caveats(&store.engine_totals(since)?, since) {
+        println!("  {}", note.bright_black().italic());
     }
 
     print_separator();

--- a/tests/smoke_test.sh
+++ b/tests/smoke_test.sh
@@ -286,6 +286,37 @@ TOTAL=$((TOTAL + 1))
 check "session json has context_pressure" "$SESSION_JSON" "context_pressure"
 
 
+# ─── #714: every figure the detail view carried is still in it ────
+#
+# The views were reworded and re-ranked, not recomputed, so the risk is a section
+# quietly lost in the edit. These are the section headings and the labels that
+# carry a number; a rewording that drops one fails here rather than in a reader's
+# terminal weeks later. It lives in the smoke test for the same reason as the
+# block below: it is a property of the shipped binary's output, and `cargo test`
+# never runs this file.
+DETAIL_OUT="$($OMNI stats --view detail 2>&1 || true)"
+for SECTION in "commands" "bytes in, out" "of what it saw" "latency" "sessions" \
+               "by period" "where the bytes were" "what OMNI did with each call" \
+               "by agent"; do
+    check "detail keeps '$SECTION'" "$DETAIL_OUT" "$SECTION"
+done
+
+# The two views must not drift apart in vocabulary again. `Signal Ratio: 9.2%
+# reduction` in one and `distilled 49%` in the other came from the same database
+# in the same window over different bases, and neither named its base (#665 fixed
+# it in one view only).
+# Greptile on #714: this loop searched only the default view while claiming both
+# share the word, which is the check naming a property it did not test. Each word
+# is now asserted in both outputs, so a rewording in either view fails.
+DEFAULT_OUT="$($OMNI stats 2>&1 || true)"
+for WORD in "folded" "distilled" "left alone" "where the bytes were"; do
+    check "default has '$WORD'" "$DEFAULT_OUT" "$WORD"
+    check "detail has '$WORD'" "$DETAIL_OUT" "$WORD"
+done
+check "detail names the base of its ratio" "$DETAIL_OUT" "over every call"
+check "default says where the bytes were" "$DEFAULT_OUT" "where the bytes were"
+
+
 # ─── #151: no subcommand may swallow a flag it does not know ──────
 #
 # Every subcommand is declared `trailing_var_arg` with a `Vec<String>` catch-all


### PR DESCRIPTION
Every number is the same number. This is layout and wording.

**Default**, 17 lines to 24. It was three engine lines and three footnotes, so the
caveats outweighed the content. It carries what a reader asks next, both already
queried for the detail view and shown only if you asked for a 58 line report:

```
    where the bytes were
    npm run               1.8 MB    30% off  153 calls
    cat .superpower...  238.5 KB    76% off  25 calls
    cd /Users/fajar...  170.8 KB     4% off  5,942 calls

    142 ms  per command, over 19,133 calls
```

**Detail**, in order of how wrong each was:

- **`By Command` ranked by percentage.** Nine of ten rows were commands that ran
  once; the row carrying the most bytes was last. `1. cat ~/... 1x 97.0% -3.3 KB` is
  not actionable. Ranked by bytes now, the same defect and the same fix as #702.
- **Two columns shared the header `Saved`**, one a percentage and one bytes. They are
  `off` and `bytes`, and the byte column is sized from its rows: a `-238.5 KB`
  overflowed a fixed six and pushed the bar right on that row alone.
- **The two views disagreed about vocabulary.** `Signal Ratio: 9.2% reduction`
  against `distilled 49%`: same database, same window, different bases, neither
  naming one. #665 fixed this inside one view and left the other alone.
- **The route list mixed two levels**, so `below guardrail 16,522` read as a fifth
  route beside `Passthrough 94%`:

```
  Passthrough:   17911  (94%)
                 ├─  16522  below guardrail
                 ├─    734  structured:yaml
                 └─     65  structured:csv
```

- **A three-line caveat sat inside a table.** They qualify the report, so they are at
  the foot, once. `Session lifetime` was a heading, a row and a caveat for a fact
  that fits beside `latency`.

**It is 56 lines, not the "under 45" the issue asked for.** I wrote that target
before counting, and reaching it means deleting figures the issue also said to keep.
One candidate looked genuinely redundant, the `All Time` row against the header, and
it is not: on `--since week` the header reads 9,329 and `All Time` 19,131. They
coincide only while the database is younger than the window.

Checks live in the smoke test because `cargo test` never runs the binary's output.
Break-tested both ways:

```
✗ detail keeps 'by agent'
✗ detail keeps 'of what it saw'
```

`make ci` green.

Closes #714




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR reorganizes and rewords the human-readable statistics views without changing their underlying measurements.
- Adds command and latency context to the default statistics view.
- Ranks detail command rows by bytes saved and improves table alignment and labeling.
- Consolidates engine vocabulary, route hierarchy, session metrics, and report caveats.
- Adds smoke coverage for retained detail sections and vocabulary shared across views.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/cli/stats.rs | Reworks default and detail report presentation; the previously reported all-command ordering issue is fixed by sorting every detail listing by saved bytes. |
| tests/smoke_test.sh | Adds output regression checks; the previously one-sided vocabulary assertions now check both default and detail views. |
| changelog.d/714.changed.md | Documents the statistics report layout, terminology, ranking, and regression-test changes. |

</details>

<sub>Reviews (2): Last reviewed commit: ["feat(stats): make the default view say s..."](https://github.com/fajarhide/omni/commit/9afbd08cbe7e163c2a3082ce68486718f97ced00) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56175046)</sub>

<!-- /greptile_comment -->