### PR TITLE
fix(ledger): the project scope may fold part of a reply, never the whole of it

### DIFF
--- a/changelog.d/705.fixed.md
+++ b/changelog.d/705.fixed.md
@@ -1,0 +1,15 @@
+- **The project scope replaced whole replies, leaving the reader nothing (#705)**:
+  a freshly dispatched subagent's first command came back as
+  `[OMNI: identical to 40 lines from an earlier session, none shown here]` and no
+  content at all, and it was never a subagent property: a second session on the same
+  project got the identical empty reply with the identical handle. A reviewer
+  dispatched onto a pull request had to pipe files through `base64` to read the code
+  it was sent to review. The session scope may still fold a whole reply, because that
+  reader is holding the bytes. The project scope may not: it answers for lines the
+  reader has never seen, so it now folds only part of a payload and always leaves real
+  lines to weigh the marker against. Not the reader's own set, which the report
+  proposed and the corpus falsifies: all four recorded whole-output project folds that
+  name a session happened in a session already holding 261 to 1,369 lines of its own,
+  the 1,319-byte case in the report included. Priced over this store the class is 10
+  folds and 32,104 bytes, 1.51% of every byte folded, against the 678,585 bytes the
+  partial arm keeps.

--- a/docs/website/src-id/concepts/the-ledger.md
+++ b/docs/website/src-id/concepts/the-ledger.md
@@ -66,6 +66,25 @@ yang berasal dari sesi harus menghemat 150 byte di atas penandanya; deretan yang
 berasal dari proyek harus menghemat tiga kali lipatnya, sebab agent tidak punya
 pilihan selain membayar satu pengambilan kalau ia butuh isinya.
 
+**Dan scope proyek hanya boleh melipat sebagian balasan.** Lipatan sesi boleh
+mengambil seluruh balasan, sebab pembacanya memang sedang memegang byte itu.
+Lipatan proyek tidak boleh: pembacanya belum pernah melihatnya, jadi mengganti
+semuanya meninggalkan satu penanda, nol isi, dan tidak ada cara memeriksa satu
+satunya klaim yang ia terima. Perintah pertama sebuah subagent pernah kembali
+sebagai satu baris yang bilang 40 baris identik dengan sesi terdahulu, dan seorang
+peninjau yang didispatch ke sebuah pull request harus menyalurkan berkasnya lewat
+`base64` untuk membaca kode yang ia diminta tinjau.
+
+Syaratnya adalah apa yang ditinggalkan lipatan itu, bukan siapa yang membaca.
+"Apakah pembaca ini sudah pernah melihat sesuatu" terdengar seperti uji yang sama
+padahal bukan: setiap lipatan proyek seluruh keluaran yang tercatat di mesin ini
+dan menyebut sesi terjadi di sesi yang sudah memegang antara 261 sampai 1.369
+baris miliknya sendiri. Pembaca yang pernah melihat sesuatu tidak mengatakan
+apa pun tentang apakah ia sudah melihat baris *ini*, dan justru itulah yang
+dijawab scope proyek. Menolak kelas ini memakan 10 lipatan dan 32.104 byte, 1,51%
+dari setiap byte yang pernah dilipat penyimpanan ini, berbanding 678.585 byte yang
+terus dihasilkan lengan parsial.
+
 ## Dua lantai yang memutuskan tidak ada yang dilipat sama sekali
 
 Kedua ambang di atas menanyakan apakah sebuah deretan lebih besar daripada penanda

--- a/docs/website/src/concepts/the-ledger.md
+++ b/docs/website/src/concepts/the-ledger.md
@@ -61,6 +61,23 @@ Because the project claim is not free, it carries a higher bar. A session-origin
 must save 150 bytes over its marker; a project-origin run must save three times that,
 since the agent has no choice about paying a retrieval if it needs the content.
 
+**And the project scope may only ever fold part of a reply.** A session fold can take
+the whole of one, because the reader really is holding those bytes. A project fold
+cannot: the reader has never seen them, so replacing everything leaves it with one
+marker, no content, and no way to check the only claim it was given. A subagent's
+first command came back as a single line saying 40 lines were identical to an earlier
+session, and a reviewer dispatched onto a pull request had to pipe files through
+`base64` to read the code it was sent to review.
+
+The condition is what the fold would leave behind, not who is reading. "Has this
+reader seen anything yet" sounds like the same test and is not: every whole-output
+project fold recorded on this machine that names a session happened in a session
+already holding between 261 and 1,369 lines of its own. A reader having seen
+something says nothing about whether it has seen *these* lines, which is exactly what
+the project scope answers for. Refusing the class costs 10 folds and 32,104 bytes,
+1.51% of every byte this store has folded, against the 678,585 bytes the partial arm
+keeps earning.
+
 ## The two floors that decide nothing folds at all
 
 Both bars above ask whether a run outgrows the marker replacing it. Two floors are

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -3960,13 +3960,23 @@ src/distillers/system_ops.rs:849:                is_sensitive_key(key),
         let body: String = (0..200)
             .map(|i| format!("2026-08-12T00:00:00Z  handler finished request {i} in 12ms\n"))
             .collect();
+        // The second read appends lines nobody has seen, so its fold is a run
+        // inside a payload. Since #705 the project scope refuses to replace a
+        // whole one, and a re-read of exactly the same bytes would come back
+        // verbatim on the subagent arm, which asserts on a marker.
+        let second_body = format!(
+            "{body}{}",
+            (0..20)
+                .map(|i| format!("2026-08-12T00:00:00Z  cache probe {i} missed and refilled\n"))
+                .collect::<String>()
+        );
 
-        let payload = |agent: Option<&str>| {
+        let payload = |agent: Option<&str>, text: &str| {
             let mut v = json!({
                 "session_id": session,
                 "tool_name": "Read",
                 "tool_input": {"path": "notes.txt"},
-                "tool_response": {"content": body},
+                "tool_response": {"content": text},
             });
             if let Some(a) = agent {
                 v["agent_id"] = json!(a);
@@ -3974,9 +3984,10 @@ src/distillers/system_ops.rs:849:                is_sensitive_key(key),
             v.to_string()
         };
 
-        let first = process_payload(&payload(None), Some(store.clone()), None).unwrap_or_default();
-        let second =
-            process_payload(&payload(agent), Some(store.clone()), None).unwrap_or_default();
+        let first =
+            process_payload(&payload(None, &body), Some(store.clone()), None).unwrap_or_default();
+        let second = process_payload(&payload(agent, &second_body), Some(store.clone()), None)
+            .unwrap_or_default();
         (first, second)
     }
 

--- a/src/ledger/mod.rs
+++ b/src/ledger/mod.rs
@@ -696,7 +696,7 @@ impl<'a> Ledger<'a> {
         // store can still turn a planned fold back into a verbatim run below,
         // and that direction is safe: the caller then refuses the view exactly
         // as it did before any of this existed.
-        let planned: Vec<bool> = runs
+        let mut planned: Vec<bool> = runs
             .iter()
             .map(|run| {
                 run.seen.as_ref().is_some_and(|seen| {
@@ -711,6 +711,39 @@ impl<'a> Ledger<'a> {
                 })
             })
             .collect();
+
+        // #705. The project scope may fold part of a reply, never the whole of
+        // it. A whole-output project fold leaves the reader holding one marker
+        // and no content, and the claim in that marker is the one thing it
+        // cannot check: it was not there. A subagent's first command came back
+        // as `identical to 40 lines from an earlier session, none shown here`
+        // and nothing else, and a reviewer dispatched onto a pull request had to
+        // pipe files through `base64` to read the code it was sent to review.
+        //
+        // Not the reader's own set, which is what the report proposed. That
+        // condition never fires: of the four recorded whole-output project folds
+        // that name a session, every one happened in a session already holding
+        // between 261 and 1,369 lines of its own, the 1,319-byte case in the
+        // report included. A reader having seen *something* says nothing about
+        // whether it has seen *these lines*, which is precisely what the project
+        // scope exists to answer for.
+        //
+        // Every run planned means every line goes, since an unseen or unaffordable
+        // run survives verbatim. Unplanning only the project runs rather than
+        // refusing outright keeps an honest session fold in the mixed payload, and
+        // leaves the reader real lines to weigh the marker against. Priced over
+        // the recorded corpus: 10 folds, 32,104 bytes, 1.51% of all folded bytes.
+        if planned.iter().all(|&fold| fold) {
+            for (fold, run) in planned.iter_mut().zip(&runs) {
+                if run
+                    .seen
+                    .as_ref()
+                    .is_some_and(|s| s.origin == Origin::Project)
+                {
+                    *fold = false;
+                }
+            }
+        }
 
         // #658, then #664. A host that renumbers what it is handed cannot take
         // survivors sitting in two blocks. #658 answered that by folding only down
@@ -1108,6 +1141,36 @@ mod tests {
             .join("\n")
     }
 
+    /// A repeated block and a fresh one, which since #705 is the only shape a
+    /// project fold may take: the first is foldable, the second is not, so the
+    /// reader keeps real lines to weigh the marker against. Returns the block to
+    /// prime the first session with, then the payload the second session sends.
+    ///
+    /// The repeated half is six times the session floor so the project scope's
+    /// own bar is cleared and a fold really happens. Under it the second reader is
+    /// simply shown the lines and a test asserting on an absent fold passes for
+    /// the wrong reason.
+    fn project_repeat_then_fresh() -> (String, String) {
+        let repeated = project_repeat();
+        let payload = format!("{repeated}{}", fresh_block("cache probe"));
+        (repeated, payload)
+    }
+
+    /// The block a first session is primed with, six times the session floor so
+    /// the project scope's higher bar is cleared and a fold really happens.
+    fn project_repeat() -> String {
+        (0..200)
+            .map(|i| format!("2026-08-10T00:00:00Z  handler finished request {i} in 12ms\n"))
+            .collect()
+    }
+
+    /// Lines no scope has seen, tagged so two calls can each carry their own.
+    fn fresh_block(tag: &str) -> String {
+        (0..20)
+            .map(|i| format!("2026-08-10T00:00:00Z  {tag} {i} missed and refilled\n"))
+            .collect()
+    }
+
     /// #543. A whole-output fold leaves the agent a handle and no content, so any
     /// part of the payload it still needs costs a retrieval round trip. Four of
     /// the four recorded under 1 KB were retrieved within nine seconds, against a
@@ -1313,25 +1376,19 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let db = dir.path().join("omni.db");
         let store = Store::open_path(&db).expect("store");
-        // Six times the session floor, so the project scope's higher bar is
-        // cleared and a fold really happens. Under it the second agent is simply
-        // shown the lines, and a test asserting on an absent fold passes for the
-        // wrong reason.
-        let text: String = (0..200)
-            .map(|i| format!("2026-08-10T00:00:00Z  handler finished request {i} in 12ms\n"))
-            .collect();
+        let (repeated, payload) = project_repeat_then_fresh();
 
         Ledger::new(&store, "s1")
             .with_project("/repo")
             .by("claude_code")
-            .project(&text);
+            .project(&repeated);
         let view = Ledger::new(&store, "s2")
             .with_project("/repo")
             .by("codex")
-            .project(&text)
+            .project(&payload)
             .expect("no fold on the second agent, so there is nothing to record");
         assert!(
-            view.contains("from an earlier session"),
+            view.contains("not shown here"),
             "this has to be a project fold to be the case under test: {view}"
         );
 
@@ -1353,28 +1410,82 @@ mod tests {
         assert!(lines > 0 && bytes > 0, "{lines} lines, {bytes} bytes");
     }
 
+    /// #705. A reader the project scope answers for has not seen those bytes, so
+    /// replacing the whole payload leaves it holding one marker and nothing it
+    /// can check the marker against. A subagent's first command came back as
+    /// `identical to 40 lines from an earlier session, none shown here` and
+    /// nothing else, and it is not a subagent property: a second session on the
+    /// same project gets the identical empty reply.
+    ///
+    /// The counter-case is asserted in the same test on purpose. The rule is
+    /// "never the whole of a reply", not "the project scope stops folding": the
+    /// partial arm is 635 folds and 678,585 bytes against the 10 folds and
+    /// 32,104 bytes this gives up.
+    #[test]
+    fn never_replaces_a_whole_payload_from_the_project_scope() {
+        let (store, _d) = temp_store();
+        let repeated = project_repeat();
+        Ledger::new(&store, "s1")
+            .with_project("/repo")
+            .by("claude_code")
+            .project(&repeated);
+
+        for (label, reader) in [
+            (
+                "a fresh session",
+                Ledger::new(&store, "s2").with_project("/repo"),
+            ),
+            (
+                "a subagent of the first",
+                Ledger::new(&store, scope_for("s1", Some("sub-agent-1"))).with_project("/repo"),
+            ),
+        ] {
+            assert!(
+                reader.project(&repeated).is_none(),
+                "{label} was handed a marker and zero content lines"
+            );
+        }
+
+        // Same repeated block, now inside a payload that carries lines nobody has
+        // seen. This must still fold, or the fix reads as "the project scope is
+        // off" rather than "it may not take the whole reply".
+        let view = Ledger::new(&store, "s3")
+            .with_project("/repo")
+            .project(&format!("{repeated}{}", fresh_block("cache probe")))
+            .expect("a project run inside a payload is still projectable");
+        assert!(
+            view.contains("not shown here"),
+            "the partial project fold stopped firing: {view}"
+        );
+        assert!(
+            view.contains("cache probe 0"),
+            "the reader must keep the lines the fold did not claim: {view}"
+        );
+    }
+
     /// The whole licence for the project scope. A second session may reuse the
     /// first session's history, but it has **not seen those bytes**, so the
     /// marker must not say it has. An earlier draft cancelled this phase over
     /// exactly that wording; the remedy was the wording.
+    ///
+    /// Since #705 the licence is narrower: a project fold is a run inside a
+    /// payload, never the whole of one, so the fixture carries fresh lines the
+    /// second session keeps. What is asserted here is unchanged.
     #[test]
     fn never_tells_a_new_session_it_has_already_seen_the_project_history() {
         let (store, _d) = temp_store();
-        // Six times the session floor, so it clears the project scope's own bar.
-        let text: String = (0..200)
-            .map(|i| format!("2026-08-10T00:00:00Z  handler finished request {i} in 12ms\n"))
-            .collect();
+        let (repeated, payload) = project_repeat_then_fresh();
         Ledger::new(&store, "s1")
             .with_project("/repo")
-            .project(&text);
+            .project(&repeated);
 
         let view = Ledger::new(&store, "s2")
             .with_project("/repo")
-            .project(&text)
+            .project(&payload)
             .expect("a project repeat above the floor is projectable");
 
         assert!(
-            view.contains("from an earlier session"),
+            view.contains("not shown here"),
             "the marker claimed a sighting this session never had: {view}"
         );
         assert!(
@@ -1440,28 +1551,33 @@ mod tests {
     #[test]
     fn a_folded_run_is_not_recorded_as_shown() {
         let (store, _d) = temp_store();
-        let text: String = (0..200)
-            .map(|i| format!("2026-08-10T00:00:00Z  handler finished request {i} in 12ms\n"))
-            .collect();
+        let repeated = project_repeat();
         Ledger::new(&store, "s1")
             .with_project("/repo")
-            .project(&text);
+            .project(&repeated);
+
+        // Each call carries its own fresh tail. The same one twice would put the
+        // first call's tail into s2's session scope, and the two runs together
+        // would then cover the whole payload, which #705 refuses to fold: the
+        // project run would come back verbatim and the test would fail on a
+        // fixture artefact rather than on the claim it is about.
+        let call = |tag: &str| format!("{repeated}{}", fresh_block(tag));
 
         // s2 sees it for the first time and is handed a marker, not the bytes.
         let first = Ledger::new(&store, "s2")
             .with_project("/repo")
-            .project(&text)
+            .project(&call("cache probe"))
             .expect("a project repeat above the floor is projectable");
-        assert!(first.contains("from an earlier session"), "{first}");
+        assert!(first.contains("not shown here"), "{first}");
 
-        // Same session, same payload. It has still never received those lines.
+        // Same session, same repeated block. It has still never received it.
         let second = Ledger::new(&store, "s2")
             .with_project("/repo")
-            .project(&text)
+            .project(&call("queue drain"))
             .expect("still projectable");
 
         assert!(
-            second.contains("from an earlier session"),
+            second.contains("not shown here"),
             "a run this session only ever saw as a marker was reported as shown: {second}"
         );
         assert!(


### PR DESCRIPTION
Closes #705.

A project fold answers for lines the reader has never seen, so replacing the whole
payload left it holding one marker, no content, and no way to check the only claim it
was given. The session scope may still fold a whole reply, because that reader really
is holding the bytes. The project scope now folds only part of one.

Driving `--post-hook` against an isolated DB with the reporter's 40-line fixture:

```
                                     before                     after
[1] main agent, first sight          40/40 lines delivered      unchanged
[2] freshly dispatched subagent      0/40, marker only          40/40 delivered
[3] different session, same project  0/40, same handle          40/40 delivered
[4] same 40 lines + 20 new           n/a                        20 delivered, 40 folded
```

Arm 4 is the counter-case: the rule is "never the whole of a reply", not "the project
scope stops folding".

Not the reader's own set, which is what the report proposed. That condition never
fires. Of the four recorded whole-output project folds that name a session, every one
happened in a session already holding between 261 and 1,369 lines of its own, the
report's own 1,319-byte case included, and I reproduced a session holding 40 lines it
was actually shown still getting 0 of 40 on the next payload. A reader having seen
something says nothing about whether it has seen these lines.

Priced over the recorded corpus: 10 folds, 32,104 bytes, 1.51% of all folded bytes.
The partial arm, 635 folds and 678,585 bytes, is untouched.

Four tests asserted the old shape because their fixtures were whole-output by
construction, including #581's own and the one titled "the whole licence for the
project scope". They keep every assertion and gain a fresh block, so the fold under
test is a run inside a payload. `concepts/the-ledger.md` states the narrower licence.
The new test was driven red both ways: guard off, and guard firing on a partial
payload.

`make ci` green on this branch alone: fmt, clippy 1.97.0, 894 tests, security, 70/70 smoke.




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR prevents project-scoped ledger reuse from replacing an entire reply while preserving partial project folds.
- Adjusts the ledger’s fold plan so project-origin runs remain verbatim when every run would otherwise fold.
- Updates affected hook and ledger tests to exercise partial project folds.
- Documents the narrower project-scope contract in English and Indonesian and adds the changelog entry.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/ledger/mod.rs | Adds the project-scope whole-reply guard and updates focused ledger fixtures without an identified blocking failure. |
| src/hooks/post_tool.rs | Revises the shared read fixture so the project-scope assertions continue to exercise a partial fold. |
| docs/website/src/concepts/the-ledger.md | Documents that project scope may fold only part of a reply. |
| docs/website/src-id/concepts/the-ledger.md | Adds the corresponding Indonesian documentation for the narrowed project-scope behavior. |
| changelog.d/705.fixed.md | Records the user-facing correction and its motivation. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Build fold plan for all runs] --> B{Would every run fold?}
  B -->|No| C[Apply profitable partial folds]
  B -->|Yes| D{Any project-origin runs?}
  D -->|No| E[Allow whole session-scope fold]
  D -->|Yes| F[Keep project-origin runs verbatim]
  F --> G[Fold eligible remaining session runs]
  C --> H[Deliver content and markers]
  E --> H
  G --> H
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ledger): the project scope may fold ..."](https://github.com/fajarhide/omni/commit/62d4c44f290aeaeaa042bf5c025e9fa85da1294a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57077420)</sub>

**Context used:**

- Knowledge Base — [Graphs, ledger, and context analytics](https://app.greptile.com/weekndlabs/-/custom-context/knowledge-base/fajarhide/omni/-/docs/graphs-ledger-and-context-analytics.md)
- Knowledge Base — [Context processing pipeline](https://app.greptile.com/weekndlabs/-/custom-context/knowledge-base/fajarhide/omni/-/docs/context-processing-pipeline.md)

<!-- /greptile_comment -->