### PR TITLE
fix(distillers): an empty default is not a credential, and a redacted line keeps its comma

### DIFF
--- a/changelog.d/726.fixed.md
+++ b/changelog.d/726.fixed.md
@@ -1,0 +1,14 @@
+- **A redacted empty default came back as broken syntax (#726)**: reading a
+  `.tsx` component to plan an edit to it, `apiKey = "",` was delivered as
+  `apiKey = "[REDACTED]"`, with no comma and no credential anywhere in the file.
+  Two defects on one line. The value reaches the redactor with its quotes and
+  its trailing punctuation attached, so an empty string never read as empty and
+  every key called `apiKey`, `token` or `password` had its default rewritten
+  whatever it held. The replacement then consumed everything after the opening
+  quote, which is the punctuation loss #486 fixed for HCL and did not generalise
+  past a value with nothing after it. An agent that copies the delivered line
+  into an edit writes a syntax error, and nothing in the output says the
+  punctuation moved. The literal between the quotes now decides whether there is
+  a secret to hide, single quotes keep their delimiter the way double quotes
+  already did, and trailing punctuation comes back with the line. Anything else
+  after the closing quote could be a second literal and is still redacted.

--- a/src/distillers/system_ops.rs
+++ b/src/distillers/system_ops.rs
@@ -696,7 +696,12 @@ fn looks_like_shell_expansion(value: &str) -> bool {
 ///
 /// `None` means deliver the line as written.
 fn redact_assignment(key: &str, value: &str) -> Option<String> {
-    if !is_sensitive_key(key) || value.trim().is_empty() || looks_like_shell_expansion(value) {
+    // The value arrives with its delimiters and any trailing punctuation
+    // attached, so `apiKey = "",` never read as empty and was delivered as
+    // `apiKey = "[REDACTED]"`, comma and all, which does not parse (#726).
+    let quoted = quoted_value(value);
+    let literal = quoted.map_or(value, |(_, inner, _)| inner);
+    if !is_sensitive_key(key) || literal.trim().is_empty() || looks_like_shell_expansion(value) {
         return None;
     }
     // The value only gets a say when `KEY` alone made the name look sensitive.
@@ -717,15 +722,40 @@ fn redact_assignment(key: &str, value: &str) -> Option<String> {
     // The old form ate the spacing and the quotes, so an HCL line came out as
     // `key =[REDACTED]`, which is neither valid nor informative.
     let lead: String = value.chars().take_while(|c| c.is_whitespace()).collect();
-    let quoted = value.trim_start().starts_with('"');
-    Some(format!(
-        "{lead}{}",
-        if quoted {
-            "\"[REDACTED]\""
-        } else {
-            "[REDACTED]"
+    Some(match quoted {
+        // Only punctuation is handed back with the value. Anything else after
+        // the closing quote could be a second literal, and the direction of
+        // doubt in this file is to redact.
+        Some((q, _, tail))
+            if tail
+                .chars()
+                .all(|c| c.is_whitespace() || matches!(c, ',' | ';' | ')' | ']' | '}')) =>
+        {
+            format!("{lead}{q}[REDACTED]{q}{tail}")
         }
-    ))
+        Some((q, _, _)) => format!("{lead}{q}[REDACTED]{q}"),
+        None => format!("{lead}[REDACTED]"),
+    })
+}
+
+/// A quoted value's parts: the quote character, the literal between the quotes,
+/// and whatever trails the closing one.
+///
+/// Splitting on `=` leaves the delimiters on the value, which is what made
+/// `apiKey = ""` look like it held something and cost the line its comma on the
+/// way out (#726). An unterminated quote keeps the old reading: everything
+/// after it is the literal.
+///
+/// `find` returns a char boundary and both quote characters are one ASCII byte.
+#[allow(clippy::string_slice)]
+fn quoted_value(value: &str) -> Option<(char, &str, &str)> {
+    let body = value.trim_start();
+    let quote = body.chars().next().filter(|c| matches!(c, '"' | '\''))?;
+    let rest = &body[1..];
+    Some(match rest.find(quote) {
+        Some(end) => (quote, &rest[..end], &rest[end + 1..]),
+        None => (quote, rest, ""),
+    })
 }
 
 /// Slices here are proven to sit on a char boundary rather than assumed to.
@@ -1181,6 +1211,39 @@ mod tests {
         let env = "GOOGLE_CREDENTIALS={\"type\":\"service_account\",\"private_key\":\"abc\"}\n";
         let out = redact_sensitive_assignments(env).expect("a JSON credential is still a secret");
         assert!(!out.contains("service_account"), "secret delivered:\n{out}");
+    }
+
+    /// #726. Two defects on one line, and the second is what breaks an edit.
+    ///
+    /// `apiKey = ""` names a credential and holds none, and the emptiness test
+    /// never saw that because the quotes and the comma are part of the value.
+    /// The replacement then ate the comma, so a `.tsx` came back as syntax that
+    /// does not parse. Same punctuation loss as the HCL line in #486, which
+    /// means that fix did not generalise past an unpunctuated value.
+    #[test]
+    fn keeps_empty_defaults_and_the_punctuation_after_a_secret() {
+        let tsx = "export function Demo({\n  open,\n  apiKey = \"\",\n  token = \"\",\n  label = \"hello\",\n}) {\n  return null;\n}\n";
+        assert!(
+            redact_sensitive_assignments(tsx).is_none(),
+            "an empty string is not a credential whatever the key is called"
+        );
+
+        // The delimiter and the trailing comma come back, so the line still parses.
+        assert_eq!(
+            redact_assignment("  apiKey ", " \"sk-ant-realsecret123\","),
+            Some(" \"[REDACTED]\",".to_string())
+        );
+        assert_eq!(
+            redact_assignment("password", "'hunter2';"),
+            Some("'[REDACTED]';".to_string())
+        );
+
+        // Anything past the closing quote that is not punctuation could be a
+        // second literal, so it goes with the first.
+        assert_eq!(
+            redact_assignment("API_KEY", " \"sk-one\" \"sk-two\""),
+            Some(" \"[REDACTED]\"".to_string())
+        );
     }
 
     /// #559. `echo "pass=$P/10"` after a ten-run test loop came back as

--- a/src/distillers/system_ops.rs
+++ b/src/distillers/system_ops.rs
@@ -700,8 +700,14 @@ fn redact_assignment(key: &str, value: &str) -> Option<String> {
     // attached, so `apiKey = "",` never read as empty and was delivered as
     // `apiKey = "[REDACTED]"`, comma and all, which does not parse (#726).
     let quoted = quoted_value(value);
-    let literal = quoted.map_or(value, |(_, inner, _)| inner);
-    if !is_sensitive_key(key) || literal.trim().is_empty() || looks_like_shell_expansion(value) {
+    let (literal, tail) = quoted.map_or((value, ""), |(_, inner, tail)| (inner, tail));
+    // The tail decides whether the empty literal is the whole value. Review's
+    // case: `API_KEY=""sk-secret"` opens with an empty segment and carries the
+    // credential after it, so emptiness alone would hand the line back whole.
+    if !is_sensitive_key(key)
+        || (literal.trim().is_empty() && is_only_punctuation(tail))
+        || looks_like_shell_expansion(value)
+    {
         return None;
     }
     // The value only gets a say when `KEY` alone made the name look sensitive.
@@ -723,19 +729,18 @@ fn redact_assignment(key: &str, value: &str) -> Option<String> {
     // `key =[REDACTED]`, which is neither valid nor informative.
     let lead: String = value.chars().take_while(|c| c.is_whitespace()).collect();
     Some(match quoted {
-        // Only punctuation is handed back with the value. Anything else after
-        // the closing quote could be a second literal, and the direction of
-        // doubt in this file is to redact.
-        Some((q, _, tail))
-            if tail
-                .chars()
-                .all(|c| c.is_whitespace() || matches!(c, ',' | ';' | ')' | ']' | '}')) =>
-        {
-            format!("{lead}{q}[REDACTED]{q}{tail}")
-        }
+        Some((q, _, tail)) if is_only_punctuation(tail) => format!("{lead}{q}[REDACTED]{q}{tail}"),
         Some((q, _, _)) => format!("{lead}{q}[REDACTED]{q}"),
         None => format!("{lead}[REDACTED]"),
     })
+}
+
+/// Whether what follows a closing quote is only syntax, so it can be handed
+/// back with the line. Anything else could be a second literal, and the
+/// direction of doubt in this file is to redact.
+fn is_only_punctuation(tail: &str) -> bool {
+    tail.chars()
+        .all(|c| c.is_whitespace() || matches!(c, ',' | ';' | ')' | ']' | '}'))
 }
 
 /// A quoted value's parts: the quote character, the literal between the quotes,
@@ -1239,11 +1244,20 @@ mod tests {
         );
 
         // Anything past the closing quote that is not punctuation could be a
-        // second literal, so it goes with the first.
-        assert_eq!(
-            redact_assignment("API_KEY", " \"sk-one\" \"sk-two\""),
-            Some(" \"[REDACTED]\"".to_string())
-        );
+        // second literal, so it goes with the first. Review's case is the same
+        // shape with the empty segment first, where reading emptiness alone
+        // would have delivered the credential untouched.
+        for (key, value, expected) in [
+            ("API_KEY", " \"sk-one\" \"sk-two\"", " \"[REDACTED]\""),
+            ("API_KEY", " \"\"sk-secret\"", " \"[REDACTED]\""),
+            ("password", " \'\'hunter2\'", " \'[REDACTED]\'"),
+        ] {
+            assert_eq!(
+                redact_assignment(key, value),
+                Some(expected.to_string()),
+                "{key}={value} kept a literal the reader should not see"
+            );
+        }
     }
 
     /// #559. `echo "pass=$P/10"` after a ten-run test loop came back as


### PR DESCRIPTION
`apiKey = "",` in a `.tsx` was delivered as `apiKey = "[REDACTED]"`. No comma, and
no credential anywhere in the file.

The value is split off at the first `=`, so it reaches `redact_assignment` carrying
its quotes and its trailing punctuation. `value.trim().is_empty()` therefore never
fired on an empty string, and the replacement overwrote everything after the opening
quote. That second half is the punctuation loss #486 fixed for HCL, which did not
generalise past a value with nothing after it. An agent that copies the delivered
line into an edit writes a syntax error, and nothing in the output says the
punctuation moved.

The literal between the quotes now answers both questions. Single quotes keep their
delimiter, which they never did. A tail that is not punctuation could be a second
literal and is still redacted, so the direction of doubt in this file does not change.

Reproduced on 0.7.8 through `omni --post-hook`. Not through `omni exec`, which
declines a 12 line file at the size gate.

before:

```
[OMNI: 2 sensitive value(s) redacted]
export function Demo({
  open,
  apiKey = "[REDACTED]"
  token = "[REDACTED]"
  label = "hello",
```

after:

```
export function Demo({
  open,
  apiKey = "",
  token = "",
  label = "hello",
```

Each of the three new assertions was driven red on its own break: the emptiness test
reading the raw value again, the tail dropped, the tail handed back unconditionally.

Closes #726




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR completes the fix for empty quoted defaults and punctuation-preserving credential redaction.
- Parses quoted assignments into delimiter, literal, and trailing content.
- Leaves genuinely empty quoted defaults unchanged only when the suffix is punctuation.
- Preserves safe punctuation after redacted values while redacting non-punctuation tails.
- Adds regression coverage for double-quoted and single-quoted assignments, including the previously reported empty-prefix bypass.
- Documents the correction in the changelog.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/distillers/system_ops.rs | Refines quoted-assignment parsing and redaction so empty defaults and safe punctuation are preserved without allowing credential-bearing tails through. |
| changelog.d/726.fixed.md | Accurately documents the empty-default and punctuation-loss fixes. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(distillers): an empty first segment ..."](https://github.com/fajarhide/omni/commit/3a5f6f14f242120152456929fcd67ab82fe1a1fa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58208872)</sub>

<!-- /greptile_comment -->