### PR TITLE
fix(stats): key a command class on what wrote the output, not on its cd

### DIFF
--- a/changelog.d/706.fixed.md
+++ b/changelog.d/706.fixed.md
@@ -1,0 +1,12 @@
+- **A third of all traffic was filed under `cd` (#706)**: command classes were keyed
+  on the first two words of the recorded string, and half of what an agent runs is a
+  multi-line block whose first line changes directory. So `omni stats --view
+  commands`, `omni context --tokens` and the per-agent map all answered "where did
+  your bytes go" with the name of a directory change, 7,222 calls deep on this
+  machine's corpus, and the answer was true and unusable. The key is now the segment
+  that actually wrote the output, the same predicate the pipeline routes on, so the
+  block is filed under the program that produced the bytes. A leading loop keyword
+  goes the same way, since `do` names no program either, and the program is reduced
+  to its file name so `/opt/homebrew/bin/python3` and `python3` are one row. The
+  local absolute path that used to head the table goes with the `cd`: 6 of 2,051
+  classes still carry one, against the single heaviest class before.

--- a/src/cli/stats.rs
+++ b/src/cli/stats.rs
@@ -191,11 +191,28 @@ pub(crate) fn get_top_commands(
 }
 
 fn shorten_command(cmd: &str, max_len: usize) -> String {
-    let parts: Vec<&str> = cmd.split_whitespace().collect();
-    let short = match parts.len() {
-        0 => return "[pipe]".to_string(),
-        1 => parts[0].to_string(),
-        _ => format!("{} {}", parts[0], parts[1]),
+    // Half of all recorded commands are multi-line blocks whose first line is a
+    // `cd`, so the first two words of the raw string filed them under one
+    // directory change and the heaviest class in every report was `cd` (#706).
+    // `producing_segment` is the predicate the pipeline already routes on, so the
+    // key names whatever actually wrote the bytes, and the local absolute path
+    // that came with `cd` goes with it.
+    let segment = crate::pipeline::producer::producing_segment(cmd);
+    // A loop body's segment opens with the keyword that introduced it, so
+    // `for n in 1 2; do echo hi; done` keyed as `do echo`. Stripped here rather
+    // than in `producing_segment`, which the pipeline routes on: the label wants
+    // the program, and routing has no opinion about the word in front of it.
+    let mut parts = segment
+        .split_whitespace()
+        .skip_while(|w| matches!(*w, "do" | "then" | "else"));
+    let short = match (parts.next(), parts.next()) {
+        (None, _) => return "[pipe]".to_string(),
+        // The file name, not the path: `/opt/homebrew/bin/python3` and `python3`
+        // are one program, the same reason `producer_label` reduces it (#339).
+        (Some(prog), None) => crate::pipeline::producer::program_name(prog).to_string(),
+        (Some(prog), Some(arg)) => {
+            format!("{} {arg}", crate::pipeline::producer::program_name(prog))
+        }
     };
     if short.len() <= max_len {
         short
@@ -2668,6 +2685,31 @@ mod tests {
         let args: Vec<String> = vec!["stats".into(), "--json".into()];
         let result = run(&args, &store);
         assert!(result.is_ok());
+    }
+
+    /// #706. Half of all recorded commands are multi-line blocks opening with a
+    /// `cd`, so the first two words keyed them under one directory change and the
+    /// heaviest class in every report named nothing that produced a byte. On this
+    /// machine's corpus that one key held 7,222 calls.
+    ///
+    /// A filtering tail owns the payload, so `| grep` keys as grep. That is the
+    /// same predicate the pipeline routes on, which is the point of reusing it.
+    #[test]
+    fn keys_a_block_on_what_wrote_the_output_not_on_its_cd() {
+        for (cmd, expected) in [
+            ("cd /tmp && kubectl get pods", "kubectl get"),
+            ("K=1 cd /tmp\nsed -n 1,20p f.rs", "sed -n"),
+            // The loop keyword goes with the `cd`: `do` names no program either.
+            (
+                "cd /Users/fajar/p\nfor n in 1 2; do echo hi; done",
+                "echo hi",
+            ),
+            // The file name, not the path, so one program is one row (#339).
+            ("/opt/homebrew/bin/python3 x.py", "python3 x.py"),
+            ("cat package.json", "cat package.json"),
+        ] {
+            assert_eq!(shorten_command(cmd, CMD_KEY_WIDTH), expected, "{cmd}");
+        }
     }
 
     /// The agent map is keyed by `shorten_command(cmd, CMD_KEY_WIDTH)`, and the

--- a/src/pipeline/producer.rs
+++ b/src/pipeline/producer.rs
@@ -425,6 +425,17 @@ fn words(s: &str) -> impl Iterator<Item = &str> {
 /// `/opt/homebrew/opt/python@3.11/bin/python3.11` and `python3.11` are one
 /// program and must be one row.
 pub(crate) fn producer_label(command: &str) -> &str {
+    program_name(producing_segment(command))
+}
+
+/// The segment that wrote the output, with assignments stripped: what
+/// `producer_label` names before it reduces to the program.
+///
+/// Split out for `shorten_command`, which needs the words after the program and
+/// so cannot use the label. Keying stats on the first two words of the raw
+/// string filed a third of all traffic under `cd`, because that many recorded
+/// commands are multi-line blocks whose first line changes directory (#706).
+pub(crate) fn producing_segment(command: &str) -> &str {
     // The producer when there is a single one, and otherwise the first segment
     // that actually runs something. `sole_output_command` answers `None` for a
     // chain with two producers, and the raw string it was falling back to begins
@@ -441,7 +452,7 @@ pub(crate) fn producer_label(command: &str) -> &str {
                 .find(|seg| !is_silent(seg))
         })
         .unwrap_or(command);
-    program_name(strip_assignments(segment))
+    strip_assignments(segment)
 }
 
 /// The bare program name of an already-stripped command.


### PR DESCRIPTION
`shorten_command` took the first two whitespace-separated words. On this machine's
corpus 4,468 of 8,515 recorded commands open with `cd `, 3,452 of them multi-line
blocks, so a third to a half of all traffic grouped under one key named after a
directory change. It was the heaviest class in every report that uses the key.

`producing_segment` is `producer_label` minus its last step, extracted rather than
written again: the pipeline already decides which segment owns the output, and a
second copy of that predicate is how the two halves of #339 came apart. A leading
`do`, `then` or `else` is stripped in the caller instead of in the shared function,
because routing has no opinion about the word in front of a program.

Before and after, same DB, `omni stats --view commands`:

```
-   3. cd /Users/fajar... Claude Code 7222x   3.8% -205.7 KB
+   3. sed -n             Claude Code 1559x   6.1% -185.4 KB
-   5. /bin/zsh -c        Claude Code  282x   1.7% -137.5 KB
+   5. zsh -c             Claude Code  282x   1.7% -137.5 KB
+  10. git diff           Claude Code  198x  19.7%  -43.1 KB
-   Top 10 of 210 with savings, 876 at 0% hidden
+   Top 10 of 264 with savings, 1799 at 0% hidden
```

The issue also asked whether the key should drop paths entirely. Measured after the
change: 6 of 2,051 classes still carry a home-absolute path, against the single
heaviest row before, and all 6 are the argument rather than the program. Stripping
the directory off arguments too would merge `cat src/main.rs` with
`cat tests/main.rs`, so it is left alone and the question is answered rather than
carried.

Closes #706


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR changes command-statistics grouping to derive keys from the pipeline’s existing output-producer selection rather than the beginning of the raw command string.
- Extracts `producing_segment` from `producer_label` while preserving existing producer-label behavior.
- Uses the producing segment, strips shell clause prefixes, and normalizes executable paths when creating statistics keys.
- Adds regression coverage and a changelog entry for command blocks beginning with `cd`.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified in the changed behavior.

The producer-selection extraction preserves existing routing labels, and the new statistics key consistently reuses that selection while covering the primary multiline, loop, path-normalization, and ordinary-command cases.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/cli/stats.rs | Replaces raw first-two-word grouping with producer-aware command keys and adds focused regression coverage. |
| src/pipeline/producer.rs | Extracts the producing segment selection from `producer_label` without changing its existing labeling result. |
| changelog.d/706.fixed.md | Documents the corrected attribution of multiline command blocks in statistics reports. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Recorded command] --> B[producing_segment]
  B --> C[Strip assignments]
  C --> D[Skip do / then / else]
  D --> E[Normalize executable basename]
  E --> F[Keep first two words]
  F --> G[Command statistics key]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(stats): key a command class on what ..."](https://github.com/fajarhide/omni/commit/ab79e043a419695fcd517a9e4bb620220c22d05c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58212285)</sub>

**Context used:**

- Knowledge Base — [CLI command workflows](https://app.greptile.com/weekndlabs/-/custom-context/knowledge-base/fajarhide/omni/-/docs/cli-command-workflows.md)
- Knowledge Base — [Pipeline stages and quality controls](https://app.greptile.com/weekndlabs/-/custom-context/knowledge-base/fajarhide/omni/-/docs/pipeline-stages-and-quality.md)

<!-- /greptile_comment -->