### PR TITLE
fix(bench): a competitor that changed nothing is a broken binary, not a loss

### DIFF
--- a/changelog.d/733.fixed.md
+++ b/changelog.d/733.fixed.md
@@ -1,0 +1,13 @@
+- **A competitor arm that changed nothing was published as a measured loss (#733)**:
+  every arm in the head-to-head hands back the raw payload when its binary fails,
+  `rtk_out` from three separate paths, so a tool that cannot spawn or cannot parse its
+  arguments does not go silent the way #711's headroom arm did. It emits a full table of
+  unchanged bytes and lands as a tidy 0.0% row, which is what `caveman tools compress`
+  did for four releases, and #730's presence check cannot see it because the row is
+  there. A named arm whose filter-only row saved nothing now aborts the artifact instead
+  of publishing the zero. headroom is not probed that way on purpose: its arm already
+  panics when it produces no number, and a headroom that deduped nothing would read as
+  the filters-only figure rather than as zero. What the machine could not find is
+  recorded in `arms_absent`, so a three-arm table can no longer be read as a four-arm
+  comparison, and `OMNI_BENCH_ARMS=off` works again after #732 made an empty `arms` read
+  as a failed measurement.

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -48,7 +48,7 @@ trap 'rm -f "$LOG"' EXIT
 # Cost: the competitor arms spawn a process per trace, so a full run is ~20 minutes
 # against ~40 seconds for ours alone. `OMNI_BENCH_ARMS=off` skips them when the
 # question is only whether a change moved our own number.
-declare -a ARMS_RUN=()
+declare -a ARMS_RUN=() ARMS_ABSENT=()
 if [ "${OMNI_BENCH_ARMS:-on}" != "off" ]; then
   # caveman is not on PATH and is not a bare `caveman`: the binary that compresses
   # is `caveman-engine`. See the caveman_out docstring for what naming a plausible
@@ -59,11 +59,19 @@ if [ "${OMNI_BENCH_ARMS:-on}" != "off" ]; then
   : "${OMNI_BENCH_CAVEMAN:=$([ -x "$HOME/.caveman/bin/caveman-engine" ] && echo "$HOME/.caveman/bin/caveman-engine" || true)}"
   for arm in RTK LEANCTX HEADROOM CAVEMAN; do
     var="OMNI_BENCH_$arm"
-    if [ -n "${!var:-}" ]; then export "$var"; ARMS_RUN+=("$arm"); else unset "$var" || true; fi
+    if [ -n "${!var:-}" ]; then
+      export "$var"; ARMS_RUN+=("$arm")
+    else
+      # Greptile on #712. An arm nobody could find used to vanish without a trace,
+      # so a three-arm table and a four-arm table were the same artifact. Recorded
+      # rather than refused: a machine without the competitors installed still has
+      # a legitimate reason to run this, and the artifact should say which it is.
+      unset "$var" || true; ARMS_ABSENT+=("$arm")
+    fi
   done
 fi
 echo "replaying $(wc -l < "$CORPUS" | tr -d ' ') traces against $VERSION ($COMMIT)"
-echo "arms: ${ARMS_RUN[*]:-none}"
+echo "arms: ${ARMS_RUN[*]:-none}${ARMS_ABSENT:+ (absent: ${ARMS_ABSENT[*]})}"
 OMNI_BENCH_CORPUS="$CORPUS" \
   cargo test --release --test bench_replay -- --ignored --nocapture >"$LOG" 2>&1 || {
   tail -30 "$LOG" >&2
@@ -75,10 +83,11 @@ mkdir -p "$OUT_DIR"
 # here, so this script cannot disagree with the harness it ran. A missing field
 # is left null instead of defaulted: a benchmark that reports 0 where it failed
 # to read is the failure mode this whole ticket is about.
-python3 - "$LOG" "$MANIFEST" "$VERSION" "$COMMIT" "$OUT_DIR" "$DIRTY" "${ARMS_RUN[*]:-}" <<'PY'
+python3 - "$LOG" "$MANIFEST" "$VERSION" "$COMMIT" "$OUT_DIR" "$DIRTY" "${ARMS_RUN[*]:-}" \
+  "${ARMS_ABSENT[*]:-}" <<'PY'
 import json, re, sys
 
-log, manifest_path, version, commit, out_dir, dirty, arms_run = sys.argv[1:8]
+log, manifest_path, version, commit, out_dir, dirty, arms_run, arms_absent = sys.argv[1:9]
 text = open(log, errors="replace").read()
 manifest = json.load(open(manifest_path))
 
@@ -270,9 +279,18 @@ report = {
         # arms are absent from the dict; an arm that was named and produced no row
         # aborts below rather than being published as a zero.
         "arms": arms(),
+        # Greptile on #712. Which competitors this machine could not find, so a
+        # table with three arms cannot be read as a complete four-arm comparison.
+        "arms_absent": arms_absent.split(),
     },
 }
-missing = [k for k, v in report["result"].items() if v is None or v == {}]
+required = dict(report["result"])
+# The replay prints the head-to-head block only when at least one competitor was
+# named, so with `OMNI_BENCH_ARMS=off` an empty `arms` is the correct answer rather
+# than a failed read. Required whenever an arm was asked for, and only then.
+if not arms_run.split():
+    required.pop("arms", None)
+missing = [k for k, v in required.items() if v is None or v == {}]
 if missing:
     sys.exit(f"replay output did not carry: {', '.join(missing)}")
 
@@ -293,6 +311,28 @@ silent = [
 ]
 if silent:
     sys.exit(f"named arms produced no row: {'; '.join(silent)}")
+
+# Greptile on #712, and the sharper half of the same defect. Every competitor arm
+# returns the raw payload on any failure, `rtk_out` from three separate paths, so a
+# binary that cannot spawn, cannot parse its arguments, or writes nothing does not go
+# silent. It emits a full table of unchanged bytes and lands as a tidy 0.0% row. That
+# is what `caveman tools compress` was doing, and a presence check cannot see it.
+#
+# headroom is deliberately not probed here: its arm panics outright when it produces
+# no number (#711), and a headroom that deduped nothing would read as our own
+# filters-only figure rather than as zero, so a zero test would never fire on it.
+PROBE = {"RTK": "rtk", "LEANCTX": "lean_ctx", "CAVEMAN": "caveman"}
+inert = [
+    f"{arm} ({key} saved {report['result']['arms'][key]['saved_pct']}%)"
+    for arm in arms_run.split()
+    for key in [PROBE.get(arm)]
+    if key and report["result"]["arms"].get(key, {}).get("saved_pct") == 0.0
+]
+if inert:
+    sys.exit(
+        "named arms changed nothing on any trace, which is a broken binary and not "
+        f"a measured loss: {'; '.join(inert)}"
+    )
 
 path = f"{out_dir}/{version}.json"
 with open(path, "w") as fh:

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -321,12 +321,21 @@ if silent:
 # headroom is deliberately not probed here: its arm panics outright when it produces
 # no number (#711), and a headroom that deduped nothing would read as our own
 # filters-only figure rather than as zero, so a zero test would never fire on it.
+#
+# Greptile again, on the first version of this check: it read `saved_pct`, which is
+# rounded to one decimal, so a competitor that genuinely saved under 0.05% would have
+# been failed as broken. The bytes are in the artifact unrounded, and `output ==
+# input` says exactly what this needs to say, that not one byte moved across the whole
+# corpus. rtk's own claimed count cannot stand in for it: `rtk_claimed` counts
+# commands *our* `rtk_filter` mapped, whether or not their binary then did anything.
 PROBE = {"RTK": "rtk", "LEANCTX": "lean_ctx", "CAVEMAN": "caveman"}
 inert = [
-    f"{arm} ({key} saved {report['result']['arms'][key]['saved_pct']}%)"
+    f"{arm} ({key} returned all {report['result']['arms'][key]['input_bytes']:,} bytes)"
     for arm in arms_run.split()
     for key in [PROBE.get(arm)]
-    if key and report["result"]["arms"].get(key, {}).get("saved_pct") == 0.0
+    if key
+    and (a := report["result"]["arms"].get(key))
+    and a["output_bytes"] == a["input_bytes"]
 ]
 if inert:
     sys.exit(


### PR DESCRIPTION
The fixes #732's own review asked for. They were written and answered on that thread,
and the commit carrying them was never pushed, so the merge went in without them.

**A broken competitor publishes as a 0.0% loss.** Every arm returns the raw payload on
failure, `rtk_out` from three separate paths, so a binary that cannot spawn or cannot
parse its arguments does not go silent the way #711's headroom arm did. It emits a full
table of unchanged bytes and lands as a tidy row. #730's presence check cannot see that,
because the row is there. A named arm whose filter-only row saved nothing now aborts the
artifact. headroom stays unprobed by that test on purpose: its arm already panics when
it produces no number, and a headroom that deduped nothing would read as our
filters-only figure rather than as zero.

**A missing binary is recorded, not refused.** `arms_absent` names what the machine
could not resolve, so a three-arm table cannot be read as a four-arm comparison. A
machine with none of them installed still has a good reason to run this.

**`OMNI_BENCH_ARMS=off` aborted**, introduced by #732 itself. The replay prints the
head-to-head block only when an arm is named, so an empty `arms` was read as a failed
measurement. Required only when an arm was asked for.

Verified, each proved able to fail:

- inert-arm guard, four directions: healthy passes; an inert caveman that is still named
  aborts with `CAVEMAN (caveman saved 0.0%)`; an inert caveman that was not named passes;
  a zero headroom passes by design
- `OMNI_BENCH_ARMS=off ./scripts/bench.sh` end to end, `rc=0`, `arms {}`,
  `arms_absent []`, artifact written

Closes #733




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR records unavailable benchmark arms, permits intentionally disabled competitor measurements, and replaces the rounded-percentage inert-arm check with an aggregate byte comparison.
- Adds `arms_absent` metadata to generated benchmark artifacts.
- Makes the `arms` result optional when `OMNI_BENCH_ARMS=off`.
- Rejects named competitor rows whose aggregate output equals aggregate input, although this remains unable to distinguish unchanged traces from offsetting per-trace changes.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until the inert-arm guard distinguishes truly unchanged per-trace output from valid changes that cancel in the aggregate.

The revised guard compares only aggregate byte totals, so a working competitor that shrinks and expands different traces by equal amounts still aborts artifact generation.

**Files Needing Attention:** scripts/bench.sh
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| scripts/bench.sh | Adds absent-arm reporting and disabled-arm handling, but the revised inert-arm guard still falsely aborts when valid per-trace changes have a net-zero aggregate byte delta. |
| changelog.d/733.fixed.md | Documents the benchmark reporting and validation changes. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20fajarhide%2Fomni%20PR%20%23734%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=fajarhide%2Fomni&pr=734&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Ascripts%2Fbench.sh%3A338%0A**Aggregate%20equality%20misclassifies%20changed%20output**%0A%0AWhen%20a%20healthy%20named%20competitor%20shrinks%20some%20traces%20and%20expands%20others%20by%20the%20same%20total%20number%20of%20bytes%2C%20this%20aggregate%20comparison%20treats%20the%20arm%20as%20having%20returned%20every%20trace%20unchanged%20and%20aborts%20artifact%20generation.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni&pr=734&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fajarhide%2Fomni%22%20on%20the%20existing%20branch%20%22fix%2F733-inert-arm-guard%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F733-inert-arm-guard%22.%0A%0A%23%23%23%20Issue%201%0Ascripts%2Fbench.sh%3A338%0A**Aggregate%20equality%20misclassifies%20changed%20output**%0A%0AWhen%20a%20healthy%20named%20competitor%20shrinks%20some%20traces%20and%20expands%20others%20by%20the%20same%20total%20number%20of%20bytes%2C%20this%20aggregate%20comparison%20treats%20the%20arm%20as%20having%20returned%20every%20trace%20unchanged%20and%20aborts%20artifact%20generation.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni&pr=734&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Ascripts%2Fbench.sh%3A338%0A**Aggregate%20equality%20misclassifies%20changed%20output**%0A%0AWhen%20a%20healthy%20named%20competitor%20shrinks%20some%20traces%20and%20expands%20others%20by%20the%20same%20total%20number%20of%20bytes%2C%20this%20aggregate%20comparison%20treats%20the%20arm%20as%20having%20returned%20every%20trace%20unchanged%20and%20aborts%20artifact%20generation.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=734&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fajarhide%2Fomni%22%20on%20the%20existing%20branch%20%22fix%2F733-inert-arm-guard%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F733-inert-arm-guard%22.%0A%0A%23%23%23%20Issue%201%0Ascripts%2Fbench.sh%3A338%0A**Aggregate%20equality%20misclassifies%20changed%20output**%0A%0AWhen%20a%20healthy%20named%20competitor%20shrinks%20some%20traces%20and%20expands%20others%20by%20the%20same%20total%20number%20of%20bytes%2C%20this%20aggregate%20comparison%20treats%20the%20arm%20as%20having%20returned%20every%20trace%20unchanged%20and%20aborts%20artifact%20generation.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
scripts/bench.sh:338
**Aggregate equality misclassifies changed output**

When a healthy named competitor shrinks some traces and expands others by the same total number of bytes, this aggregate comparison treats the arm as having returned every trace unchanged and aborts artifact generation.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(bench): judge an inert arm on bytes,..."](https://github.com/fajarhide/omni/commit/7f251a278767a98599edf1f947727265939f3633) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58331119)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->