### PR TITLE
fix(ledger): a command that named its line budget keeps its lines

### DIFF
--- a/changelog.d/735.fixed.md
+++ b/changelog.d/735.fixed.md
@@ -1,0 +1,20 @@
+- **A `tail -5` came back as a handle and none of its five lines (#735)**:
+  the coverage floor added by #543 and tightened by #643 asks what share of the
+  *payload* a fold took, and a compound reply hides the answer. The reported call was
+  `cat notes.md; echo ---; tail -5 index.md`, where every line of the `tail` was folded
+  through the project scope and the run still measured 45%, because the `cat` in front
+  of it paid for the other 55%. The floor never looked, #705's whole-output guard never
+  fired because the `cat` survived, and the reader got a header announcing content
+  followed by a marker instead of it, then spent an `omni retrieve` to get back 965
+  bytes the fold had saved 910 of. Nothing at that stage can find a command boundary
+  inside a joined payload, so the ledger now asks the command rather than the bytes: a
+  `head` or `tail` counting lines has already named the answer, so its retrieval is not
+  a risk the project scope is taking, it is the outcome. Only the project scope is
+  refused, since the session scope's reader is holding the bytes and its handle costs
+  nothing. `tail -f` and `head -c` do not count, because neither names a set of lines.
+  Deliberately narrower than `registry::passes_through_verbatim`, which reaches the same
+  conclusion one stage earlier for the collapse fallback: its list carries `cat` and
+  `grep`, and those are where the project scope earns most of what it earns. Measured
+  over the 7 days in `ledger_folds`, 569 folds and 564,995 bytes: dropping the size
+  precondition on the existing floor instead, which is what the report first proposed,
+  would give up 170,518 bytes, 30.2% of every byte folded, and still miss this case.

--- a/changelog.d/736.fixed.md
+++ b/changelog.d/736.fixed.md
@@ -1,0 +1,13 @@
+- **The ledger was told which command it was answering on one door of three (#736)**:
+  `Ledger::from` names the command a reply belongs to, and only `fold_cross_turn`
+  passed it. `process_payload`, which is where a Bash reply actually meets the ledger,
+  and `pipe::distill`, which is where an `omni exec` reply does, both left it empty,
+  though each had the command in scope. An empty source never equals a recorded one, so
+  #622's differing-source clause could not fire on either: a marker there either named a
+  source it should not have or, on a first sighting, said nothing while the ledger knew
+  better. It also made #735's guard inert on the only path that had reported the defect,
+  which is how the same fix could pass its unit test and change nothing in the shipped
+  binary. Driving the built binary through `--post-hook`, a repeat now reads
+  `200 lines not shown here from cat handlers.log` where it read `200 lines not shown
+  here`. Same shape as #452, #454 and #456: one pipeline, more than one entrance, and a
+  fix applied to whichever entrance the report came through.

--- a/src/hooks/pipe.rs
+++ b/src/hooks/pipe.rs
@@ -359,6 +359,11 @@ fn distill(
             .with_project(crate::paths::project_key(std::path::Path::new(
                 &project_path,
             )))
+            // #736, the third door. `post_tool` named its command and this did
+            // not, which is the drift #452, #454 and #456 each paid for once:
+            // one pipeline, two entrances, a fix applied to whichever one the
+            // report happened to come through.
+            .from(command_name.unwrap_or(""))
             .by(resolve_pipe_agent_id())
             .project(&output)
     {

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -811,6 +811,12 @@ pub fn process_payload(
             .with_project(crate::paths::project_key(std::path::Path::new(
                 &project_path,
             )))
+            // #736. This is the door a Bash reply comes through, and it was the
+            // one door of three that never named its command, so every guard and
+            // marker reading the source was inert here. #735's fix went in at
+            // `fold_cross_turn` and did nothing to a real `tail -5` until this
+            // line existed.
+            .from(normalized.command.as_str())
             .by(_agent_id)
             .project(&final_out)
     {

--- a/src/ledger/mod.rs
+++ b/src/ledger/mod.rs
@@ -733,7 +733,28 @@ impl<'a> Ledger<'a> {
         // refusing outright keeps an honest session fold in the mixed payload, and
         // leaves the reader real lines to weigh the marker against. Priced over
         // the recorded corpus: 10 folds, 32,104 bytes, 1.51% of all folded bytes.
-        if planned.iter().all(|&fold| fold) {
+        //
+        // #735 widens the same remedy to a second case the coverage floor above
+        // cannot see. That floor asks what share of the *payload* went, and a
+        // compound reply hides the answer: `cat notes.md; echo ---; tail -5 log`
+        // folded all five lines of the `tail` and still measured 45%, because the
+        // `cat` before it paid for the other 55%. Nothing here can find the
+        // command boundary inside a joined payload, so this asks the command
+        // instead of the bytes.
+        //
+        // A command that rations its own output has already named the answer.
+        // `tail -5` means those five lines are the question and not the
+        // background, so retrieval is not a risk the project scope is taking, it
+        // is the outcome. That is why the bet is off here and nowhere else: the
+        // session scope keeps folding, because there the reader is holding the
+        // bytes and the handle costs it nothing.
+        //
+        // Deliberately narrower than `registry::passes_through_verbatim`, which
+        // reaches the same conclusion one stage earlier for the collapse
+        // fallback. Its list carries `cat` and `grep`, and those are where the
+        // project scope earns most of what it earns, so borrowing it wholesale
+        // would pay for this report with the feature.
+        if planned.iter().all(|&fold| fold) || rations_its_output(&self.source) {
             for (fold, run) in planned.iter_mut().zip(&runs) {
                 if run
                     .seen
@@ -891,6 +912,26 @@ fn group_runs(hashes: &[String], origin_of: &dyn Fn(&String) -> Option<Seen>) ->
         }
     }
     runs
+}
+
+/// Whether the command rationed its own output to a set of lines it named.
+///
+/// `head` and `tail` only, and only when they are counting lines. `tail -f`
+/// never ends and `head -c` counts bytes, so neither of those says the reader
+/// picked a set of lines it now wants to read. A bare `head file` is as explicit
+/// as `head -10 file`, since the default is what the reader accepted.
+///
+/// Matched on whole tokens and on the basename, so `/usr/bin/tail` counts and a
+/// `--tail` flag or a `tailwind` argument does not.
+fn rations_its_output(command: &str) -> bool {
+    let tokens: Vec<&str> = command.split_whitespace().collect();
+    tokens.iter().enumerate().any(|(i, tok)| {
+        let base = tok.rsplit('/').next().unwrap_or(tok);
+        (base == "head" || base == "tail")
+            && tokens.get(i + 1).is_none_or(|next| {
+                !(next.starts_with('-') && next.trim_start_matches('-').starts_with(['c', 'f']))
+            })
+    })
 }
 
 /// A line's identity in the ledger.
@@ -1492,6 +1533,85 @@ mod tests {
             !view.contains("already shown"),
             "a project repeat was reported as a session repeat: {view}"
         );
+    }
+
+    /// #735. The coverage floor asks what share of the *payload* a fold took, and
+    /// a compound reply hides the answer. The report folded all five lines of a
+    /// `tail -5` and still measured 45%, because the `cat` in front of it paid for
+    /// the other 55%, so the reader was handed a header announcing content and
+    /// then a marker instead of it.
+    ///
+    /// Both arms in one test on purpose. The guard has to be the command and not
+    /// the project scope: unbudgeted commands must still fold, or the fix costs
+    /// the feature rather than the defect.
+    ///
+    /// Each arm carries its own fresh block, and that is load-bearing. Sharing
+    /// one payload lets the first arm record the other's survivors, which leaves
+    /// every run project-seen and hands the refusal to #705's whole-output guard
+    /// instead. The test then passes with this guard deleted, which is how the
+    /// first draft of it read.
+    #[test]
+    fn a_line_budgeted_command_keeps_the_lines_it_asked_for() {
+        let (store, _d) = temp_store();
+        let repeated = project_repeat();
+        let unbudgeted = format!("{repeated}{}", fresh_block("cache probe"));
+        let budgeted = format!("{repeated}{}", fresh_block("queue probe"));
+        Ledger::new(&store, "s1")
+            .with_project("/repo")
+            .project(&repeated);
+
+        let folded = Ledger::new(&store, "s2")
+            .with_project("/repo")
+            .from("cat handlers.log")
+            .project(&unbudgeted)
+            .expect("a command that named no line budget still folds");
+        assert!(
+            folded.contains("not shown here"),
+            "the unbudgeted arm stopped folding, so this test no longer proves \
+             the guard reads the command: {folded}"
+        );
+
+        // Same store, same project history, survivors of its own. Only the
+        // command differs.
+        let view = Ledger::new(&store, "s3")
+            .with_project("/repo")
+            .from("cat notes.md; echo ---; tail -5 handlers.log")
+            .project(&budgeted)
+            .unwrap_or_else(|| budgeted.clone());
+        assert!(
+            !view.contains("not shown here"),
+            "a tail -5 was answered with a handle for lines this session never held: {view}"
+        );
+        assert!(
+            view.contains("handler finished request 0"),
+            "the budgeted arm kept the marker out but lost the lines anyway: {view}"
+        );
+    }
+
+    /// The predicate on its own, in both directions. A line budget counts and a
+    /// byte budget or a follow does not, and neither does a word that merely
+    /// contains one of the names.
+    #[test]
+    fn rations_its_output_reads_a_line_budget_and_nothing_else() {
+        for cmd in [
+            "tail -5 notes.md",
+            "tail -n 5 notes.md",
+            "cargo test | tail -30",
+            "head -20 src/main.rs",
+            "head notes.md",
+            "/usr/bin/tail -1 notes.md",
+        ] {
+            assert!(rations_its_output(cmd), "should ration: {cmd}");
+        }
+        for cmd in [
+            "tail -f /var/log/app.log",
+            "head -c 200 notes.md",
+            "cat notes.md",
+            "kubectl logs pod --tail=20",
+            "npm run build -- --watch tailwind.config.js",
+        ] {
+            assert!(!rations_its_output(cmd), "should not ration: {cmd}");
+        }
     }
 
     /// #567. The run marker said `from an earlier session`, which states where the


### PR DESCRIPTION
A `tail -5` came back as one marker and none of its five lines. The coverage floor asks what share of the payload a fold took, and a compound reply hides the answer: every line of the `tail` went and the run still measured 45%, because the `cat` in front of it paid for the rest. #705's whole-output guard slept for the same reason.

Nothing at that stage can find a command boundary inside a joined payload, so the ledger asks the command instead. A `head` or `tail` counting lines has named the answer, so the project scope's retrieval is not a risk it is taking, it is the outcome. Session scope is untouched: that reader is holding the bytes. `tail -f` and `head -c` do not count. Deliberately narrower than `registry::passes_through_verbatim`, whose list carries `cat` and `grep`, which is where the project scope earns most of what it earns.

The second commit is why the first one matters. `Ledger::from` was passed on one door of three, and a Bash reply meets the ledger on one of the two that dropped it, so the guard passed its unit test and changed nothing in the binary. Filed as #736 before it was fixed here.

Driving the built binary through `--post-hook`, same store, same primed block, same payload, only the command differing:

```
before  budgeted  [OMNI: 200 lines not shown here, omni retrieve f29cb82c...]
        control   [OMNI: 200 lines not shown here, omni retrieve f29cb82c...]
after   budgeted  no rewrite, the host keeps its bytes
        control   [OMNI: 200 lines not shown here from cat handlers.log, ...]
```

The control still folds, and now names the command that first showed those lines, which is #622's clause that this door could never render.

`make ci` green. The ledger guard's three assertions were each driven red: guard removed, predicate forced true, and the `-c`/`-f` exclusion removed. The first draft passed with the guard deleted, because one shared payload let the first arm record the other's survivors and handed the refusal to #705 instead; each arm now carries its own fresh block.

The door change has no unit-level check. `process_payload` returns None for this fixture in the harness whatever the command is, including shapes an existing passing test folds, and running that down is a larger job than a one-line argument pass. Verified at the boundary instead.

Measured before choosing the shape, 7 days of `ledger_folds`, 569 folds and 564,995 bytes: the alternative the report first proposed, dropping the size precondition on the existing floor, gives up 170,518 bytes, 30.2% of every byte folded, and still misses this case.

Closes #735, closes #736


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR carries command identity into the ledger from the post-tool and pipe entry points, then preserves project-seen output when a command appears to request a bounded set of lines.
- Adds command-source propagation for Bash post-hook and pipe processing.
- Adds a ledger guard for line-oriented `head` and `tail` commands while excluding byte and follow modes.
- Adds regression tests and changelog entries for the two corrected ledger behaviors.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking command-parsing issue that can unnecessarily disable project-level deduplication.

The ledger’s new whitespace-token predicate interprets standalone `head` and `tail` arguments as executed line-budget commands, causing repeated project output to remain verbatim for unrelated commands.

**Files Needing Attention:** src/ledger/mod.rs
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/ledger/mod.rs | Adds the line-budget guard and regression coverage; token scanning also mistakes standalone command arguments for executed `head` or `tail`. |
| src/hooks/post_tool.rs | Propagates the normalized command into the ledger on the Bash post-tool path. |
| src/hooks/pipe.rs | Propagates an available pipe command name into the ledger. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20fajarhide%2Fomni%20PR%20%23737%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=fajarhide%2Fomni&pr=737&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fledger%2Fmod.rs%3A929-934%0A**Standalone%20arguments%20trigger%20rationing**%0A%0AThe%20predicate%20treats%20any%20standalone%20%60head%60%20or%20%60tail%60%20token%20as%20an%20executed%20command%2C%20so%20inputs%20such%20as%20%60grep%20tail%20notes.md%60%20suppress%20project-origin%20folds%20and%20consume%20agent%20context%20with%20repeated%20content.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni&pr=737&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fajarhide%2Fomni%22%20on%20the%20existing%20branch%20%22fix%2F735-line-budgeted-project-fold%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F735-line-budgeted-project-fold%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fledger%2Fmod.rs%3A929-934%0A**Standalone%20arguments%20trigger%20rationing**%0A%0AThe%20predicate%20treats%20any%20standalone%20%60head%60%20or%20%60tail%60%20token%20as%20an%20executed%20command%2C%20so%20inputs%20such%20as%20%60grep%20tail%20notes.md%60%20suppress%20project-origin%20folds%20and%20consume%20agent%20context%20with%20repeated%20content.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni&pr=737&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Asrc%2Fledger%2Fmod.rs%3A929-934%0A**Standalone%20arguments%20trigger%20rationing**%0A%0AThe%20predicate%20treats%20any%20standalone%20%60head%60%20or%20%60tail%60%20token%20as%20an%20executed%20command%2C%20so%20inputs%20such%20as%20%60grep%20tail%20notes.md%60%20suppress%20project-origin%20folds%20and%20consume%20agent%20context%20with%20repeated%20content.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=737&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fajarhide%2Fomni%22%20on%20the%20existing%20branch%20%22fix%2F735-line-budgeted-project-fold%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F735-line-budgeted-project-fold%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fledger%2Fmod.rs%3A929-934%0A**Standalone%20arguments%20trigger%20rationing**%0A%0AThe%20predicate%20treats%20any%20standalone%20%60head%60%20or%20%60tail%60%20token%20as%20an%20executed%20command%2C%20so%20inputs%20such%20as%20%60grep%20tail%20notes.md%60%20suppress%20project-origin%20folds%20and%20consume%20agent%20context%20with%20repeated%20content.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/ledger/mod.rs:929-934
**Standalone arguments trigger rationing**

The predicate treats any standalone `head` or `tail` token as an executed command, so inputs such as `grep tail notes.md` suppress project-origin folds and consume agent context with repeated content.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(hooks): name the command on the two ..."](https://github.com/fajarhide/omni/commit/a47193297abb119aecb0df1b3257cfd4b5da36e7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58361905)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Graphs, ledger, and context analytics](https://app.greptile.com/weekndlabs/-/custom-context/knowledge-base/fajarhide/omni/-/docs/graphs-ledger-and-context-analytics.md)
- Knowledge Base — [Tool hook integration](https://app.greptile.com/weekndlabs/-/custom-context/knowledge-base/fajarhide/omni/-/docs/tool-hook-integration.md)
- Knowledge Base — [Context processing pipeline](https://app.greptile.com/weekndlabs/-/custom-context/knowledge-base/fajarhide/omni/-/docs/context-processing-pipeline.md)
- Knowledge Base — [Prevent project folds from hiding an entire reply](https://app.greptile.com/weekndlabs/-/custom-context/knowledge-base/fajarhide/omni/-/reverts/incident-mitigation_728-20260827-project-fold-empty-reply-cc16931.md)
</details>


<!-- /greptile_comment -->