### PR TITLE
fix(ledger): read the line budget in command position, and read sed ranges

### DIFF
--- a/changelog.d/738.fixed.md
+++ b/changelog.d/738.fixed.md
@@ -1,0 +1,11 @@
+- **`grep -rn head src/` turned off the project scope (#738)**: the line-budget predicate
+  added in #737 matched `head` or `tail` anywhere in the command string, so any search
+  whose *pattern* was one of those words, or any pipeline ending `| grep tail`, read as a
+  reader rationing its own output. It failed safe, since the reader kept its content, but
+  it gave up folds for nothing on two shapes this repository runs constantly. The name now
+  counts only in command position: the first word of the reply, or the first word after a
+  shell separator. A separator glued to the following token (`cat a.md;tail -5 b`) is not
+  recognised and that shape folds as before, which is a deliberate limit rather than an
+  oversight: agents write the spaced form, and a tokeniser is a larger thing than this
+  predicate deserves. Raised by review on the pull request that shipped the defect and
+  merged ahead of the fix, which is the second time in three pull requests.

--- a/changelog.d/741.fixed.md
+++ b/changelog.d/741.fixed.md
@@ -1,0 +1,15 @@
+- **A `sed` range of a source file came back as a marker on its first appearance (#741)**:
+  `sed -n 60,200p` of a React component, in a context cleared moments earlier, returned 28
+  lines of the `steps.map` render branch as `[OMNI: 28 lines not shown here]`, and the next
+  step was editing that render path to add a case. An edit written against a marker is a
+  wrong edit, which is a worse outcome than the wasted retrieval #735 described. The ledger
+  behaved as designed: the lines were seen in an earlier session of the same project and
+  the marker used the project-scope wording that does not claim this context saw them. The
+  design was one command family too narrow. #737 taught the ledger to step aside when a
+  command names its own line budget and covered only `head` and `tail`, and
+  `sed -n 60,200p` names its lines exactly as `tail -5` does. `sed` addresses that name
+  line numbers now count, quoted or bare, single line or range. A pattern address
+  (`/failed/p`) and a substitution do not: those filter, which is a different claim from
+  naming the lines wanted. `awk` stays uncovered on purpose, because its line selection is
+  an expression rather than a flag and the obvious guess matches `{print NR}`, which prints
+  line numbers rather than selecting them.

--- a/src/ledger/mod.rs
+++ b/src/ledger/mod.rs
@@ -916,22 +916,79 @@ fn group_runs(hashes: &[String], origin_of: &dyn Fn(&String) -> Option<Seen>) ->
 
 /// Whether the command rationed its own output to a set of lines it named.
 ///
-/// `head` and `tail` only, and only when they are counting lines. `tail -f`
-/// never ends and `head -c` counts bytes, so neither of those says the reader
-/// picked a set of lines it now wants to read. A bare `head file` is as explicit
-/// as `head -10 file`, since the default is what the reader accepted.
+/// Three forms, and they are one idea: the caller said which lines it wants, so
+/// those lines are the answer rather than the background. `head` and `tail`
+/// counting lines, and a `sed` address naming line numbers. `tail -f` never ends
+/// and `head -c` counts bytes, so neither names a set of lines. A bare
+/// `head file` is as explicit as `head -10 file`, since the default is what the
+/// reader accepted.
 ///
-/// Matched on whole tokens and on the basename, so `/usr/bin/tail` counts and a
-/// `--tail` flag or a `tailwind` argument does not.
+/// **Only in command position** (#738). The first shipped version matched the
+/// name anywhere, so `grep -rn head src/` and `ls | grep tail` read as a reader
+/// rationing itself when the word was somebody else's argument. That is a fold
+/// given up for nothing, on two shapes this repository runs constantly.
+///
+/// **`sed` ranges count** (#741). The first version covered `head` and `tail`
+/// only, and shipped one command family too narrow: `sed -n 60,200p` of a source
+/// file names its lines exactly as `tail -5` does, and folding it handed the
+/// reader a marker where it was about to edit that code.
+/// `registry::passes_through_verbatim` already groups `sed` with `head` and
+/// `tail` for the collapse fallback, under this same reasoning.
+///
+/// **`awk` is deliberately not covered.** Its line selection is an expression
+/// rather than a flag, no report has produced one, and the obvious guess is
+/// wrong: `NR` appears in `{print NR}`, which prints line numbers rather than
+/// selecting them. It gets added when a payload demands it, not before.
+///
+/// Matched on the basename, so `/usr/bin/tail` counts and a `--tail` flag or a
+/// `tailwind` argument does not.
 fn rations_its_output(command: &str) -> bool {
     let tokens: Vec<&str> = command.split_whitespace().collect();
     tokens.iter().enumerate().any(|(i, tok)| {
-        let base = tok.rsplit('/').next().unwrap_or(tok);
-        (base == "head" || base == "tail")
-            && tokens.get(i + 1).is_none_or(|next| {
+        if !opens_a_command(&tokens, i) {
+            return false;
+        }
+        match tok.rsplit('/').next().unwrap_or(tok) {
+            "head" | "tail" => tokens.get(i + 1).is_none_or(|next| {
                 !(next.starts_with('-') && next.trim_start_matches('-').starts_with(['c', 'f']))
-            })
+            }),
+            "sed" => tokens[i + 1..].iter().any(|a| names_line_numbers(a)),
+            _ => false,
+        }
     })
+}
+
+/// Whether the token at `i` is the first word of a command.
+///
+/// The first word of the reply, or the first word after a shell separator. The
+/// separator is usually glued to the token before it (`notes.md;`), which is why
+/// this reads the end of the previous token rather than looking for a bare one.
+///
+/// A separator glued to the *following* token (`cat a.md;tail -5 b`) is not
+/// recognised, so that shape folds as before. It is left alone rather than
+/// split here: agents write the spaced form, and a tokeniser is a larger thing
+/// than this predicate deserves.
+fn opens_a_command(tokens: &[&str], i: usize) -> bool {
+    match i.checked_sub(1).map(|p| tokens[p]) {
+        None => true,
+        Some(prev) => prev.ends_with([';', '|', '&']),
+    }
+}
+
+/// A `sed` address that names line numbers: `5p`, `60,200p`, quoted or not.
+///
+/// A pattern address (`/foo/p`) and a substitution (`s/a/b/`) are both refused.
+/// They filter, which is a different claim from naming the lines wanted, and the
+/// ledger only steps aside for the second.
+fn names_line_numbers(arg: &str) -> bool {
+    let Some(body) = arg.trim_matches(['\'', '"']).strip_suffix('p') else {
+        return false;
+    };
+    let (start, end) = body.split_once(',').unwrap_or((body, body));
+    !start.is_empty()
+        && !end.is_empty()
+        && start.bytes().all(|b| b.is_ascii_digit())
+        && end.bytes().all(|b| b.is_ascii_digit())
 }
 
 /// A line's identity in the ledger.
@@ -1600,6 +1657,13 @@ mod tests {
             "head -20 src/main.rs",
             "head notes.md",
             "/usr/bin/tail -1 notes.md",
+            // After a separator, which is normally glued to the token before it.
+            "cat notes.md; echo ---; tail -5 handlers.log",
+            "cat a.md && head -3 b.md",
+            // #741, the reported command, unquoted and quoted.
+            "sed -n 60,200p app/run-panel.tsx",
+            "sed -n '285,340p' src/lib.rs",
+            "sed -n 5p notes.md",
         ] {
             assert!(rations_its_output(cmd), "should ration: {cmd}");
         }
@@ -1609,6 +1673,18 @@ mod tests {
             "cat notes.md",
             "kubectl logs pod --tail=20",
             "npm run build -- --watch tailwind.config.js",
+            // #738. The word is somebody else's argument, not a reader
+            // rationing itself, and both of these run constantly here.
+            "grep tail notes.md",
+            "grep -rn head src/",
+            "ls | grep tail",
+            "cat tail",
+            // A `sed` that filters rather than naming lines.
+            "sed -n '/failed/p' build.log",
+            "sed 's/a/b/' notes.md",
+            // Deliberately uncovered, so a future change that starts matching
+            // it is a decision rather than a side effect.
+            "awk 'NR>=60 && NR<=200' src/lib.rs",
         ] {
             assert!(!rations_its_output(cmd), "should not ration: {cmd}");
         }


### PR DESCRIPTION
Two errors at opposite ends of one function, both found within a day of #737 shipping it.

`rations_its_output` matched `head` or `tail` anywhere in the string, so `grep -rn head src/` and `ls | grep tail` turned the project scope off for the whole reply (#738). And it covered `head` and `tail` only, so `sed -n 60,200p` of a source file fell straight through: 28 lines of a JSX render branch folded on the file's first appearance in a cleared context, with the next step being an edit to that render path (#741). An edit written against a marker is worse than a wasted retrieval.

The name now counts only in command position, and `sed` addresses that name line numbers count. A pattern address and a substitution do not, because those filter, which is a different claim from naming the lines wanted.

Driving the built binary through `--post-hook`, same store, same primed block, same payload, only the command differing. Three arms must not fold and three must:

```
sed -n 60,200p app/run-panel.tsx      no rewrite     #741
sed -n '60,200p' app/run-panel.tsx    no rewrite     #741, quoted
cat notes.md; echo ---; tail -5 x     no rewrite     #735, still works
grep -rn head src/                    folds          #738
sed -n '/failed/p' build.log          folds          a pattern is not a line budget
cat handlers.log                      folds          the feature is intact
```

`make ci` green. Four break tests, each with its diff proven before the run: command-position guard removed, `sed` arm removed, `sed` address check neutered, and the `-c`/`-f` exclusion removed. All four went red.

`awk` is deliberately uncovered and its negative case is in the test, so a future change that starts matching it is a decision rather than a side effect. Its line selection is an expression rather than a flag, and the obvious guess matches `{print NR}`, which prints line numbers rather than selecting them.

One known limit, stated rather than hidden: a separator glued to the following token (`cat a.md;tail -5 b`) is not recognised and folds as before. Agents write the spaced form, and a tokeniser is a larger thing than this predicate deserves.

Closes #738, closes #741


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR narrows line-budget detection to command position and adds numeric `sed` address recognition so ledger project folding does not hide explicitly requested lines.
- Adds command-boundary classification for `head`, `tail`, and `sed`.
- Recognizes quoted and unquoted numeric `sed` print addresses.
- Adds regression coverage and changelog entries for issues #738 and #741.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The wrapped-command regression should be fixed before merging because it can again hide explicitly selected lines behind a project-history marker.

The command-position predicate excludes realistic wrapper-prefixed `head`, `tail`, and `sed` invocations, bypassing the guard added to preserve line-budgeted output; the sed scan also crosses command boundaries and can unnecessarily disable folding.

**Files Needing Attention:** src/ledger/mod.rs
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/ledger/mod.rs | Adds command-position and numeric-sed parsing, but wrapped selectors bypass the preservation guard and the sed argument scan crosses command boundaries. |
| changelog.d/738.fixed.md | Documents the command-position false-positive correction and its intentional glued-separator limitation. |
| changelog.d/741.fixed.md | Documents preservation of output selected by numeric sed addresses. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20fajarhide%2Fomni%20PR%20%23742%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=fajarhide%2Fomni&pr=742&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fledger%2Fmod.rs%3A947-949%0A**Wrappers%20bypass%20line-budget%20detection**%0A%0AWhen%20%60head%60%2C%20%60tail%60%2C%20or%20%60sed%60%20is%20invoked%20through%20a%20supported%20wrapper%20such%20as%20%60docker%20exec%20app%20tail%20-5%20app.log%60%2C%20%60opens_a_command%60%20rejects%20the%20selector%20because%20its%20preceding%20token%20is%20not%20a%20shell%20separator.%20The%20project-fold%20guard%20then%20fails%20to%20preserve%20the%20explicitly%20selected%20lines%2C%20causing%20them%20to%20be%20replaced%20by%20a%20retrieval%20marker%20in%20compound%20output.%0A%0A%23%23%23%20Issue%202%0Asrc%2Fledger%2Fmod.rs%3A954-955%0A**Sed%20scan%20crosses%20command%20boundaries**%0A%0AFor%20a%20command%20such%20as%20%60sed%20-n%20'%2Ffailed%2Fp'%20build.log%3B%20echo%205p%60%2C%20the%20%60sed%60%20branch%20scans%20every%20remaining%20token%20and%20mistakes%20the%20later%20command's%20%605p%60%20argument%20for%20a%20numeric%20sed%20address.%20This%20unnecessarily%20disables%20project%20folding%20for%20the%20entire%20payload%20and%20consumes%20context%20with%20repeated%20output.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni&pr=742&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fajarhide%2Fomni%22%20on%20the%20existing%20branch%20%22fix%2F741-738-line-budget-command-position%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F741-738-line-budget-command-position%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fledger%2Fmod.rs%3A947-949%0A**Wrappers%20bypass%20line-budget%20detection**%0A%0AWhen%20%60head%60%2C%20%60tail%60%2C%20or%20%60sed%60%20is%20invoked%20through%20a%20supported%20wrapper%20such%20as%20%60docker%20exec%20app%20tail%20-5%20app.log%60%2C%20%60opens_a_command%60%20rejects%20the%20selector%20because%20its%20preceding%20token%20is%20not%20a%20shell%20separator.%20The%20project-fold%20guard%20then%20fails%20to%20preserve%20the%20explicitly%20selected%20lines%2C%20causing%20them%20to%20be%20replaced%20by%20a%20retrieval%20marker%20in%20compound%20output.%0A%0A%23%23%23%20Issue%202%0Asrc%2Fledger%2Fmod.rs%3A954-955%0A**Sed%20scan%20crosses%20command%20boundaries**%0A%0AFor%20a%20command%20such%20as%20%60sed%20-n%20'%2Ffailed%2Fp'%20build.log%3B%20echo%205p%60%2C%20the%20%60sed%60%20branch%20scans%20every%20remaining%20token%20and%20mistakes%20the%20later%20command's%20%605p%60%20argument%20for%20a%20numeric%20sed%20address.%20This%20unnecessarily%20disables%20project%20folding%20for%20the%20entire%20payload%20and%20consumes%20context%20with%20repeated%20output.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni&pr=742&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Asrc%2Fledger%2Fmod.rs%3A947-949%0A**Wrappers%20bypass%20line-budget%20detection**%0A%0AWhen%20%60head%60%2C%20%60tail%60%2C%20or%20%60sed%60%20is%20invoked%20through%20a%20supported%20wrapper%20such%20as%20%60docker%20exec%20app%20tail%20-5%20app.log%60%2C%20%60opens_a_command%60%20rejects%20the%20selector%20because%20its%20preceding%20token%20is%20not%20a%20shell%20separator.%20The%20project-fold%20guard%20then%20fails%20to%20preserve%20the%20explicitly%20selected%20lines%2C%20causing%20them%20to%20be%20replaced%20by%20a%20retrieval%20marker%20in%20compound%20output.%0A%0A%23%23%23%20Issue%202%0Asrc%2Fledger%2Fmod.rs%3A954-955%0A**Sed%20scan%20crosses%20command%20boundaries**%0A%0AFor%20a%20command%20such%20as%20%60sed%20-n%20'%2Ffailed%2Fp'%20build.log%3B%20echo%205p%60%2C%20the%20%60sed%60%20branch%20scans%20every%20remaining%20token%20and%20mistakes%20the%20later%20command's%20%605p%60%20argument%20for%20a%20numeric%20sed%20address.%20This%20unnecessarily%20disables%20project%20folding%20for%20the%20entire%20payload%20and%20consumes%20context%20with%20repeated%20output.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=742&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fajarhide%2Fomni%22%20on%20the%20existing%20branch%20%22fix%2F741-738-line-budget-command-position%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F741-738-line-budget-command-position%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fledger%2Fmod.rs%3A947-949%0A**Wrappers%20bypass%20line-budget%20detection**%0A%0AWhen%20%60head%60%2C%20%60tail%60%2C%20or%20%60sed%60%20is%20invoked%20through%20a%20supported%20wrapper%20such%20as%20%60docker%20exec%20app%20tail%20-5%20app.log%60%2C%20%60opens_a_command%60%20rejects%20the%20selector%20because%20its%20preceding%20token%20is%20not%20a%20shell%20separator.%20The%20project-fold%20guard%20then%20fails%20to%20preserve%20the%20explicitly%20selected%20lines%2C%20causing%20them%20to%20be%20replaced%20by%20a%20retrieval%20marker%20in%20compound%20output.%0A%0A%23%23%23%20Issue%202%0Asrc%2Fledger%2Fmod.rs%3A954-955%0A**Sed%20scan%20crosses%20command%20boundaries**%0A%0AFor%20a%20command%20such%20as%20%60sed%20-n%20'%2Ffailed%2Fp'%20build.log%3B%20echo%205p%60%2C%20the%20%60sed%60%20branch%20scans%20every%20remaining%20token%20and%20mistakes%20the%20later%20command's%20%605p%60%20argument%20for%20a%20numeric%20sed%20address.%20This%20unnecessarily%20disables%20project%20folding%20for%20the%20entire%20payload%20and%20consumes%20context%20with%20repeated%20output.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/ledger/mod.rs:947-949
**Wrappers bypass line-budget detection**

When `head`, `tail`, or `sed` is invoked through a supported wrapper such as `docker exec app tail -5 app.log`, `opens_a_command` rejects the selector because its preceding token is not a shell separator. The project-fold guard then fails to preserve the explicitly selected lines, causing them to be replaced by a retrieval marker in compound output.

### Issue 2
src/ledger/mod.rs:954-955
**Sed scan crosses command boundaries**

For a command such as `sed -n '/failed/p' build.log; echo 5p`, the `sed` branch scans every remaining token and mistakes the later command's `5p` argument for a numeric sed address. This unnecessarily disables project folding for the entire payload and consumes context with repeated output.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): record the command-posi..."](https://github.com/fajarhide/omni/commit/c6fc458c79dbbd9ba80818f4fbafb3e0bba8a91e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58518666)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->