### PR TITLE
fix(ledger): read the line budget per command, not per reply

### DIFF
--- a/changelog.d/750.fixed.md
+++ b/changelog.d/750.fixed.md
@@ -1,0 +1,9 @@
+- **The ledger folded the lines a multi-line command asked for (#750, #751)**: reading
+  the line budget in command position (#742) read that position off the previous token,
+  and `split_whitespace` has already eaten the newline, so `cd repo` followed by
+  `sed -n '58,95p' src/app.tsx` on the next line was one long command and the guard was
+  off. Replayed over the 4,193 commands recorded here, the narrowing gave up the guard on
+  168 of them and 136 of those to a newline. The question is now asked per command rather
+  than per reply, so a newline separates, a `sed` address cannot be read out of a later
+  command, `sudo` and `env VAR=1` step aside, and a wrapper such as
+  `docker exec app tail -5 app.log` keeps the lines it named.

--- a/src/ledger/mod.rs
+++ b/src/ledger/mod.rs
@@ -43,6 +43,7 @@ use std::collections::{HashMap, HashSet};
 use crate::guard::limits::{
     MIN_LEDGER_INPUT, MIN_LEDGER_RUN_GAIN, MIN_WHOLE_OUTPUT_FOLD, PROJECT_FLOOR_MULT,
 };
+use crate::pipeline::registry;
 use crate::store::sqlite::Store;
 
 /// How much of a source name a marker will carry.
@@ -928,6 +929,13 @@ fn group_runs(hashes: &[String], origin_of: &dyn Fn(&String) -> Option<Seen>) ->
 /// rationing itself when the word was somebody else's argument. That is a fold
 /// given up for nothing, on two shapes this repository runs constantly.
 ///
+/// **Per segment, and a newline is a separator** (#750). The first version of
+/// that narrowing read command position off the previous token, which
+/// `split_whitespace` had already stripped the newline from, so a two-line
+/// command was one command and nothing on the second line could open one.
+/// `cd repo` then `sed -n 58,95p src/app.tsx` is the #741 shape again, and it is
+/// 136 of the 168 commands the narrowing cost across the recorded corpus.
+///
 /// **`sed` ranges count** (#741). The first version covered `head` and `tail`
 /// only, and shipped one command family too narrow: `sed -n 60,200p` of a source
 /// file names its lines exactly as `tail -5` does, and folding it handed the
@@ -943,9 +951,23 @@ fn group_runs(hashes: &[String], origin_of: &dyn Fn(&String) -> Option<Seen>) ->
 /// Matched on the basename, so `/usr/bin/tail` counts and a `--tail` flag or a
 /// `tailwind` argument does not.
 fn rations_its_output(command: &str) -> bool {
-    let tokens: Vec<&str> = command.split_whitespace().collect();
+    command
+        .split(['\n', ';', '|', '&'])
+        .any(segment_rations_its_output)
+}
+
+/// The same question for one command of the reply, separators already removed.
+///
+/// A wrapper (`docker exec app tail -5 x`, `ssh host 'tail -6 x'`) runs a
+/// program this cannot parse, so nothing in the segment is at a position we can
+/// read and the name counts wherever it appears. That errs toward keeping the
+/// lines the caller named, which is the direction this predicate exists to
+/// protect (#751).
+fn segment_rations_its_output(segment: &str) -> bool {
+    let tokens: Vec<&str> = segment.split_whitespace().collect();
+    let opaque = registry::wraps_another_command(segment);
     tokens.iter().enumerate().any(|(i, tok)| {
-        if !opens_a_command(&tokens, i) {
+        if !opaque && !opens_a_command(&tokens, i) {
             return false;
         }
         match tok.rsplit('/').next().unwrap_or(tok) {
@@ -958,21 +980,23 @@ fn rations_its_output(command: &str) -> bool {
     })
 }
 
-/// Whether the token at `i` is the first word of a command.
+/// Whether the token at `i` is the first word of its segment's command.
 ///
-/// The first word of the reply, or the first word after a shell separator. The
-/// separator is usually glued to the token before it (`notes.md;`), which is why
-/// this reads the end of the previous token rather than looking for a bare one.
-///
-/// A separator glued to the *following* token (`cat a.md;tail -5 b`) is not
-/// recognised, so that shape folds as before. It is left alone rather than
-/// split here: agents write the spaced form, and a tokeniser is a larger thing
-/// than this predicate deserves.
+/// The segment already ends at the next separator, so this only has to step over
+/// the words that introduce a command without being one: `sudo`, `env` and the
+/// `VAR=value` assignments a shell strips before exec.
 fn opens_a_command(tokens: &[&str], i: usize) -> bool {
-    match i.checked_sub(1).map(|p| tokens[p]) {
-        None => true,
-        Some(prev) => prev.ends_with([';', '|', '&']),
-    }
+    tokens[..i].iter().all(|t| introduces_a_command(t))
+}
+
+/// A word that precedes a command without being the command.
+fn introduces_a_command(token: &str) -> bool {
+    matches!(
+        token.rsplit('/').next().unwrap_or(token),
+        "sudo" | "env" | "time" | "nohup"
+    ) || token.split_once('=').is_some_and(|(name, _)| {
+        !name.is_empty() && name.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'_')
+    })
 }
 
 /// A `sed` address that names line numbers: `5p`, `60,200p`, quoted or not.
@@ -1664,6 +1688,20 @@ mod tests {
             "sed -n 60,200p app/run-panel.tsx",
             "sed -n '285,340p' src/lib.rs",
             "sed -n 5p notes.md",
+            // #750. A newline separates two commands, and the reply is written
+            // that way far more often than with a `;`.
+            "cd /path/to/repo\nsed -n '58,95p' src/app.tsx",
+            "cd /path/to/repo\ntail -20 /tmp/dev.log",
+            // A separator glued to the following token, which the token-position
+            // version could not see either.
+            "cat a.md;tail -5 b.md",
+            // #751. Words that introduce a command without being one.
+            "sudo tail -20 /var/log/app.log",
+            "env OMNI_PASSTHROUGH=1 sed -n '335,360p' src/hooks/post_tool.rs",
+            // #751. A wrapper's argument list is somebody else's command line,
+            // so the name counts anywhere inside it.
+            "docker exec app tail -5 /var/log/app.log",
+            "kubectl exec pod -- head -30 /etc/config.yaml",
         ] {
             assert!(rations_its_output(cmd), "should ration: {cmd}");
         }
@@ -1685,6 +1723,11 @@ mod tests {
             // Deliberately uncovered, so a future change that starts matching
             // it is a decision rather than a side effect.
             "awk 'NR>=60 && NR<=200' src/lib.rs",
+            // #751. The `sed` scan stops at its own command's end, so a later
+            // command's `5p` is not this one's address.
+            "sed -n '/failed/p' build.log; echo 5p",
+            // A newline is a separator, not a licence to match anywhere.
+            "cd /path/to/repo\ngrep -rn head src/",
         ] {
             assert!(!rations_its_output(cmd), "should not ration: {cmd}");
         }

--- a/src/pipeline/registry.rs
+++ b/src/pipeline/registry.rs
@@ -609,7 +609,7 @@ pub fn passes_through_verbatim(command: &str) -> bool {
 /// 59 of 8,032 recorded commands are wrappers, 0.7%, so that parser and its
 /// failure modes would be bought for less than one call in a hundred. If the
 /// share grows, revisit it with the same query.
-fn wraps_another_command(command: &str) -> bool {
+pub(crate) fn wraps_another_command(command: &str) -> bool {
     let mut tokens = command.split_whitespace().map(|t| t.trim_matches('"'));
     let base = tokens
         .next()


### PR DESCRIPTION
`rations_its_output` was narrowed to command position by #742, and read that position
off the previous token. `split_whitespace` has already eaten the newline by then, so a
two-line command is one command and nothing on the second line can open one. That put
the #741 shape back for the way an agent actually writes a command:

```
cd /path/to/repo
sed -n '58,95p' src/app.tsx
```

The reply is now split at its separators and the question is asked per command. A
newline separates, the `sed` scan cannot reach a later command's `5p`, a separator glued
to the following token works, `sudo` / `env VAR=1` / `time` / `nohup` step aside, and a
wrapper such as `docker exec app tail -5 app.log` keeps the lines it named, since its
argument list is somebody else's command line and no position in it is ours to read.

Measured by replaying the predicate over the 4,193 commands recorded in `~/.omni/omni.db`:

| predicate | commands it rations |
| --- | --- |
| before #742, name anywhere | 2,697 |
| shipped in #742, command position | 2,529 |
| this PR, per command | 2,730 |

168 of the 201 recovered are the regression, 136 of them to a newline. The other 33 are
`sed -n '255,300p;403,497p' f` and friends, where the old version read the whole
multi-address as one token and rejected it. The 18 commands the anywhere-match caught
and this does not are #738's own case: the word inside a heredoc body or a path.

Verification: `make ci` green. `rations_its_output_reads_a_line_budget_and_nothing_else`
was driven red five times, once per direction the fix can be wrong (newline not a
separator, wrapper not opaque, no prefix words, `;` not a separator, and the `sed`
boundary on its own with the positives that shadow it removed).

Closes #750
Closes #751


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR changes ledger line-budget detection to evaluate newline- and operator-separated command segments, recognizes several command introducers, and reuses wrapper detection from the pipeline registry.
- Splits compound replies before identifying `head`, `tail`, and numeric `sed` budgets.
- Adds support for bare `sudo`, `env`, `time`, and `nohup` prefixes.
- Makes wrapper detection available to the ledger and expands regression tests.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The PR should not merge until option-bearing prefixes and prefixed opaque wrappers reliably preserve explicitly requested lines.

The new command-position logic misses bounded readers after common prefix options, and wrapper detection misses wrappers preceded by introducers, allowing project folds to hide the requested output; raw separator splitting also causes a non-blocking regression for literal command text.

**Files Needing Attention:** src/ledger/mod.rs and src/pipeline/registry.rs
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/ledger/mod.rs | Adds per-segment budget detection, but raw separator parsing and incomplete prefix handling leave both false-positive and missed-budget paths. |
| src/pipeline/registry.rs | Exposes wrapper detection to the ledger, but the helper still assumes the wrapper is the first token. |
| changelog.d/750.fixed.md | Documents the intended newline, prefix, and wrapper behavior. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Raw command] --> B[Split into segments]
  B --> C{Opaque wrapper?}
  C -->|Yes| D[Scan bounded reader anywhere]
  C -->|No| E[Find command after introducers]
  D --> F{Line budget found?}
  E --> F
  F -->|Yes| G[Preserve project-origin lines]
  F -->|No| H[Allow normal ledger folding]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20fajarhide%2Fomni%20PR%20%23752%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=fajarhide%2Fomni&pr=752&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fledger%2Fmod.rs%3A988-990%0A**Prefix%20options%20hide%20bounded%20commands**%0A%0AWhen%20a%20bounded%20reader%20uses%20an%20option-bearing%20prefix%20such%20as%20%60sudo%20-u%20root%20tail%20-5%20app.log%60%2C%20%60opens_a_command%60%20rejects%20the%20reader%20because%20%60-u%60%20and%20%60root%60%20are%20not%20introducers%2C%20causing%20project-origin%20folds%20to%20replace%20explicitly%20requested%20lines%20with%20a%20retrieval%20marker.%0A%0A%23%23%23%20Issue%202%0Asrc%2Fledger%2Fmod.rs%3A954-955%0A**Literal%20separators%20become%20command%20boundaries**%0A%0AThe%20unconditional%20split%20treats%20separators%20inside%20heredoc%20bodies%2C%20comments%2C%20and%20quoted%20arguments%20as%20command%20boundaries%2C%20so%20literal%20%60head%60%2C%20%60tail%60%2C%20or%20numeric%20%60sed%60%20text%20disables%20project%20folding%20for%20replies%20that%20did%20not%20request%20bounded%20output%2C%20increasing%20delivered%20context%20unnecessarily.%0A%0A%23%23%23%20Issue%203%0Asrc%2Fledger%2Fmod.rs%3A994-1000%0A**Introducer%20options%20bypass%20line%20protection**%0A%0AWhen%20a%20bounded%20reader%20uses%20an%20ordinary%20option-bearing%20prefix%20such%20as%20%60env%20-i%20head%20-20%20file%60%20or%20%60time%20-p%20sed%20-n%205p%20file%60%2C%20the%20option%20token%20fails%20%60introduces_a_command%60%2C%20causing%20project-origin%20folds%20to%20replace%20the%20requested%20lines%20with%20a%20retrieval%20marker.%0A%0A%23%23%23%20Issue%204%0Asrc%2Fledger%2Fmod.rs%3A968-972%0A**Prefixed%20wrappers%20lose%20opacity**%0A%0AWhen%20an%20opaque%20wrapper%20is%20preceded%20by%20an%20introducer%2C%20as%20in%20%60sudo%20docker%20exec%20app%20tail%20-5%20app.log%60%2C%20wrapper%20detection%20sees%20%60sudo%60%20instead%20of%20%60docker%60%20and%20command-position%20checking%20rejects%20the%20nested%20reader%2C%20causing%20project%20folding%20to%20replace%20the%20wrapper%E2%80%99s%20requested%20output%20with%20a%20retrieval%20marker.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni&pr=752&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fajarhide%2Fomni%22%20on%20the%20existing%20branch%20%22fix%2F750-751-command-position-per-segment%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F750-751-command-position-per-segment%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fledger%2Fmod.rs%3A988-990%0A**Prefix%20options%20hide%20bounded%20commands**%0A%0AWhen%20a%20bounded%20reader%20uses%20an%20option-bearing%20prefix%20such%20as%20%60sudo%20-u%20root%20tail%20-5%20app.log%60%2C%20%60opens_a_command%60%20rejects%20the%20reader%20because%20%60-u%60%20and%20%60root%60%20are%20not%20introducers%2C%20causing%20project-origin%20folds%20to%20replace%20explicitly%20requested%20lines%20with%20a%20retrieval%20marker.%0A%0A%23%23%23%20Issue%202%0Asrc%2Fledger%2Fmod.rs%3A954-955%0A**Literal%20separators%20become%20command%20boundaries**%0A%0AThe%20unconditional%20split%20treats%20separators%20inside%20heredoc%20bodies%2C%20comments%2C%20and%20quoted%20arguments%20as%20command%20boundaries%2C%20so%20literal%20%60head%60%2C%20%60tail%60%2C%20or%20numeric%20%60sed%60%20text%20disables%20project%20folding%20for%20replies%20that%20did%20not%20request%20bounded%20output%2C%20increasing%20delivered%20context%20unnecessarily.%0A%0A%23%23%23%20Issue%203%0Asrc%2Fledger%2Fmod.rs%3A994-1000%0A**Introducer%20options%20bypass%20line%20protection**%0A%0AWhen%20a%20bounded%20reader%20uses%20an%20ordinary%20option-bearing%20prefix%20such%20as%20%60env%20-i%20head%20-20%20file%60%20or%20%60time%20-p%20sed%20-n%205p%20file%60%2C%20the%20option%20token%20fails%20%60introduces_a_command%60%2C%20causing%20project-origin%20folds%20to%20replace%20the%20requested%20lines%20with%20a%20retrieval%20marker.%0A%0A%23%23%23%20Issue%204%0Asrc%2Fledger%2Fmod.rs%3A968-972%0A**Prefixed%20wrappers%20lose%20opacity**%0A%0AWhen%20an%20opaque%20wrapper%20is%20preceded%20by%20an%20introducer%2C%20as%20in%20%60sudo%20docker%20exec%20app%20tail%20-5%20app.log%60%2C%20wrapper%20detection%20sees%20%60sudo%60%20instead%20of%20%60docker%60%20and%20command-position%20checking%20rejects%20the%20nested%20reader%2C%20causing%20project%20folding%20to%20replace%20the%20wrapper%E2%80%99s%20requested%20output%20with%20a%20retrieval%20marker.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni&pr=752&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Asrc%2Fledger%2Fmod.rs%3A988-990%0A**Prefix%20options%20hide%20bounded%20commands**%0A%0AWhen%20a%20bounded%20reader%20uses%20an%20option-bearing%20prefix%20such%20as%20%60sudo%20-u%20root%20tail%20-5%20app.log%60%2C%20%60opens_a_command%60%20rejects%20the%20reader%20because%20%60-u%60%20and%20%60root%60%20are%20not%20introducers%2C%20causing%20project-origin%20folds%20to%20replace%20explicitly%20requested%20lines%20with%20a%20retrieval%20marker.%0A%0A%23%23%23%20Issue%202%0Asrc%2Fledger%2Fmod.rs%3A954-955%0A**Literal%20separators%20become%20command%20boundaries**%0A%0AThe%20unconditional%20split%20treats%20separators%20inside%20heredoc%20bodies%2C%20comments%2C%20and%20quoted%20arguments%20as%20command%20boundaries%2C%20so%20literal%20%60head%60%2C%20%60tail%60%2C%20or%20numeric%20%60sed%60%20text%20disables%20project%20folding%20for%20replies%20that%20did%20not%20request%20bounded%20output%2C%20increasing%20delivered%20context%20unnecessarily.%0A%0A%23%23%23%20Issue%203%0Asrc%2Fledger%2Fmod.rs%3A994-1000%0A**Introducer%20options%20bypass%20line%20protection**%0A%0AWhen%20a%20bounded%20reader%20uses%20an%20ordinary%20option-bearing%20prefix%20such%20as%20%60env%20-i%20head%20-20%20file%60%20or%20%60time%20-p%20sed%20-n%205p%20file%60%2C%20the%20option%20token%20fails%20%60introduces_a_command%60%2C%20causing%20project-origin%20folds%20to%20replace%20the%20requested%20lines%20with%20a%20retrieval%20marker.%0A%0A%23%23%23%20Issue%204%0Asrc%2Fledger%2Fmod.rs%3A968-972%0A**Prefixed%20wrappers%20lose%20opacity**%0A%0AWhen%20an%20opaque%20wrapper%20is%20preceded%20by%20an%20introducer%2C%20as%20in%20%60sudo%20docker%20exec%20app%20tail%20-5%20app.log%60%2C%20wrapper%20detection%20sees%20%60sudo%60%20instead%20of%20%60docker%60%20and%20command-position%20checking%20rejects%20the%20nested%20reader%2C%20causing%20project%20folding%20to%20replace%20the%20wrapper%E2%80%99s%20requested%20output%20with%20a%20retrieval%20marker.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=752&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fajarhide%2Fomni%22%20on%20the%20existing%20branch%20%22fix%2F750-751-command-position-per-segment%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F750-751-command-position-per-segment%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fledger%2Fmod.rs%3A988-990%0A**Prefix%20options%20hide%20bounded%20commands**%0A%0AWhen%20a%20bounded%20reader%20uses%20an%20option-bearing%20prefix%20such%20as%20%60sudo%20-u%20root%20tail%20-5%20app.log%60%2C%20%60opens_a_command%60%20rejects%20the%20reader%20because%20%60-u%60%20and%20%60root%60%20are%20not%20introducers%2C%20causing%20project-origin%20folds%20to%20replace%20explicitly%20requested%20lines%20with%20a%20retrieval%20marker.%0A%0A%23%23%23%20Issue%202%0Asrc%2Fledger%2Fmod.rs%3A954-955%0A**Literal%20separators%20become%20command%20boundaries**%0A%0AThe%20unconditional%20split%20treats%20separators%20inside%20heredoc%20bodies%2C%20comments%2C%20and%20quoted%20arguments%20as%20command%20boundaries%2C%20so%20literal%20%60head%60%2C%20%60tail%60%2C%20or%20numeric%20%60sed%60%20text%20disables%20project%20folding%20for%20replies%20that%20did%20not%20request%20bounded%20output%2C%20increasing%20delivered%20context%20unnecessarily.%0A%0A%23%23%23%20Issue%203%0Asrc%2Fledger%2Fmod.rs%3A994-1000%0A**Introducer%20options%20bypass%20line%20protection**%0A%0AWhen%20a%20bounded%20reader%20uses%20an%20ordinary%20option-bearing%20prefix%20such%20as%20%60env%20-i%20head%20-20%20file%60%20or%20%60time%20-p%20sed%20-n%205p%20file%60%2C%20the%20option%20token%20fails%20%60introduces_a_command%60%2C%20causing%20project-origin%20folds%20to%20replace%20the%20requested%20lines%20with%20a%20retrieval%20marker.%0A%0A%23%23%23%20Issue%204%0Asrc%2Fledger%2Fmod.rs%3A968-972%0A**Prefixed%20wrappers%20lose%20opacity**%0A%0AWhen%20an%20opaque%20wrapper%20is%20preceded%20by%20an%20introducer%2C%20as%20in%20%60sudo%20docker%20exec%20app%20tail%20-5%20app.log%60%2C%20wrapper%20detection%20sees%20%60sudo%60%20instead%20of%20%60docker%60%20and%20command-position%20checking%20rejects%20the%20nested%20reader%2C%20causing%20project%20folding%20to%20replace%20the%20wrapper%E2%80%99s%20requested%20output%20with%20a%20retrieval%20marker.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/ledger/mod.rs:988-990
**Prefix options hide bounded commands**

When a bounded reader uses an option-bearing prefix such as `sudo -u root tail -5 app.log`, `opens_a_command` rejects the reader because `-u` and `root` are not introducers, causing project-origin folds to replace explicitly requested lines with a retrieval marker.

### Issue 2
src/ledger/mod.rs:954-955
**Literal separators become command boundaries**

The unconditional split treats separators inside heredoc bodies, comments, and quoted arguments as command boundaries, so literal `head`, `tail`, or numeric `sed` text disables project folding for replies that did not request bounded output, increasing delivered context unnecessarily.

### Issue 3
src/ledger/mod.rs:994-1000
**Introducer options bypass line protection**

When a bounded reader uses an ordinary option-bearing prefix such as `env -i head -20 file` or `time -p sed -n 5p file`, the option token fails `introduces_a_command`, causing project-origin folds to replace the requested lines with a retrieval marker.

### Issue 4
src/ledger/mod.rs:968-972
**Prefixed wrappers lose opacity**

When an opaque wrapper is preceded by an introducer, as in `sudo docker exec app tail -5 app.log`, wrapper detection sees `sudo` instead of `docker` and command-position checking rejects the nested reader, causing project folding to replace the wrapper’s requested output with a retrieval marker.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ledger): read the line budget per co..."](https://github.com/fajarhide/omni/commit/7d8e3db67c0b68ab937c67e11a5c1f0965f121d6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59371142)</sub>

> Greptile also left **4 inline comments** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Graphs, ledger, and context analytics](https://app.greptile.com/weekndlabs/-/custom-context/knowledge-base/fajarhide/omni/-/docs/graphs-ledger-and-context-analytics.md)
- Knowledge Base — [Restore command-aware ledger folding](https://app.greptile.com/weekndlabs/-/custom-context/knowledge-base/fajarhide/omni/-/reverts/incident-mitigation_737-20260830-command-budgeted-output-cdc73f6.md)
- Knowledge Base — [Restore accurate ledger handling for bounded command output](https://app.greptile.com/weekndlabs/-/custom-context/knowledge-base/fajarhide/omni/-/reverts/rollback_742-20260901-ledger-line-budget-detection-f1fc2a4.md)
</details>


<!-- /greptile_comment -->