### PR TITLE
test(ledger): a project fold outlives a branch switch and a new commit

### DIFF
--- a/changelog.d/739.fixed.md
+++ b/changelog.d/739.fixed.md
@@ -1,0 +1,7 @@
+- **Nothing asserted that the ledger folds across a branch switch (#739)**: the host's
+  prompt cache is pinned to the git snapshot it started on, so a checkout or a new commit
+  starts the next session cold even where the bytes are identical. The ledger's project
+  scope is keyed on the repository root and never reads a ref, which is the one saving in
+  this lane the cache structurally cannot make, and it was true only by construction. A
+  test now primes a project scope, switches branch and lands a commit under it with real
+  git, and asserts a new session still gets the fold.

--- a/src/ledger/mod.rs
+++ b/src/ledger/mod.rs
@@ -1297,7 +1297,14 @@ mod tests {
         let mut cmd = std::process::Command::new("git");
         cmd.current_dir(dir).args(args);
         for (name, _) in std::env::vars_os() {
-            if name.to_string_lossy().starts_with("GIT_") {
+            // Uppercased first: Windows env names are case-insensitive to git,
+            // so a `git_dir` would survive a case-sensitive prefix check and
+            // point the test at another repository (PR #754 review).
+            if name
+                .to_string_lossy()
+                .to_ascii_uppercase()
+                .starts_with("GIT_")
+            {
                 cmd.env_remove(&name);
             }
         }

--- a/src/ledger/mod.rs
+++ b/src/ledger/mod.rs
@@ -1286,12 +1286,22 @@ mod tests {
             .collect()
     }
 
-    /// Runs git in `dir`, hermetically: the machine's own config decides nothing
-    /// here, and a missing config file is an empty one to git.
+    /// Runs git in `dir`, hermetically: nothing the surrounding environment says
+    /// about git reaches it, and a missing config file is an empty one to git.
+    ///
+    /// Every inherited `GIT_*` goes, rather than a list of the ones that bite.
+    /// `GIT_DIR` alone is enough to point the whole test at another repository,
+    /// and it fails as `fatal: this operation must be run in a work tree` from a
+    /// test that never mentions a work tree (PR #754 review).
     fn git(dir: &std::path::Path, args: &[&str]) {
-        let out = std::process::Command::new("git")
-            .current_dir(dir)
-            .args(args)
+        let mut cmd = std::process::Command::new("git");
+        cmd.current_dir(dir).args(args);
+        for (name, _) in std::env::vars_os() {
+            if name.to_string_lossy().starts_with("GIT_") {
+                cmd.env_remove(&name);
+            }
+        }
+        let out = cmd
             .env("GIT_CONFIG_GLOBAL", dir.join("no-such-gitconfig"))
             .env("GIT_CONFIG_SYSTEM", dir.join("no-such-gitconfig"))
             .env("GIT_AUTHOR_NAME", "omni test")

--- a/src/ledger/mod.rs
+++ b/src/ledger/mod.rs
@@ -1286,6 +1286,27 @@ mod tests {
             .collect()
     }
 
+    /// Runs git in `dir`, hermetically: the machine's own config decides nothing
+    /// here, and a missing config file is an empty one to git.
+    fn git(dir: &std::path::Path, args: &[&str]) {
+        let out = std::process::Command::new("git")
+            .current_dir(dir)
+            .args(args)
+            .env("GIT_CONFIG_GLOBAL", dir.join("no-such-gitconfig"))
+            .env("GIT_CONFIG_SYSTEM", dir.join("no-such-gitconfig"))
+            .env("GIT_AUTHOR_NAME", "omni test")
+            .env("GIT_AUTHOR_EMAIL", "test@example.invalid")
+            .env("GIT_COMMITTER_NAME", "omni test")
+            .env("GIT_COMMITTER_EMAIL", "test@example.invalid")
+            .output()
+            .expect("git has to be on PATH for this test to mean anything");
+        assert!(
+            out.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
     /// Lines no scope has seen, tagged so two calls can each carry their own.
     fn fresh_block(tag: &str) -> String {
         (0..20)
@@ -1731,6 +1752,56 @@ mod tests {
         ] {
             assert!(!rations_its_output(cmd), "should not ration: {cmd}");
         }
+    }
+
+    /// #739. The host's prompt cache is pinned to the git snapshot it started on:
+    /// a branch switch or a new commit means the next session shares no prefix and
+    /// starts cold, even where the bytes are identical. The ledger has no such
+    /// constraint, and that is the one saving in this lane the cache structurally
+    /// cannot make.
+    ///
+    /// Nothing asserted it. `paths::project_key` walks to the repository root and
+    /// never reads a ref, which is correct by construction and one refactor away
+    /// from silently not being true, which is the shape of every guard this
+    /// repository has found decorative after the fact.
+    ///
+    /// Real git rather than a hand-built `.git` directory, because the property is
+    /// that a real snapshot change does not move the scope. A fabricated `.git`
+    /// would still pass if someone made the key shell out to `git rev-parse`.
+    #[test]
+    fn a_project_fold_outlives_a_branch_switch_and_a_new_commit() {
+        let (store, _d) = temp_store();
+        let repo = tempfile::tempdir().expect("tempdir");
+        git(repo.path(), &["init", "-q", "-b", "main"]);
+        std::fs::write(repo.path().join("app.rs"), "fn main() {}\n").expect("write");
+        git(repo.path(), &["add", "app.rs"]);
+        git(repo.path(), &["commit", "-qm", "first"]);
+        let before = crate::paths::project_key(repo.path());
+
+        let (repeated, payload) = project_repeat_then_fresh();
+        Ledger::new(&store, "s1")
+            .with_project(&before)
+            .project(&repeated);
+
+        git(repo.path(), &["checkout", "-qb", "feature"]);
+        std::fs::write(repo.path().join("app.rs"), "fn main() { run() }\n").expect("write");
+        git(repo.path(), &["commit", "-qam", "second"]);
+        let after = crate::paths::project_key(repo.path());
+
+        assert_eq!(
+            after, before,
+            "the project scope moved with the branch, so every session after a \
+             checkout would open a fresh history"
+        );
+
+        let view = Ledger::new(&store, "s2")
+            .with_project(&after)
+            .project(&payload)
+            .expect("the project history has to outlive the snapshot it was recorded on");
+        assert!(
+            view.contains("not shown here"),
+            "a new session on a new commit was not given the project history: {view}"
+        );
     }
 
     /// #567. The run marker said `from an earlier session`, which states where the


### PR DESCRIPTION
The host's prompt cache is pinned to the git snapshot it started on, so a checkout or a
new commit means the next session shares no prefix and starts cold, even where the bytes
are identical. The ledger's project scope is keyed on the repository root and never reads
a ref, so it folds across both. That is the one saving in this lane the cache
structurally cannot make, and nothing asserted it: `grep -n branch src/ledger/mod.rs`
returned a doc comment about something else.

The test primes a project scope from a real repository's `project_key`, switches branch
and lands a commit under it, then asks a new session id for the same block and requires
the fold.

Real git rather than a hand-built `.git` directory, because the property is that a real
snapshot change does not move the scope, and a fabricated `.git` would still pass if
someone made the key shell out to `git rev-parse`. It runs hermetically:
`GIT_CONFIG_GLOBAL` and `GIT_CONFIG_SYSTEM` point at files that do not exist and the
identity is set per process, so the machine's own git config decides nothing.

Verification: `make ci` green, including `smoke_test.sh` 70/70. Driven red twice, once
per direction it can be wrong.

Making `project_key` read `.git/HEAD`, which is the refactor this exists to catch:

```
assertion `left == right` failed: the project scope moved with the branch, so every
session after a checkout would open a fresh history
  left: "/var/folders/.../.tmpmnkzui#ref: refs/heads/feature"
 right: "/var/folders/.../.tmpmnkzui#ref: refs/heads/main"
```

Pointing the second session at another project scope, which proves the fold assertion
carries its own weight:

```
panicked at src/ledger/mod.rs:1800:14:
the project history has to outlive the snapshot it was recorded on
```

Closes #739






<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds a regression test proving that project-scoped ledger folding survives a real Git branch switch and subsequent commit.
- Adds a helper that invokes Git without inherited Git-specific environment configuration.
- Creates a real temporary repository, records project history, changes its snapshot, and verifies a new session still receives the fold.
- Documents the regression fix in the changelog.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/ledger/mod.rs | Adds hermetic Git test infrastructure and branch-switch regression coverage; both previously reported environment-isolation issues are fixed. |
| changelog.d/739.fixed.md | Accurately documents the newly covered project-ledger behavior. |

</details>

<sub>Reviews (3): Last reviewed commit: ["test(ledger): uppercase the GIT\_ prefix ..."](https://github.com/fajarhide/omni/commit/b5302754fe9b36e83dbd8c6650b3865ffb50762c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59829543)</sub>

<!-- /greptile_comment -->