### PR TITLE
docs(manual): say the MCP server is a cache trade on Claude Code

### DIFF
--- a/docs/website/src-id/reference/agents.md
+++ b/docs/website/src-id/reference/agents.md
@@ -62,7 +62,10 @@ tersambung atau terputus sementara perkakasnya sudah dimuat, yang bisa terjadi s
 saat proses server keluar lalu tersambung lagi di tengah sesi tanpa Anda melakukan apa
 pun. `omni init --claude` mendaftarkannya. Jalur plugin tidak menambah definisi perkakas
 sama sekali. Untuk tetap memakai hook tanpa pertukaran itu, hapus entri `omni` dari
-`mcpServers` di `~/.claude.json`.
+`mcpServers` di `~/.claude.json`, dan ketahui bahwa penghapusannya tidak bertahan:
+`omni doctor` melaporkan ketiadaannya sebagai peringatan, sedangkan `omni doctor --fix`
+dan `omni init` berikutnya akan mendaftarkannya lagi. Belum ada flag khusus hook saja
+([#757](https://github.com/fajarhide/omni/issues/757)).
 
 **OpenClaw** Penuh di giliran berikutnya, bukan giliran saat ini. Hook
 `tool_result_persist`-nya menulis ulang hasil tool yang disimpan OpenClaw, jadi model

--- a/docs/website/src-id/reference/agents.md
+++ b/docs/website/src-id/reference/agents.md
@@ -53,6 +53,17 @@ berkas, pencarian dan pengambilan web berjalan sama sekali. Tiga di antaranya
 sudah ditulis dan diuji sepenuhnya dan tidak pernah sekali pun berjalan di sesi
 sungguhan.
 
+Ia juga host tempat `omni init` memasang dua hal dan hanya satu di antaranya yang
+bekerja. Hook-lah yang memendekkan keluaran. Server MCP adalah kemudahan yang menaruh
+`omni_retrieve` dan `omni_explain_savings` di tempat yang bisa dipanggil agent, dan di
+host ini ia sebuah pertukaran dengan cache prompt: dua definisi itu berukuran 471 byte
+JSON di awal setiap request, dan host membuang seluruh cache ketika sebuah server MCP
+tersambung atau terputus sementara perkakasnya sudah dimuat, yang bisa terjadi sendiri
+saat proses server keluar lalu tersambung lagi di tengah sesi tanpa Anda melakukan apa
+pun. `omni init --claude` mendaftarkannya. Jalur plugin tidak menambah definisi perkakas
+sama sekali. Untuk tetap memakai hook tanpa pertukaran itu, hapus entri `omni` dari
+`mcpServers` di `~/.claude.json`.
+
 **OpenClaw** Penuh di giliran berikutnya, bukan giliran saat ini. Hook
 `tool_result_persist`-nya menulis ulang hasil tool yang disimpan OpenClaw, jadi model
 membaca byte sulingan setiap kali transkrip dibaca ulang, sementara giliran yang

--- a/docs/website/src-id/reference/mcp-tools.md
+++ b/docs/website/src-id/reference/mcp-tools.md
@@ -22,6 +22,11 @@ dengan 467 byte, sedangkan enam sisanya memakan 1.631 byte untuk 11 panggilan se
 korpus. Host Handoff-first tidak pernah mendapat penulisan ulang pada output perkakas
 bawaannya, jadi MCP adalah satu-satunya pintu OMNI di sana dan tidak ada yang dipangkas.
 
+Di Claude Code, daftar terpendek pun tetap ada ongkosnya, dan byte-nya justru bagian yang
+lebih kecil: host membuang seluruh cache prompt ketika sebuah server MCP tersambung atau
+terputus sementara perkakasnya sudah dimuat. [Agent yang didukung](agents.md) menjelaskan
+artinya dan cara menjalankan hook tanpa server MCP.
+
 Perkakas yang tidak diiklankan juga tidak bisa dipanggil di tier itu, jadi jalan kembalinya
 adalah CLI atau override:
 

--- a/docs/website/src-id/use/install.md
+++ b/docs/website/src-id/use/install.md
@@ -59,6 +59,10 @@ omni init --all      # semua host, plus .vscode/mcp.json di direktori saat ini
 `omni init` menulis hook dan mendaftarkan server MCP. Ia idempoten, jadi
 menjalankannya lagi setelah upgrade adalah langkah yang benar, bukan risiko.
 
+Di Claude Code, bagian yang memendekkan keluaran adalah hook-nya, sedangkan server MCP
+adalah kemudahan yang ada ongkos cache-nya. Membiarkannya terpasang tidak masalah; yang
+perlu Anda tahu ongkosnya ada di [Agent yang didukung](../reference/agents.md).
+
 Tanpa terminal untuk bertanya, yang memang begitulah cara agent menjalankannya,
 `omni init` menyetel host tempat ia berjalan alih-alih gagal karena menunya tidak
 ada. Ia menyebut host mana yang ia pilih. Kalau ia tidak bisa menyebut host-nya,

--- a/docs/website/src/reference/agents.md
+++ b/docs/website/src/reference/agents.md
@@ -49,6 +49,16 @@ execution semantics into OMNI, and bypasses the host's approval flow.
 distillers run at all. Three of them had been fully written and tested and had never
 executed on a real session.
 
+It is also the host where `omni init` installs two things and only one of them does the
+work. The hooks are what shortens output. The MCP server is a convenience that puts
+`omni_retrieve` and `omni_explain_savings` where the agent can call them, and on this
+host it is a trade against the prompt cache: those two definitions are 471 bytes of JSON
+in the prefix of every request, and the host discards the whole cache when an MCP server
+connects or disconnects with its tools loaded, which a server process can do by exiting
+and reconnecting mid-session without you touching anything. `omni init --claude`
+registers it. The plugin route adds no tool definitions at all. To keep the hooks and
+drop the trade, remove the `omni` entry from `mcpServers` in `~/.claude.json`.
+
 **OpenClaw** is Full on a later turn, not the current one. Its `tool_result_persist`
 hook rewrites the tool result OpenClaw persists, so the model reads the distilled bytes
 every time the transcript is re-read, while the turn that ran the command still sees the

--- a/docs/website/src/reference/agents.md
+++ b/docs/website/src/reference/agents.md
@@ -56,8 +56,11 @@ host it is a trade against the prompt cache: those two definitions are 471 bytes
 in the prefix of every request, and the host discards the whole cache when an MCP server
 connects or disconnects with its tools loaded, which a server process can do by exiting
 and reconnecting mid-session without you touching anything. `omni init --claude`
-registers it. The plugin route adds no tool definitions at all. To keep the hooks and
-drop the trade, remove the `omni` entry from `mcpServers` in `~/.claude.json`.
+registers it. The plugin route adds no tool definitions at all. To keep the hooks and drop
+the trade, remove the `omni` entry from `mcpServers` in `~/.claude.json`, and know that
+the removal does not stick: `omni doctor` reports the absence as a warning, and both
+`omni doctor --fix` and the next `omni init` register it again. There is no hooks-only
+flag yet ([#757](https://github.com/fajarhide/omni/issues/757)).
 
 **OpenClaw** is Full on a later turn, not the current one. Its `tool_result_persist`
 hook rewrites the tool result OpenClaw persists, so the model reads the distilled bytes

--- a/docs/website/src/reference/mcp-tools.md
+++ b/docs/website/src/reference/mcp-tools.md
@@ -22,6 +22,11 @@ in 467 bytes, while the other six cost 1,631 bytes for 11 calls in the life of t
 corpus. A Handoff-first host never has its built-in tool output rewritten, so MCP is the
 only door OMNI has there and nothing is priced away.
 
+On Claude Code the shortest list is still not free, and the bytes are the smaller half of
+why: the host discards the whole prompt cache when an MCP server connects or disconnects
+with its tools loaded. [Supported agents](agents.md) has what that means and how to run
+the hooks without it.
+
 An unadvertised tool is not callable on that tier either, so the way back is the CLI or
 the override:
 

--- a/docs/website/src/use/install.md
+++ b/docs/website/src/use/install.md
@@ -59,6 +59,10 @@ omni init --all      # every host, and a .vscode/mcp.json in the current directo
 `omni init` writes hooks and registers the MCP server. It is idempotent, so running it
 again after an upgrade is the right move rather than a risk.
 
+On Claude Code the hooks are the part that shortens output, and the MCP server is a
+convenience with a cache cost. Keeping it is fine; knowing what it costs is in
+[Supported agents](../reference/agents.md).
+
 With no terminal to prompt on, which is how an agent runs it, `omni init` configures
 the host it is running inside instead of failing on the absent menu. It says which
 host it picked. If it cannot name the host, a plain shell for instance, it stops and


### PR DESCRIPTION
The host discards the whole prompt cache when an MCP server connects or disconnects with
its tools loaded, and it says a server process can exit and reconnect mid-session with
nobody doing anything. On Claude Code the hooks are what shortens output, so registering
the MCP server buys `omni_retrieve` and `omni_explain_savings` at that risk. The manual
said none of this.

Three pages in both trees: the Claude Code note in `reference/agents.md` carries the
explanation, `use/install.md` and `reference/mcp-tools.md` get a line each pointing at
it, including how to keep the hooks without the server.

**One correction to the note this came from**, which called the MCP server the optional
configuration. `omni init --claude` calls `install_mcp_server` (`src/agents/claude.rs:43`),
so on the CLI path it is registered by default and there is no flag to skip it. The plugin
path is the one that adds no tool definitions: `plugins/claude-code/.claude-plugin/plugin.json`
has no `mcpServers` key. The pages say which is which.

The 471 bytes is measured here rather than borrowed: `tools/list` on the `claude_code`
tier returns the two advertised definitions, and `jq -c '.result.tools' | wc -c` is 471.
The figure already in `mcp-tools.md` counts something else, the bytes of recorded calls.

Verification: `make ci` green, `scripts/check_translations.sh origin/main` reports every
changed page has its counterpart in the diff.

Closes #740




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR documents the prompt-cache tradeoff of enabling OMNI’s MCP server in Claude Code while clarifying that output shortening comes from hooks.
- Explains the MCP tool-definition and cache-invalidation costs.
- Distinguishes the CLI installation path from the plugin path.
- Documents how to retain hooks without MCP and warns that `omni doctor --fix` or `omni init` restores the MCP registration.
- Applies equivalent updates to the English and Indonesian documentation trees.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/website/src/reference/agents.md | Adds the detailed Claude Code cache tradeoff and fully addresses the prior warning about MCP registration being restored. |
| docs/website/src/reference/mcp-tools.md | Adds a concise cache-cost warning and directs readers to the detailed Claude Code guidance. |
| docs/website/src/use/install.md | Clarifies the separate roles of Claude Code hooks and the MCP server during installation. |
| docs/website/src-id/reference/agents.md | Mirrors the detailed Claude Code guidance in Indonesian. |
| docs/website/src-id/reference/mcp-tools.md | Mirrors the MCP cache-cost warning and cross-reference in Indonesian. |
| docs/website/src-id/use/install.md | Mirrors the Claude Code installation clarification in Indonesian. |

</details>

<sub>Reviews (2): Last reviewed commit: ["docs(manual): say that removing the MCP ..."](https://github.com/fajarhide/omni/commit/753a39bfa4ac1dcdb77ea40919cc7115819d66d5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59839253)</sub>

<!-- /greptile_comment -->