### PR TITLE
fix(ledger): tell a re-run its lines are unchanged, not that they were shown

### DIFF
--- a/changelog.d/755.fixed.md
+++ b/changelog.d/755.fixed.md
@@ -1,0 +1,9 @@
+- **A re-run was told its lines were shown, not that they were unchanged (#755)**: a poll
+  run a second time asks whether the value moved, and when it has not, that is the answer.
+  The run marker said `N lines already shown`, which puts the bytes behind a handle
+  without saying they are this command's own output and identical to last time, so a
+  reply whose surviving half was an unrelated table read as a complete result. The source
+  clause already knew: #622 recorded a source only when it differed from the command being
+  answered, so the case that most needs naming collapsed into the same absence as
+  "nothing recorded". A same-command run now says `N lines identical to an earlier run`,
+  and a different command still names itself.

--- a/docs/website/src-id/use/markers.md
+++ b/docs/website/src-id/use/markers.md
@@ -23,6 +23,16 @@ klaimnya adalah agent masih memegangnya dan handle-nya tidak berongkos kecuali i
 memang mau membaca ulang.
 
 ```
+[OMNI: 40 lines identical to an earlier run, omni retrieve 0000000000000000]
+```
+
+Ledger lagi, untuk kasus ketika kesamaannya justru jawabannya. Anda menjalankan
+perintah yang sama untuk kedua kalinya dan ia mencetak baris yang sama, jadi marker
+menyebut itu alih-alih "already shown": polling yang diulang untuk melihat apakah
+sebuah nilai berubah dijawab oleh nilainya yang tidak berubah, dan pembacaan ulang
+dijawab oleh berkasnya yang tidak berubah.
+
+```
 [OMNI: 40 lines not shown here, omni retrieve 0000000000000000]
 ```
 
@@ -71,10 +81,10 @@ karena berkas lain sudah menampilkannya lebih dulu. Tanpa klausa itu, membanding
 dua berkas untuk memeriksa apakah blok bersamanya sama dijawab dengan menghapus
 buktinya.
 
-Membaca ulang berkas yang sama tidak membawa klausa apa pun, dan itu disengaja,
-bukan kelalaian. Panjang penanda menentukan apa yang layak dilipat sama sekali,
-jadi mencantumkan sumber di setiap penanda akan memotong penghematan pada kasus
-yang umum demi menamai kasus yang jarang.
+Menjalankan ulang perintah yang sama tidak membawa klausa itu, karena penanda di
+atas sudah menyebutkannya dengan kata-kata. Panjang penanda menentukan apa yang
+layak dilipat sama sekali, jadi mencantumkan sumber di setiap penanda akan
+memotong penghematan pada kasus yang umum demi menamai kasus yang jarang.
 
 ```
 [N similar lines collapsed]

--- a/docs/website/src/use/markers.md
+++ b/docs/website/src/use/markers.md
@@ -22,6 +22,15 @@ the agent is still holding them and the handle costs nothing unless it wants to
 re-read.
 
 ```
+[OMNI: 40 lines identical to an earlier run, omni retrieve 0000000000000000]
+```
+
+The ledger again, for the case where the identity is the answer. You ran the same
+command a second time and it printed the same lines, so the marker says that rather
+than "already shown": a poll re-run to find out whether a value moved is answered by
+the value not having moved, and a re-read is answered by the file not having changed.
+
+```
 [OMNI: 40 lines not shown here, omni retrieve 0000000000000000]
 ```
 
@@ -67,9 +76,9 @@ and having a block elided because a different file showed it earlier. Without th
 clause, comparing two files to check a shared block matches is answered by deleting
 the evidence.
 
-Re-reading the same file carries no clause, and that is deliberate rather than an
-omission. Marker length decides what is worth folding at all, so a source on every
-marker would cost savings on the common case to label the rare one.
+Running the same command again carries no clause, because the marker above already
+says so in words. Marker length decides what is worth folding at all, so a source on
+every marker would cost savings on the common case to label the rare one.
 
 ```
 [N similar lines collapsed]

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -4048,14 +4048,23 @@ src/distillers/system_ops.rs:849:                is_sensitive_key(key),
 
     /// The other half of #581, and the one a scope change would break silently:
     /// the main agent has no `agent_id`, so its scope is unchanged and a repeat
-    /// inside one session still folds as `already shown`, which is true there.
+    /// inside one session still folds through it.
+    ///
+    /// It asserts the session scope rather than one wording. #755 moved the
+    /// string for a command run a second time, which this fixture is, and the
+    /// project scope is what a scope regression would produce, so the claim to
+    /// hold is that this did not come back through it.
     #[test]
-    fn the_main_agent_still_folds_its_own_repeats_as_already_shown() {
+    fn the_main_agent_still_folds_its_own_repeats_through_the_session_scope() {
         let (_, second) = two_reads_of_one_file("solo-session-581", None);
 
         assert!(
-            second.contains("already shown"),
+            second.contains("identical to an earlier run"),
             "the session scope stopped folding for the reader that does hold the bytes: {second}"
+        );
+        assert!(
+            !second.contains("not shown here") && !second.contains("none shown here"),
+            "the main agent's own repeat was answered by the project scope: {second}"
         );
     }
 

--- a/src/ledger/mod.rs
+++ b/src/ledger/mod.rs
@@ -112,15 +112,26 @@ impl Origin {
     /// get them back. The session form was 87 bytes and is 65; trimming it moved
     /// the aggregate by 0.3 points on its own, because a shorter marker makes
     /// smaller runs worth folding (#450).
-    fn marker(self, lines: usize, handle: &str, source: Option<&str>) -> String {
+    fn marker(self, lines: usize, handle: &str, source: &SourceOfSighting) -> String {
         // Only ever present when the source differs from the command being
         // answered (#622). `Seen` decides that; this only renders it, and keeps
         // it short because the fold gate weighs this string.
         let from = match source {
-            Some(s) => format!(" from {}", source_label(s)),
-            None => String::new(),
+            SourceOfSighting::Another(s) => format!(" from {}", source_label(s)),
+            _ => String::new(),
         };
         match self {
+            // #755. A poll re-run verbatim is asking whether the value moved,
+            // and `N lines already shown` answers a different question: it says
+            // the bytes are behind you without saying they are the same bytes
+            // this command printed last time. The reported reply kept its first
+            // half, which read as a complete result, and put the seven metric
+            // lines the caller was watching behind a handle. The identity is
+            // what the run was asking for, so it is what the marker states, at
+            // 15 bytes more than the wording it replaces on this arm only.
+            Self::Session if matches!(source, SourceOfSighting::ThisCommandAgain) => {
+                format!("[OMNI: {lines} lines identical to an earlier run, omni retrieve {handle}]")
+            }
             Self::Session => {
                 format!("[OMNI: {lines} lines already shown{from}, omni retrieve {handle}]")
             }
@@ -152,10 +163,12 @@ impl Origin {
     ///
     /// It states the identity instead, which is the fact the re-run was asking
     /// for and is strictly more information than the run wording carried.
-    fn whole_output_marker(self, lines: usize, handle: &str, source: Option<&str>) -> String {
+    fn whole_output_marker(self, lines: usize, handle: &str, source: &SourceOfSighting) -> String {
+        // No `ThisCommandAgain` arm: this wording has stated the identity since
+        // #519, which is the fact a re-run is asking for.
         let from = match source {
-            Some(s) => format!(" from {}", source_label(s)),
-            None => String::new(),
+            SourceOfSighting::Another(s) => format!(" from {}", source_label(s)),
+            _ => String::new(),
         };
         match self {
             Self::Session => format!(
@@ -337,7 +350,26 @@ pub struct Ledger<'a> {
 #[derive(Clone, PartialEq, Eq, Debug)]
 struct Seen {
     origin: Origin,
-    source: Option<String>,
+    source: SourceOfSighting,
+}
+
+/// Which command put these lines in front of the agent, relative to the one
+/// being answered now.
+///
+/// Three cases and they say different things, which is why this is not an
+/// `Option<String>`. Before #755 the middle and the last were one `None`, and
+/// the last is the one a reader most needs named: a poll re-run verbatim whose
+/// output has not changed is answered by the fact that it has not changed, and
+/// `N lines already shown` does not say that.
+#[derive(Clone, PartialEq, Eq, Debug)]
+enum SourceOfSighting {
+    /// Nothing recorded, so nothing claimed.
+    Unrecorded,
+    /// A different command (#622). The marker names it so the reader can tell
+    /// whether the lines it is missing came from something relevant.
+    Another(String),
+    /// This same command, run again, printing these same lines (#755).
+    ThisCommandAgain,
 }
 
 /// One stretch of output, and where it was seen before if it was.
@@ -487,7 +519,13 @@ impl<'a> Ledger<'a> {
         // rendered marker cannot disagree: a run only claims a source when the
         // ledger recorded one and it is not the command being answered (#622).
         let differing = |seen: &crate::store::sqlite::SeenLine| {
-            (!seen.source.is_empty() && seen.source != self.source).then(|| seen.source.clone())
+            if seen.source.is_empty() {
+                SourceOfSighting::Unrecorded
+            } else if seen.source == self.source {
+                SourceOfSighting::ThisCommandAgain
+            } else {
+                SourceOfSighting::Another(seen.source.clone())
+            }
         };
         let origin_of = |h: &String| {
             if never_fold.contains(h) {
@@ -630,7 +668,7 @@ impl<'a> Ledger<'a> {
     /// which needs different wording (#519), and that wording is longer: an
     /// earlier draft weighed the short one and emitted the long one.
     fn marker_for(&self, run: &Run, seen: &Seen, total: usize, handle: &str) -> String {
-        let src = seen.source.as_deref();
+        let src = &seen.source;
         let lines = run.end - run.start;
         if run.start == 0 && run.end == total {
             seen.origin.whole_output_marker(lines, handle, src)
@@ -1082,6 +1120,50 @@ mod tests {
 
         assert!(second.len() < text.len());
         assert!(second.contains("lines already shown"));
+    }
+
+    /// #755. A poll is re-run to find out whether the value moved, and when it
+    /// has not, that is the answer. `N lines already shown` does not give it:
+    /// it says the bytes are behind the reader without saying they are this
+    /// command's own output, unchanged. In the report the surviving half of the
+    /// reply was an unrelated table that read as a complete result, and the
+    /// seven metric lines the caller was watching went behind a handle.
+    ///
+    /// Two arms, because the wording moves only for the command that ran again.
+    /// A different command still names itself (#622), which is what a reader
+    /// needs there: it tells them whether the lines they cannot see came from
+    /// something relevant.
+    #[test]
+    fn a_command_run_again_is_told_its_lines_are_unchanged() {
+        let (store, _d) = temp_store();
+        let poll = "for p in 0 1 2; do wget -qO- 127.0.0.1:8482/metrics | grep ^is_read_only; done";
+        let metrics = fresh_block("is_read_only");
+
+        Ledger::new(&store, "s1").from(poll).project(&metrics);
+        let again = Ledger::new(&store, "s1")
+            .from(poll)
+            .project(&format!("{}{metrics}", fresh_block("capacity")))
+            .expect("a verbatim re-run of a recorded block is projectable");
+
+        assert!(
+            again.contains("identical to an earlier run"),
+            "a re-run has to be told its own output did not change: {again}"
+        );
+        assert!(
+            !again.contains("already shown"),
+            "the wording that answers a different question survived: {again}"
+        );
+
+        let elsewhere = Ledger::new(&store, "s1")
+            .from("kubectl get pvc")
+            .project(&format!("{}{metrics}", fresh_block("phase")))
+            .expect("the same block under another command is projectable");
+
+        assert!(
+            elsewhere.contains("already shown") && elsewhere.contains("from for p in"),
+            "a different command still has to name the source it is standing in \
+             for (#622): {elsewhere}"
+        );
     }
 
     /// #627. A fold archives the run it replaced, never the reply, so the handle
@@ -1921,7 +2003,11 @@ mod tests {
     #[test]
     fn a_source_cannot_break_out_of_its_marker() {
         let nasty = "cat <<EOF\nsecond line\nthird line\nEOF";
-        let marker = Origin::Session.marker(9, &"0".repeat(HANDLE_LEN), Some(nasty));
+        let marker = Origin::Session.marker(
+            9,
+            &"0".repeat(HANDLE_LEN),
+            &SourceOfSighting::Another(nasty.to_string()),
+        );
         assert_eq!(
             marker.lines().count(),
             1,
@@ -1932,7 +2018,11 @@ mod tests {
             "expected the first line only: {marker:?}"
         );
 
-        let tabs = Origin::Session.marker(9, &"0".repeat(HANDLE_LEN), Some("go\ttest\t./..."));
+        let tabs = Origin::Session.marker(
+            9,
+            &"0".repeat(HANDLE_LEN),
+            &SourceOfSighting::Another("go\ttest\t./...".to_string()),
+        );
         assert_eq!(tabs.lines().count(), 1, "a tab split the marker: {tabs:?}");
         assert!(
             tabs.contains("from go test ./..."),
@@ -2023,11 +2113,11 @@ mod tests {
             .map(|i| format!("2026-08-10T00:00:0{i}Z  handler finished request {i}\n"))
             .collect();
         let session_bar = Origin::Session
-            .marker(9, &"0".repeat(HANDLE_LEN), None)
+            .marker(9, &"0".repeat(HANDLE_LEN), &SourceOfSighting::Unrecorded)
             .len()
             + Origin::Session.min_gain();
         let project_bar = Origin::Project
-            .marker(9, &"0".repeat(HANDLE_LEN), None)
+            .marker(9, &"0".repeat(HANDLE_LEN), &SourceOfSighting::Unrecorded)
             .len()
             + Origin::Project.min_gain();
         assert!(
@@ -2195,7 +2285,7 @@ mod tests {
         ledger.project(&format!("{run}{}", payload()));
 
         let bar = Origin::Session
-            .marker(3, &"0".repeat(HANDLE_LEN), None)
+            .marker(3, &"0".repeat(HANDLE_LEN), &SourceOfSighting::Unrecorded)
             .len()
             + Origin::Session.min_gain();
         assert!(
@@ -2230,9 +2320,11 @@ mod tests {
 
         assert_eq!(handle.len(), HANDLE_LEN);
         assert_eq!(
-            Origin::Session.marker(9, &handle, None).len(),
             Origin::Session
-                .marker(9, &"0".repeat(HANDLE_LEN), None)
+                .marker(9, &handle, &SourceOfSighting::Unrecorded)
+                .len(),
+            Origin::Session
+                .marker(9, &"0".repeat(HANDLE_LEN), &SourceOfSighting::Unrecorded)
                 .len()
         );
     }
@@ -2297,7 +2389,7 @@ mod tests {
         assert!(
             block('a').len()
                 >= Origin::Session
-                    .marker(8, &"0".repeat(HANDLE_LEN), None)
+                    .marker(8, &"0".repeat(HANDLE_LEN), &SourceOfSighting::Unrecorded)
                     .len()
                     + Origin::Session.min_gain(),
             "each block must be able to fold on its own, or the guard is not what \


### PR DESCRIPTION
A poll re-run verbatim is asking whether the value moved. When it has not, the run
marker said `N lines already shown`, which puts the bytes behind a handle without saying
they are this command's own output and the same as last time. In the report the surviving
half of the reply was an unrelated table that read as a complete result, and the metric
lines the caller was watching went behind the handle.

**The source clause already knew the answer and threw it away.** #622 made `Seen` carry
`Some(source)` only when it differed from the command being answered, so the case that
most needs naming, the same command run again, collapsed into the same `None` as "nothing
was recorded". Three states, so it is an enum now, and the wording follows it:

| what put the lines there | marker |
| --- | --- |
| this same command, again | `N lines identical to an earlier run` |
| a different command | `N lines already shown from <command>` (#622, unchanged) |
| nothing recorded | `N lines already shown` (unchanged) |

The whole-output arm already stated the identity, since #519, and is untouched.

Why the marker rather than exempting the fold, which the issue also offers: exempting
pays the payload in full to deliver one fact the marker can state in a line, and in-session
the agent is still holding those bytes, which is the ledger's whole premise.

**Cost, stated rather than estimated:** the marker gains 15 bytes on that arm only, and
marker length gates folding, so a few of the smallest same-command runs stop being worth
folding. What share of folds that is cannot be measured from the current schema, since
`ledger_folds` records no source, so it is not measured here.

Two gates caught what review would not have. The docs gate refused a marker that
`use/markers.md` never shows, so both language trees document it and the page's claim
that a re-read "carries no clause" is corrected. And
`the_main_agent_still_folds_its_own_repeats` asserted the exact old string rather than the
session scope it exists to protect, so it went red on a fold that was still correct; it
now asserts the fold happened and did not come back through the project scope.

Verification: `make ci` green, `smoke_test.sh` 70/70, `check_translations.sh` green. The
new test has two arms and each was driven red on its own: removing the same-command arm
fails the first, and making every source compare equal fails the #622 arm.

Closes #755


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR distinguishes unchanged output from a verbatim command re-run from output previously shown by another command, while preserving existing whole-output and project-scope semantics.
- Replaces optional source attribution with a three-state `SourceOfSighting` enum.
- Adds the `N lines identical to an earlier run` marker for partial session folds from the same command.
- Updates ledger and hook regression tests for the new wording and scope behavior.
- Documents the marker in both language trees and adds a changelog entry.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the new marker classification remaining consistent with existing reader scopes and fold gating.

The same stored source and current command are classified only for repeated line content, project-origin markers retain their existing unseen-content wording, and planning and emission render from the same source state.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/ledger/mod.rs | Introduces explicit source-state classification and renders the new same-command marker while preserving marker-length gating and scope-specific behavior. |
| src/hooks/post_tool.rs | Updates the main-agent scope regression test to assert folding and reject project-scope wording without coupling it to the obsolete marker. |
| docs/website/src/use/markers.md | Documents the new English marker and explains its same-command polling semantics. |
| docs/website/src-id/use/markers.md | Mirrors the marker documentation and explanation in Indonesian. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  H[Previously delivered line hash] --> S{Stored source}
  S -->|Empty| U[Unrecorded]
  S -->|Equals current command| T[ThisCommandAgain]
  S -->|Different command| A[Another command]
  T --> M[Session marker: identical to an earlier run]
  A --> F[Session marker: already shown from source]
  U --> G[Session marker: already shown]
  T --> P[Project marker remains: not shown here]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(manual): document the marker a re-r..."](https://github.com/fajarhide/omni/commit/ce770df8cdb20e4119c7ea9deab15c46046552e2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59853640)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Graphs, ledger, and context analytics](https://app.greptile.com/weekndlabs/-/custom-context/knowledge-base/fajarhide/omni/-/docs/graphs-ledger-and-context-analytics.md)
- Knowledge Base — [Tool hook integration](https://app.greptile.com/weekndlabs/-/custom-context/knowledge-base/fajarhide/omni/-/docs/tool-hook-integration.md)
- Knowledge Base — [Prevent project folds from hiding an entire reply](https://app.greptile.com/weekndlabs/-/custom-context/knowledge-base/fajarhide/omni/-/reverts/incident-mitigation_728-20260827-project-fold-empty-reply-cc16931.md)
</details>


<!-- /greptile_comment -->