### PR TITLE
fix(bench): tell the replay's ledger which command produced the payload

### DIFF
--- a/changelog.d/760.fixed.md
+++ b/changelog.d/760.fixed.md
@@ -1,0 +1,12 @@
+- **The benchmark measured a ledger with its guards switched off (#760)**: `make bench`
+  replayed the frozen corpus through a ledger that was never told which command produced
+  the payload, so every rule that reads the command was inert in the one place this
+  project measures itself: the `from` clause, the line budget that leaves a `tail -5`
+  alone, and the wording a re-run gets. Found by measuring 0.7.8 against `main`, where
+  every class came back byte-identical because three of the four changes in that range
+  could not reach the harness. With it fixed, on the same corpus and the same commit, the
+  ledger arm reads **3.0% where it published 4.9%**, and file reads read 1.5% where they
+  published 4.3%. Only the arms that use our ledger move; the filters and the three
+  competitor engines are unchanged. Artifacts now carry
+  `harness.ledger_knows_the_command`, so a measurement taken before this is visibly not
+  comparable with one taken after.

--- a/docs/website/src/develop/benchmarks.md
+++ b/docs/website/src/develop/benchmarks.md
@@ -7,6 +7,36 @@ same run as the rest of that section, including the ones that do not flatter us.
 useful thing on the page: the number OMNI reports is a property of the week it replays, not
 a constant. Read the corpus line before the figure, every time.
 
+## Correction, 2026-09-03: every ledger figure below is overstated
+
+The replay built its ledger without ever telling it which command produced the payload
+(#760), so every rule in the ledger that reads the command was inert here while running
+normally in production: the `from` clause, the line budget that leaves a `tail -5` alone,
+and the wording a re-run gets. The harness measured a ledger with its guards switched off.
+
+Re-measured on the same frozen corpus, same commit, with only that fixed:
+
+| arm | as published | with the guards visible |
+| --- | --- | --- |
+| omni, with the ledger | 4.9% | **3.0%** |
+| rtk + our ledger | 5.7% | 3.7% |
+| caveman + our ledger | 5.6% | 3.7% |
+| headroom dedup | 5.8% | 5.8% |
+| lean-ctx compress | 4.8% | 4.8% |
+| omni, filters only | 1.4% | 1.4% |
+
+Per class, with the ledger: file read 4.3% to **1.5%**, other 4.6% to 2.8%, git 8.6% to
+6.4%, search 4.2% to 4.0%, infra 3.8% to 3.6%, build and test 11.1% to 10.7%. The capture
+rate goes 23.3% to 10.7%.
+
+Only the arms that use our ledger move, which is the check that the change is what it
+claims to be. Filters do not touch the ledger and read 1.4% either way, and the three
+competitor engines are untouched.
+
+The tables below are left as they were measured, because deleting a published number is
+worse than labelling it. Artifacts carry `harness.ledger_knows_the_command` from #760 on,
+and one written without that field was measured this way.
+
 ## The current run, 2026-08-24, and the first one that will still exist next month
 
 **Corpus**: 9,478 traces, 8,458,937 bytes, 70 sessions, all `agent_id='claude_code'`,

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -249,6 +249,16 @@ if other:
 report = {
     "version": version,
     "commit": commit,
+    # #760. The replay used to build its ledger without ever naming the command
+    # that produced the payload, so every source-aware rule was inert here: the
+    # `from` clause (#622), the line budget (#735, #742, #750) and the re-run
+    # wording (#755). Artifacts written before this field exists were measured by
+    # that harness, and their fold rate is an upper bound on production rather
+    # than a measurement of it. A delta across the boundary is a harness change
+    # and a code change added together, which is exactly what #704 exists to
+    # prevent, so the boundary is recorded rather than explained in a release
+    # note nobody will have to hand.
+    "harness": {"ledger_knows_the_command": True},
     # True means the working tree carried uncommitted changes, so `commit` names
     # the nearest commit and not the source that was measured.
     "dirty_tree": dirty == "true",

--- a/tests/bench_replay.rs
+++ b/tests/bench_replay.rs
@@ -790,7 +790,6 @@ fn replay_execution_traces_net_savings() {
     // nothing but this file's own reporting line, so setting it relabelled the
     // output without moving the arm (#472).
     let project_scope = std::env::var("OMNI_BENCH_PROJECT").ok().as_deref() != Some("off");
-    let (mut mark_session, mut mark_project) = (0u64, 0u64);
     // #450's three gates, in repeated bytes the ledger never got to claim.
     let mut gap_seen = GapSeen::default();
     let (mut gap_structured, mut gap_under_floor, mut gap_processed) = (0u64, 0u64, 0u64);
@@ -993,31 +992,22 @@ fn replay_execution_traces_net_savings() {
         let l = match after_ledger {
             Some(view) => {
                 ledger_calls += 1;
-                // Counted on marker lines, not anywhere in the payload. A
-                // substring scan reads a surviving line that quotes the wording
-                // as a fold, and this repository writes those strings into its
-                // own changelog and docs, so the corpus really carries them
-                // (#557 learned the same thing about a different guard).
+                // No marker tally here any more, and the deletion is the point.
                 //
-                // Every session wording, not one string: a same-command re-run
-                // says `identical to an earlier run` since #755, and counting
-                // only the older phrase dropped those folds from the tally while
-                // the number carried on looking plausible.
-                let markers: Vec<&str> =
-                    view.lines().filter(|l| l.starts_with("[OMNI: ")).collect();
-                mark_session += markers
-                    .iter()
-                    .filter(|l| {
-                        l.contains("lines already shown")
-                            || l.contains("identical to an earlier run")
-                    })
-                    .count() as u64;
-                // `shown here` and not the whole phrase: a project run says
-                // `not shown here` and a project whole-output fold says
-                // `none shown here`, while neither session form contains it
-                // (#567). Counting the old phrase would silently drop every run
-                // marker from the tally.
-                mark_project += markers.iter().filter(|l| l.contains("shown here")).count() as u64;
+                // Counting by string cannot be made correct from this side. A
+                // substring scan reads a surviving line that quotes the wording;
+                // filtering on the `[OMNI: ` prefix reads a surviving line that
+                // starts with it, and this repository writes exactly those lines
+                // into its changelog and its manual, so the corpus carries them.
+                // #557 is the same lesson one guard earlier: identity has to come
+                // from the side that produced the string, never from parsing it
+                // back.
+                //
+                // The ledger does not report which marker shape it rendered yet.
+                // That is #766, and the split comes back when it lands. What is
+                // reported below is `ledger_calls`, which is the count of replies
+                // the ledger folded, taken from `Option::Some` rather than from
+                // text, and which content cannot spoof.
                 view.len() as u64
             }
             None => o,
@@ -1250,7 +1240,7 @@ fn replay_execution_traces_net_savings() {
         ratio(out_total.saturating_sub(ledger_total), avail_total)
     );
     println!(
-        "ledger arm:      project_scope={project_scope} floor_mult={} bytes={ledger_total} markers: {mark_session} session, {mark_project} project",
+        "ledger arm:      project_scope={project_scope} floor_mult={} bytes={ledger_total} folds: {ledger_calls} replies (marker shapes pending #766)",
         omni::guard::limits::PROJECT_FLOOR_MULT
     );
 

--- a/tests/bench_replay.rs
+++ b/tests/bench_replay.rs
@@ -967,13 +967,22 @@ fn replay_execution_traces_net_savings() {
             }
         }
 
-        // Same two gates the hook applies: structured payloads are never
-        // projected, and the scope is the session the trace really belongs to.
+        // Same three gates the hook applies: structured payloads are never
+        // projected, the scope is the session the trace really belongs to, and
+        // the ledger is told which command produced the payload.
+        //
+        // #760. That last one was missing, and it made this harness blind to
+        // every rule that reads the command. The `from` clause never rendered
+        // (#622), the line budget never fired (#735, #742, #750, #751), and the
+        // re-run wording never appeared (#755), so a release could change all of
+        // them and the artifact came back byte-identical, which it did between
+        // 0.7.8 and this commit. The corpus carries the command and the routing
+        // half above already uses it; only the ledger was left guessing.
         let after_ledger = ledger_store
             .as_ref()
             .filter(|_| omni::pipeline::format::sniff(&distilled).is_none())
             .and_then(|s| {
-                let ledger = omni::ledger::Ledger::new(s, &t.session);
+                let ledger = omni::ledger::Ledger::new(s, &t.session).from(&t.command);
                 let ledger = if project_scope {
                     ledger.with_project(&t.project)
                 } else {
@@ -984,7 +993,13 @@ fn replay_execution_traces_net_savings() {
         let l = match after_ledger {
             Some(view) => {
                 ledger_calls += 1;
-                mark_session += view.matches("lines already shown").count() as u64;
+                // Every session wording, not one string. A same-command re-run
+                // says `identical to an earlier run` since #755, and counting
+                // only the older phrase dropped those folds from the tally while
+                // the number carried on looking plausible.
+                mark_session += (view.matches("lines already shown").count()
+                    + view.matches("identical to an earlier run").count())
+                    as u64;
                 // `shown here` and not the whole phrase: a project run says
                 // `not shown here` and a project whole-output fold says
                 // `none shown here`, while neither session form contains it
@@ -1039,6 +1054,7 @@ fn replay_execution_traces_net_savings() {
                 .filter(|_| omni::pipeline::format::sniff(&rtk_text).is_none())
                 .and_then(|s| {
                     omni::ledger::Ledger::new(s, &t.session)
+                        .from(&t.command)
                         .with_project(&t.project)
                         .project(&rtk_text)
                 });
@@ -1059,6 +1075,7 @@ fn replay_execution_traces_net_savings() {
                 .filter(|_| omni::pipeline::format::sniff(&cm_text).is_none())
                 .and_then(|s| {
                     omni::ledger::Ledger::new(s, &t.session)
+                        .from(&t.command)
                         .with_project(&t.project)
                         .project(&cm_text)
                 });

--- a/tests/bench_replay.rs
+++ b/tests/bench_replay.rs
@@ -993,19 +993,31 @@ fn replay_execution_traces_net_savings() {
         let l = match after_ledger {
             Some(view) => {
                 ledger_calls += 1;
-                // Every session wording, not one string. A same-command re-run
+                // Counted on marker lines, not anywhere in the payload. A
+                // substring scan reads a surviving line that quotes the wording
+                // as a fold, and this repository writes those strings into its
+                // own changelog and docs, so the corpus really carries them
+                // (#557 learned the same thing about a different guard).
+                //
+                // Every session wording, not one string: a same-command re-run
                 // says `identical to an earlier run` since #755, and counting
                 // only the older phrase dropped those folds from the tally while
                 // the number carried on looking plausible.
-                mark_session += (view.matches("lines already shown").count()
-                    + view.matches("identical to an earlier run").count())
-                    as u64;
+                let markers: Vec<&str> =
+                    view.lines().filter(|l| l.starts_with("[OMNI: ")).collect();
+                mark_session += markers
+                    .iter()
+                    .filter(|l| {
+                        l.contains("lines already shown")
+                            || l.contains("identical to an earlier run")
+                    })
+                    .count() as u64;
                 // `shown here` and not the whole phrase: a project run says
                 // `not shown here` and a project whole-output fold says
                 // `none shown here`, while neither session form contains it
                 // (#567). Counting the old phrase would silently drop every run
                 // marker from the tally.
-                mark_project += view.matches("shown here").count() as u64;
+                mark_project += markers.iter().filter(|l| l.contains("shown here")).count() as u64;
                 view.len() as u64
             }
             None => o,


### PR DESCRIPTION
`make bench` replayed the frozen corpus through a ledger built with a session and a
project and no `.from()`, so every rule that reads the command was inert in the one place
this project measures itself: the `from` clause (#622), the line budget (#735, #742, #750,
#751) and the re-run wording (#755). The corpus carries the command and the routing half
already used it; only the ledger was left guessing.

Found by measuring 0.7.8 against `main` for the 0.7.9 cut. Every class came back
byte-identical, which was true and meant nothing: three of the four code changes in that
range could not reach the harness.

**What it was hiding.** Same corpus, same commit, only the harness fixed:

| arm | as published | with the guards visible |
| --- | --- | --- |
| omni, with the ledger | 4.9% | **3.0%** |
| rtk + our ledger | 5.7% | 3.7% |
| caveman + our ledger | 5.6% | 3.7% |
| headroom dedup | 5.8% | 5.8% |
| lean-ctx compress | 4.8% | 4.8% |
| omni, filters only | 1.4% | 1.4% |

Only the arms that use our ledger move, which is the check that this is what it claims to
be. Per class, with the ledger: file read 4.3% to 1.5%, other 4.6% to 2.8%, git 8.6% to
6.4%. Capture rate 23.3% to 10.7%.

**The harness has teeth now, proved by removal.** Disabling `rations_its_output`, which
only exists because the ledger knows the command, moves the aggregate from 3.0% to 3.4%
and file reads from 1.5% to 1.9%. Under the old harness that change was invisible.

Artifacts carry `harness.ledger_knows_the_command` from here on, so a measurement taken
before this is visibly not comparable with one taken after, rather than looking like a
regression to whoever diffs two of them.

The published tables are not touched here. They sit inside `omni:corpus-table` regions
rendered from `docs/benchmarks/<version>.json` and guarded by `tests/published_figures.rs`,
so they change when a release writes a new artifact, not by hand. `benchmarks.md` carries
the correction now, and the sweep across the other fifteen surfaces is #761, sequenced
after the 0.7.9 cut for that reason.

Verification: `make ci` green, `smoke_test.sh` 70/70, `check_translations.sh` green.

Closes #760






<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The benchmark replay now supplies each corpus command to every ledger-backed arm, activating command-aware folding guards and recording the resulting measurement boundary in generated artifacts.

- Passes `t.command` through `Ledger::from` for Omni, RTK, and Caveman replay paths.
- Replaces spoofable marker-text diagnostics with a count of replies actually projected by the ledger.
- Adds benchmark correction documentation, artifact metadata, and a changelog entry.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| tests/bench_replay.rs | Propagates corpus commands into all ledger projections and replaces content-spoofable marker tallies with an accurately labeled count of folded replies. |
| scripts/bench.sh | Adds explicit artifact metadata distinguishing command-aware benchmark runs from older incomparable measurements. |
| docs/website/src/develop/benchmarks.md | Documents the historical benchmark overstatement and corrected command-aware measurements without rewriting published tables. |
| changelog.d/760.fixed.md | Records the benchmark harness correction and its effect on reported ledger savings. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    C[Frozen corpus trace] --> D[Distilled payload]
    C --> K[Recorded command]
    D --> L[Ledger projection]
    K --> F[Ledger::from]
    F --> L
    L --> G[Command-aware guards]
    G --> R[Benchmark measurements]
    R --> A[Artifact with harness boundary]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(bench): stop counting fold markers b..."](https://github.com/fajarhide/omni/commit/91755d1c9581ba2a83b90308bdb13a0f4df761a1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60262186)</sub>

<!-- /greptile_comment -->