### PR TITLE
feat(ledger): record which marker shape a fold rendered, and its handle

### DIFF
--- a/changelog.d/766.added.md
+++ b/changelog.d/766.added.md
@@ -1,0 +1,8 @@
+- **The ledger records which marker shape it rendered (#766)**: `ledger_folds` groups a
+  call's folds by origin and source agent and carries no handle, so it could say how much
+  was folded and never which of the five marker wordings a reader met, nor whether anyone
+  went back for the bytes. Three wording changes shipped on reasoning alone for that
+  reason. `fold_markers` records the shape and the handle at the grain a marker lives at,
+  the shape comes from the arm that renders the string rather than from parsing one back,
+  and `marker_retrieve_rates` joins the handle to a later retrieval. A shape with a high
+  retrieve rate is one that did not answer the question it interrupted.

--- a/src/ledger/mod.rs
+++ b/src/ledger/mod.rs
@@ -112,7 +112,12 @@ impl Origin {
     /// get them back. The session form was 87 bytes and is 65; trimming it moved
     /// the aggregate by 0.3 points on its own, because a shorter marker makes
     /// smaller runs worth folding (#450).
-    fn marker(self, lines: usize, handle: &str, source: &SourceOfSighting) -> String {
+    fn marker(
+        self,
+        lines: usize,
+        handle: &str,
+        source: &SourceOfSighting,
+    ) -> (String, &'static str) {
         // Only ever present when the source differs from the command being
         // answered (#622). `Seen` decides that; this only renders it, and keeps
         // it short because the fold gate weighs this string.
@@ -129,12 +134,16 @@ impl Origin {
             // lines the caller was watching behind a handle. The identity is
             // what the run was asking for, so it is what the marker states, at
             // 15 bytes more than the wording it replaces on this arm only.
-            Self::Session if matches!(source, SourceOfSighting::ThisCommandAgain) => {
-                format!("[OMNI: {lines} lines identical to an earlier run, omni retrieve {handle}]")
-            }
-            Self::Session => {
-                format!("[OMNI: {lines} lines already shown{from}, omni retrieve {handle}]")
-            }
+            Self::Session if matches!(source, SourceOfSighting::ThisCommandAgain) => (
+                format!(
+                    "[OMNI: {lines} lines identical to an earlier run, omni retrieve {handle}]"
+                ),
+                "session_rerun",
+            ),
+            Self::Session => (
+                format!("[OMNI: {lines} lines already shown{from}, omni retrieve {handle}]"),
+                "session_run",
+            ),
             // #567. `from an earlier session` states provenance and reads as
             // "you have seen this", which is the opposite of what it means: the
             // project scope only answers for lines the session scope did not, so
@@ -146,9 +155,10 @@ impl Origin {
             // is also nine bytes shorter. Marker length gates folding, and the
             // session form's trim was worth 0.3 points on its own (#450), so the
             // honest wording is the cheaper one here rather than a trade.
-            Self::Project => {
-                format!("[OMNI: {lines} lines not shown here{from}, omni retrieve {handle}]")
-            }
+            Self::Project => (
+                format!("[OMNI: {lines} lines not shown here{from}, omni retrieve {handle}]"),
+                "project_run",
+            ),
         }
     }
 
@@ -163,7 +173,12 @@ impl Origin {
     ///
     /// It states the identity instead, which is the fact the re-run was asking
     /// for and is strictly more information than the run wording carried.
-    fn whole_output_marker(self, lines: usize, handle: &str, source: &SourceOfSighting) -> String {
+    fn whole_output_marker(
+        self,
+        lines: usize,
+        handle: &str,
+        source: &SourceOfSighting,
+    ) -> (String, &'static str) {
         // No `ThisCommandAgain` arm: this wording has stated the identity since
         // #519, which is the fact a re-run is asking for.
         let from = match source {
@@ -171,14 +186,20 @@ impl Origin {
             _ => String::new(),
         };
         match self {
-            Self::Session => format!(
-                "[OMNI: identical to the {lines} lines already shown{from}, omni retrieve {handle}]"
+            Self::Session => (
+                format!(
+                    "[OMNI: identical to the {lines} lines already shown{from}, omni retrieve {handle}]"
+                ),
+                "session_whole",
             ),
             // The whole payload, and none of it delivered here, so the agent
             // holds nothing at all. Worth the extra bytes to say both: this
             // marker is already gated at `MIN_WHOLE_OUTPUT_FOLD` (#567).
-            Self::Project => format!(
-                "[OMNI: identical to {lines} lines from an earlier session{from}, none shown here, omni retrieve {handle}]"
+            Self::Project => (
+                format!(
+                    "[OMNI: identical to {lines} lines from an earlier session{from}, none shown here, omni retrieve {handle}]"
+                ),
+                "project_whole",
             ),
         }
     }
@@ -552,7 +573,7 @@ impl<'a> Ledger<'a> {
         // deterministic for a caller replaying the same session.
         let projected = self
             .substitute(&lines, &hashes, &origin_of)
-            .filter(|(view, _, _, _)| view.len() < text.len());
+            .filter(|(view, _, _, _, _)| view.len() < text.len());
 
         // What the fold did to the numbering below it (#557), read from the folded
         // indices where the answer is known. Decided here rather than after the
@@ -562,7 +583,7 @@ impl<'a> Ledger<'a> {
         // already where the file has it and no starting number moves (#664).
         let shifts = projected
             .as_ref()
-            .map(|(_, folded, above, padded)| {
+            .map(|(_, folded, above, padded, _)| {
                 if *padded {
                     FoldShift::None
                 } else {
@@ -584,7 +605,7 @@ impl<'a> Ledger<'a> {
         // the gain filter above, the caller emits `text` verbatim and every line
         // was delivered. That is the empty-set case and needs no special arm.
         let delivered: Vec<String> = match &projected {
-            Some((_, folded, _, _)) => hashes
+            Some((_, folded, _, _, _)) => hashes
                 .iter()
                 .enumerate()
                 .filter(|(i, _)| !folded.contains(i))
@@ -596,7 +617,7 @@ impl<'a> Ledger<'a> {
         // like this session's (#533). `PROJECT_FLOOR_MULT` prices cross-agent
         // reuse and was calibrated on the single-agent case, and nothing recorded
         // enough to tell the two apart after the fact.
-        if let Some((_, folded, _, _)) = &projected {
+        if let Some((_, folded, _, _, markers)) = &projected {
             // Every line folded means the agent holds markers and nothing else,
             // which is the case `MIN_WHOLE_OUTPUT_FOLD` refuses below 1 KB. Read
             // here rather than threaded out of `substitute`, because that flag is
@@ -643,8 +664,13 @@ impl<'a> Ledger<'a> {
             let scope = self.project.as_deref().unwrap_or(&self.scope);
             // `scope` above is the project when there is one, so the session
             // has to travel separately or the row cannot answer for itself.
-            self.store
-                .ledger_record_folds(scope, &self.agent, session_of(&self.scope), &folds);
+            self.store.ledger_record_folds(
+                scope,
+                &self.agent,
+                session_of(&self.scope),
+                &folds,
+                markers,
+            );
         }
 
         self.store
@@ -658,7 +684,7 @@ impl<'a> Ledger<'a> {
                 .ledger_record(p, &delivered, &self.agent, &self.source);
         }
 
-        projected.map(|(view, _, _, _)| (view, shifts))
+        projected.map(|(view, _, _, _, _)| (view, shifts))
     }
 
     /// The marker one run would be replaced by, rendered rather than estimated
@@ -667,7 +693,13 @@ impl<'a> Ledger<'a> {
     /// A run covering every line means the reply is this marker and nothing else,
     /// which needs different wording (#519), and that wording is longer: an
     /// earlier draft weighed the short one and emitted the long one.
-    fn marker_for(&self, run: &Run, seen: &Seen, total: usize, handle: &str) -> String {
+    fn marker_for(
+        &self,
+        run: &Run,
+        seen: &Seen,
+        total: usize,
+        handle: &str,
+    ) -> (String, &'static str) {
         let src = &seen.source;
         let lines = run.end - run.start;
         if run.start == 0 && run.end == total {
@@ -687,7 +719,13 @@ impl<'a> Ledger<'a> {
         lines: &[&str],
         hashes: &[String],
         origin_of: &dyn Fn(&String) -> Option<Seen>,
-    ) -> Option<(String, HashSet<usize>, usize, bool)> {
+    ) -> Option<(
+        String,
+        HashSet<usize>,
+        usize,
+        bool,
+        Vec<crate::store::sqlite::MarkerRecord>,
+    )> {
         let runs = group_runs(hashes, origin_of);
         if !runs.iter().any(|r| r.seen.is_some()) {
             return None;
@@ -741,6 +779,7 @@ impl<'a> Ledger<'a> {
                 run.seen.as_ref().is_some_and(|seen| {
                     let marker = self
                         .marker_for(run, seen, lines.len(), &"0".repeat(HANDLE_LEN))
+                        .0
                         .len();
                     lines[run.start..run.end]
                         .iter()
@@ -832,6 +871,10 @@ impl<'a> Ledger<'a> {
         // or stays verbatim, and adjacent runs of different origin are separate
         // runs. Every attempt to infer it downstream was wrong (#573).
         let mut markers_above = 0usize;
+        // #766. What was actually handed over, at the grain the marker lives at.
+        // `ledger_folds` groups a call by (origin, source agent), so it cannot
+        // answer which wording a reader met or which handle they were given.
+        let mut emitted: Vec<crate::store::sqlite::MarkerRecord> = Vec::new();
         let mut still_above = true;
         let mut padded_any = false;
         for (i, run) in runs.iter().enumerate() {
@@ -879,6 +922,7 @@ impl<'a> Ledger<'a> {
                     // gain it is required to make (review of #664).
                     let marker = self
                         .marker_for(run, seen, lines.len(), &"0".repeat(HANDLE_LEN))
+                        .0
                         .len()
                         + usize::from(body.ends_with('\n'));
                     body.len() >= marker + padding + seen.origin.min_gain()
@@ -903,7 +947,14 @@ impl<'a> Ledger<'a> {
                 .zip(run.seen.as_ref())
             {
                 Some((handle, seen)) => {
-                    out.push_str(&render(seen, &handle));
+                    let (marker, kind) = render(seen, &handle);
+                    out.push_str(&marker);
+                    emitted.push(crate::store::sqlite::MarkerRecord {
+                        kind,
+                        handle: handle.clone(),
+                        lines: run.end - run.start,
+                        bytes: body.len(),
+                    });
                     // The run carried its own terminator, so the marker needs one
                     // only when the text it replaced ended a line. A run at the
                     // very end of an output with no trailing newline does not.
@@ -928,7 +979,7 @@ impl<'a> Ledger<'a> {
                 }
             }
         }
-        replaced_any.then_some((out, folded, markers_above, padded_any))
+        replaced_any.then_some((out, folded, markers_above, padded_any, emitted))
     }
 }
 
@@ -1163,6 +1214,59 @@ mod tests {
             elsewhere.contains("already shown") && elsewhere.contains("from for p in"),
             "a different command still has to name the source it is standing in \
              for (#622): {elsewhere}"
+        );
+    }
+
+    /// #766. Every wording change so far was argued from examples, because
+    /// nothing recorded which shape a reader met. `ledger_folds` groups a call by
+    /// (origin, source agent) and holds no handle, so it can say how much was
+    /// folded and never which marker did it or whether anyone went back for the
+    /// bytes.
+    ///
+    /// The kind comes from the arm that renders the string, so this asserts the
+    /// pairing rather than a label somebody typed twice: a re-run records
+    /// `session_rerun` and says `identical to an earlier run`, and a different
+    /// command records `session_run` and says `already shown`. A parser over the
+    /// rendered text would be the second copy #765 just deleted.
+    #[test]
+    fn a_fold_records_which_marker_shape_it_rendered() {
+        let (store, _d) = temp_store();
+        let poll = "wget -qO- 127.0.0.1:8482/metrics | grep ^is_read_only";
+        let block = fresh_block("is_read_only");
+
+        Ledger::new(&store, "s1").from(poll).project(&block);
+        let again = Ledger::new(&store, "s1")
+            .from(poll)
+            .project(&format!("{}{block}", fresh_block("capacity")))
+            .expect("a verbatim re-run is projectable");
+        let elsewhere = Ledger::new(&store, "s1")
+            .from("kubectl get pvc")
+            .project(&format!("{}{block}", fresh_block("phase")))
+            .expect("the same block under another command is projectable");
+
+        let rates = store.marker_retrieve_rates(1);
+        let by_kind: std::collections::HashMap<&str, i64> =
+            rates.iter().map(|r| (r.kind.as_str(), r.folds)).collect();
+
+        assert_eq!(
+            by_kind.get("session_rerun").copied(),
+            Some(1),
+            "a re-run has to be recorded as one: {:?}",
+            rates.iter().map(|r| (&r.kind, r.folds)).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            by_kind.get("session_run").copied(),
+            Some(1),
+            "a different command has to be recorded as one: {:?}",
+            rates.iter().map(|r| (&r.kind, r.folds)).collect::<Vec<_>>()
+        );
+        assert!(
+            again.contains("identical to an earlier run") && elsewhere.contains("already shown"),
+            "the recorded kinds have to name the wording that was rendered:\n{again}\n{elsewhere}"
+        );
+        assert!(
+            rates.iter().all(|r| r.retrieved == 0),
+            "nothing was retrieved in this test, so the rate has to read zero"
         );
     }
 
@@ -2003,11 +2107,13 @@ mod tests {
     #[test]
     fn a_source_cannot_break_out_of_its_marker() {
         let nasty = "cat <<EOF\nsecond line\nthird line\nEOF";
-        let marker = Origin::Session.marker(
-            9,
-            &"0".repeat(HANDLE_LEN),
-            &SourceOfSighting::Another(nasty.to_string()),
-        );
+        let marker = Origin::Session
+            .marker(
+                9,
+                &"0".repeat(HANDLE_LEN),
+                &SourceOfSighting::Another(nasty.to_string()),
+            )
+            .0;
         assert_eq!(
             marker.lines().count(),
             1,
@@ -2018,11 +2124,13 @@ mod tests {
             "expected the first line only: {marker:?}"
         );
 
-        let tabs = Origin::Session.marker(
-            9,
-            &"0".repeat(HANDLE_LEN),
-            &SourceOfSighting::Another("go\ttest\t./...".to_string()),
-        );
+        let tabs = Origin::Session
+            .marker(
+                9,
+                &"0".repeat(HANDLE_LEN),
+                &SourceOfSighting::Another("go\ttest\t./...".to_string()),
+            )
+            .0;
         assert_eq!(tabs.lines().count(), 1, "a tab split the marker: {tabs:?}");
         assert!(
             tabs.contains("from go test ./..."),
@@ -2114,10 +2222,12 @@ mod tests {
             .collect();
         let session_bar = Origin::Session
             .marker(9, &"0".repeat(HANDLE_LEN), &SourceOfSighting::Unrecorded)
+            .0
             .len()
             + Origin::Session.min_gain();
         let project_bar = Origin::Project
             .marker(9, &"0".repeat(HANDLE_LEN), &SourceOfSighting::Unrecorded)
+            .0
             .len()
             + Origin::Project.min_gain();
         assert!(
@@ -2286,6 +2396,7 @@ mod tests {
 
         let bar = Origin::Session
             .marker(3, &"0".repeat(HANDLE_LEN), &SourceOfSighting::Unrecorded)
+            .0
             .len()
             + Origin::Session.min_gain();
         assert!(
@@ -2322,9 +2433,11 @@ mod tests {
         assert_eq!(
             Origin::Session
                 .marker(9, &handle, &SourceOfSighting::Unrecorded)
+                .0
                 .len(),
             Origin::Session
                 .marker(9, &"0".repeat(HANDLE_LEN), &SourceOfSighting::Unrecorded)
+                .0
                 .len()
         );
     }
@@ -2390,6 +2503,7 @@ mod tests {
             block('a').len()
                 >= Origin::Session
                     .marker(8, &"0".repeat(HANDLE_LEN), &SourceOfSighting::Unrecorded)
+                    .0
                     .len()
                     + Origin::Session.min_gain(),
             "each block must be able to fold on its own, or the guard is not what \

--- a/src/ledger/mod.rs
+++ b/src/ledger/mod.rs
@@ -1268,6 +1268,31 @@ mod tests {
             rates.iter().all(|r| r.retrieved == 0),
             "nothing was retrieved in this test, so the rate has to read zero"
         );
+
+        // The join is the deliverable, so it is asserted rather than assumed. An
+        // earlier draft of this test passed with the handle column written blank,
+        // which would have shipped a retrieve rate that is always zero.
+        let handle = again
+            .split("omni retrieve ")
+            .nth(1)
+            .and_then(|rest| rest.split(']').next())
+            .expect("the marker carries a handle");
+        store.record_retrieve_event("omni retrieve", handle, "claude_code");
+
+        let after = store.marker_retrieve_rates(1);
+        let rerun = after
+            .iter()
+            .find(|r| r.kind == "session_rerun")
+            .expect("the re-run row is still there");
+        assert_eq!(
+            rerun.retrieved,
+            1,
+            "following the handle back has to land on the shape that printed it: {:?}",
+            after
+                .iter()
+                .map(|r| (&r.kind, r.folds, r.retrieved))
+                .collect::<Vec<_>>()
+        );
     }
 
     /// #627. A fold archives the run it replaced, never the reply, so the handle

--- a/src/ledger/mod.rs
+++ b/src/ledger/mod.rs
@@ -393,6 +393,22 @@ enum SourceOfSighting {
     ThisCommandAgain,
 }
 
+/// What one substitution produced.
+///
+/// A tuple until #766 added the fifth field, at which point clippy called it a
+/// very complex type and was right: five positional fields is a shape nobody can
+/// read at the call site.
+struct Substitution {
+    view: String,
+    folded: HashSet<usize>,
+    /// Markers standing above the first surviving line, which is what decides
+    /// whether a starting line number still describes the view.
+    markers_above: usize,
+    padded: bool,
+    /// One row per marker actually emitted, for the books (#766).
+    emitted: Vec<crate::store::sqlite::MarkerRecord>,
+}
+
 /// One stretch of output, and where it was seen before if it was.
 struct Run {
     start: usize,
@@ -573,7 +589,7 @@ impl<'a> Ledger<'a> {
         // deterministic for a caller replaying the same session.
         let projected = self
             .substitute(&lines, &hashes, &origin_of)
-            .filter(|(view, _, _, _, _)| view.len() < text.len());
+            .filter(|s| s.view.len() < text.len());
 
         // What the fold did to the numbering below it (#557), read from the folded
         // indices where the answer is known. Decided here rather than after the
@@ -583,11 +599,12 @@ impl<'a> Ledger<'a> {
         // already where the file has it and no starting number moves (#664).
         let shifts = projected
             .as_ref()
-            .map(|(_, folded, above, padded, _)| {
-                if *padded {
+            .map(|s| {
+                let (folded, above, padded) = (&s.folded, s.markers_above, s.padded);
+                if padded {
                     FoldShift::None
                 } else {
-                    FoldShift::of(folded, lines.len(), *above)
+                    FoldShift::of(folded, lines.len(), above)
                 }
             })
             .unwrap_or(FoldShift::None);
@@ -605,7 +622,7 @@ impl<'a> Ledger<'a> {
         // the gain filter above, the caller emits `text` verbatim and every line
         // was delivered. That is the empty-set case and needs no special arm.
         let delivered: Vec<String> = match &projected {
-            Some((_, folded, _, _, _)) => hashes
+            Some(Substitution { folded, .. }) => hashes
                 .iter()
                 .enumerate()
                 .filter(|(i, _)| !folded.contains(i))
@@ -617,7 +634,12 @@ impl<'a> Ledger<'a> {
         // like this session's (#533). `PROJECT_FLOOR_MULT` prices cross-agent
         // reuse and was calibrated on the single-agent case, and nothing recorded
         // enough to tell the two apart after the fact.
-        if let Some((_, folded, _, _, markers)) = &projected {
+        if let Some(Substitution {
+            folded,
+            emitted: markers,
+            ..
+        }) = &projected
+        {
             // Every line folded means the agent holds markers and nothing else,
             // which is the case `MIN_WHOLE_OUTPUT_FOLD` refuses below 1 KB. Read
             // here rather than threaded out of `substitute`, because that flag is
@@ -684,7 +706,7 @@ impl<'a> Ledger<'a> {
                 .ledger_record(p, &delivered, &self.agent, &self.source);
         }
 
-        projected.map(|(view, _, _, _, _)| (view, shifts))
+        projected.map(|s| (s.view, shifts))
     }
 
     /// The marker one run would be replaced by, rendered rather than estimated
@@ -719,13 +741,7 @@ impl<'a> Ledger<'a> {
         lines: &[&str],
         hashes: &[String],
         origin_of: &dyn Fn(&String) -> Option<Seen>,
-    ) -> Option<(
-        String,
-        HashSet<usize>,
-        usize,
-        bool,
-        Vec<crate::store::sqlite::MarkerRecord>,
-    )> {
+    ) -> Option<Substitution> {
         let runs = group_runs(hashes, origin_of);
         if !runs.iter().any(|r| r.seen.is_some()) {
             return None;
@@ -979,7 +995,13 @@ impl<'a> Ledger<'a> {
                 }
             }
         }
-        replaced_any.then_some((out, folded, markers_above, padded_any, emitted))
+        replaced_any.then_some(Substitution {
+            view: out,
+            folded,
+            markers_above,
+            padded: padded_any,
+            emitted,
+        })
     }
 }
 

--- a/src/ledger/mod.rs
+++ b/src/ledger/mod.rs
@@ -1315,6 +1315,26 @@ mod tests {
                 .map(|r| (&r.kind, r.folds, r.retrieved))
                 .collect::<Vec<_>>()
         );
+
+        // #771 review. A handle is the SHA of its content, so one pulled twice
+        // used to multiply its own marker through the join: the fold count
+        // stopped counting markers and the retrieval sum stopped counting
+        // answered questions.
+        store.record_retrieve_event("omni retrieve", handle, "claude_code");
+        let twice = store.marker_retrieve_rates(1);
+        let after_two = twice
+            .iter()
+            .find(|r| r.kind == "session_rerun")
+            .expect("the re-run row survives a second pull");
+        assert_eq!(
+            (after_two.folds, after_two.retrieved),
+            (1, 1),
+            "pulling one handle twice has to stay one marker and one answered question: {:?}",
+            twice
+                .iter()
+                .map(|r| (&r.kind, r.folds, r.retrieved))
+                .collect::<Vec<_>>()
+        );
     }
 
     /// #627. A fold archives the run it replaced, never the reply, so the handle

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -2352,6 +2352,14 @@ impl SqliteBackend {
     /// content, in different shapes, are both credited by one retrieval. Content
     /// addressing is what makes a handle worth having, and separating those two
     /// would need a per-marker id the retrieval path does not carry.
+    ///
+    /// `>=` and not `>`, deliberately. Both tables keep whole seconds, so a tie is
+    /// ambiguous either way, and the two readings are not equally likely: a reader
+    /// follows a handle within seconds of meeting it (#543 recorded four of four
+    /// pulls inside nine seconds), while the case `>` would protect against needs
+    /// the same content folded twice with a pull in between, inside one second.
+    /// `>` would drop the common case to avoid the rare one. Resolving the tie for
+    /// real needs sub-second timestamps on both tables (#771 review).
     pub fn marker_retrieve_rates(&self, days: i64) -> Vec<MarkerRate> {
         let Ok(conn) = self.pool.get() else {
             return Vec::new();

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -970,6 +970,40 @@ impl SqliteBackend {
                 [],
             );
         }
+        // #766. `ledger_folds` aggregates a call's folds by (origin, source agent),
+        // so it cannot say which marker wording a reader was handed, and it holds
+        // no handle, so nothing joins a retrieval back to the fold that caused it.
+        // Both questions are per marker, which is a finer grain than that table
+        // has, and widening it would change every figure already published from
+        // it. A second table at the right grain answers them and disturbs nothing.
+        //
+        // `kind` is decided by the code that renders the string, never by parsing
+        // one back: this repository has been bitten three times by two copies of
+        // one string (#452, #454, #456), and #765 removed a tally that tried to
+        // recognise markers in text.
+        let _ = conn.execute(
+            "CREATE TABLE IF NOT EXISTS fold_markers (
+                id      INTEGER PRIMARY KEY,
+                fold_id INTEGER NOT NULL,
+                ts      INTEGER NOT NULL,
+                scope   TEXT NOT NULL,
+                session TEXT NOT NULL DEFAULT '',
+                agent_id TEXT NOT NULL DEFAULT 'unknown',
+                kind    TEXT NOT NULL,
+                handle  TEXT NOT NULL DEFAULT '',
+                lines   INTEGER NOT NULL,
+                bytes   INTEGER NOT NULL
+            )",
+            [],
+        );
+        let _ = conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_fold_markers_handle ON fold_markers(handle)",
+            [],
+        );
+        let _ = conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_fold_markers_ts ON fold_markers(ts)",
+            [],
+        );
         let _ = conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_ledger_folds_fold ON ledger_folds(fold_id)",
             [],
@@ -2299,6 +2333,39 @@ impl SqliteBackend {
         let _ = tx.commit();
     }
 
+    /// Retrieve rate per marker shape, over the last `days`.
+    ///
+    /// Joined on the handle, which is the only thing that ties a retrieval to the
+    /// marker that caused it. `retrieve_events` predates `fold_markers`, so a
+    /// retrieval of a marker written before #766 finds no row here and is absent
+    /// rather than counted against some other shape: window the query and read
+    /// `folds` before reading the rate.
+    pub fn marker_retrieve_rates(&self, days: i64) -> Vec<MarkerRate> {
+        let Ok(conn) = self.pool.get() else {
+            return Vec::new();
+        };
+        let Ok(mut stmt) = conn.prepare(
+            "SELECT m.kind, COUNT(*),
+                    SUM(CASE WHEN r.hash IS NOT NULL THEN 1 ELSE 0 END)
+               FROM fold_markers m
+               LEFT JOIN retrieve_events r ON r.hash = m.handle
+              WHERE m.ts >= strftime('%s','now') - (?1 * 86400)
+              GROUP BY m.kind
+              ORDER BY 3 DESC",
+        ) else {
+            return Vec::new();
+        };
+        let rows = stmt.query_map(params![days], |r| {
+            Ok(MarkerRate {
+                kind: r.get(0)?,
+                folds: r.get(1)?,
+                retrieved: r.get(2).unwrap_or(0),
+            })
+        });
+        rows.map(|rs| rs.filter_map(Result::ok).collect())
+            .unwrap_or_default()
+    }
+
     /// Records what one call's folds drew on, grouped by origin and source agent.
     ///
     /// Written after the view is decided rather than while it is being built, so
@@ -2311,6 +2378,7 @@ impl SqliteBackend {
         agent_id: &str,
         session: &str,
         folds: &[FoldRecord],
+        markers: &[MarkerRecord],
     ) {
         if folds.is_empty() {
             return;
@@ -2355,6 +2423,29 @@ impl SqliteBackend {
                     f.payload_bytes as i64,
                     session,
                     fold_id
+                ]);
+            }
+        }
+        {
+            let Ok(mut stmt) = tx.prepare_cached(
+                "INSERT INTO fold_markers
+                     (fold_id, ts, scope, session, agent_id, kind, handle, lines, bytes)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            ) else {
+                let _ = tx.commit();
+                return;
+            };
+            for m in markers {
+                let _ = stmt.execute(params![
+                    fold_id,
+                    ts,
+                    scope,
+                    session,
+                    agent_id,
+                    m.kind,
+                    m.handle,
+                    m.lines as i64,
+                    m.bytes as i64,
                 ]);
             }
         }
@@ -3110,6 +3201,33 @@ impl EngineTotals {
 }
 
 #[derive(Debug, Clone)]
+/// How often one marker shape sent a reader back for the bytes.
+///
+/// The whole point of recording the kind (#766). A shape with a high retrieve
+/// rate is one that did not answer the question it interrupted, which is a work
+/// queue rather than an opinion about wording.
+pub struct MarkerRate {
+    pub kind: String,
+    pub folds: i64,
+    pub retrieved: i64,
+}
+
+/// One marker a reader was actually handed, at the grain `ledger_folds` cannot
+/// reach: that table groups a call's folds by (origin, source agent), and a
+/// marker is per run.
+///
+/// `kind` comes from the arm that rendered the string, so a wording change moves
+/// the label with it (#766). `handle` is what joins a later `retrieve_events`
+/// row back to the marker that sent the reader looking, which is the measurement
+/// this exists for: a marker shape with a high retrieve rate is one that did not
+/// answer the question it interrupted.
+pub struct MarkerRecord {
+    pub kind: &'static str,
+    pub handle: String,
+    pub lines: usize,
+    pub bytes: usize,
+}
+
 pub struct FoldRecord {
     /// The agent that was shown these lines first, from `ledger_lines.agent_id`.
     pub source_agent: String,
@@ -4026,6 +4144,7 @@ mod tests {
                     payload_bytes: 2_000,
                 },
             ],
+            &[],
         );
 
         // A second fold, same second, same session, same payload size, and it
@@ -4043,6 +4162,7 @@ mod tests {
                 whole_output: false,
                 payload_bytes: 2_000,
             }],
+            &[],
         );
 
         // A third fold sharing the second, the session, the agent, the scope and
@@ -4060,6 +4180,7 @@ mod tests {
                 whole_output: false,
                 payload_bytes: 2_000,
             }],
+            &[],
         );
 
         // A fourth fold with no payload size: summable, never divisible.
@@ -4075,6 +4196,7 @@ mod tests {
                 whole_output: false,
                 payload_bytes: 0,
             }],
+            &[],
         );
 
         // Force every row into one second. The recorder stamps wall clock, so a

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -2340,15 +2340,27 @@ impl SqliteBackend {
     /// retrieval of a marker written before #766 finds no row here and is absent
     /// rather than counted against some other shape: window the query and read
     /// `folds` before reading the rate.
+    ///
+    /// `EXISTS` rather than a join, and the difference is not style (#771 review).
+    /// A handle is the SHA of the content, so the same bytes folded twice carry
+    /// the same handle, and a plain `LEFT JOIN` then multiplies a marker by every
+    /// retrieval that ever matched it: `COUNT(*)` stops counting markers and the
+    /// sum stops counting pulls. This asks one question per marker instead, which
+    /// is "was this content ever fetched after this marker was shown".
+    ///
+    /// The bound that remains, stated rather than hidden: two markers of the same
+    /// content, in different shapes, are both credited by one retrieval. Content
+    /// addressing is what makes a handle worth having, and separating those two
+    /// would need a per-marker id the retrieval path does not carry.
     pub fn marker_retrieve_rates(&self, days: i64) -> Vec<MarkerRate> {
         let Ok(conn) = self.pool.get() else {
             return Vec::new();
         };
         let Ok(mut stmt) = conn.prepare(
             "SELECT m.kind, COUNT(*),
-                    SUM(CASE WHEN r.hash IS NOT NULL THEN 1 ELSE 0 END)
+                    SUM(EXISTS (SELECT 1 FROM retrieve_events r
+                                 WHERE r.hash = m.handle AND r.ts >= m.ts))
                FROM fold_markers m
-               LEFT JOIN retrieve_events r ON r.hash = m.handle
               WHERE m.ts >= strftime('%s','now') - (?1 * 86400)
               GROUP BY m.kind
               ORDER BY 3 DESC",
@@ -2553,6 +2565,10 @@ impl SqliteBackend {
         // its deletion in the same commit as its schema rather than a follow-up.
         let _ = conn.execute(
             "DELETE FROM ledger_folds WHERE ts < ?1",
+            params![ts_threshold],
+        );
+        let _ = conn.execute(
+            "DELETE FROM fold_markers WHERE ts < ?1",
             params![ts_threshold],
         );
 


### PR DESCRIPTION
Three marker wordings have shipped on reasoning alone (#519, #567, #755), because nothing
recorded which shape a reader actually met. #755 had to say in its own PR that its cost
was unmeasurable, and #760 could not size what its fix cost, both for the same missing
column.

**Why not widen `ledger_folds`.** It groups a call's folds by (origin, source agent), so
several markers land on one row, and it holds no handle, so nothing joins a retrieval back
to the marker that sent the reader looking. The question is per marker, which is a finer
grain than that table has, and changing its grain would move every figure already
published from it. `fold_markers` sits at the grain a marker lives at and disturbs nothing
that exists.

**The kind comes from the arm that renders the string.** Both marker functions now return
`(String, &'static str)`, so a wording change moves its label with it. Recognising markers
by parsing the rendered output is the second copy of one string that #765 deleted two PRs
ago, and that this repository has been bitten by three times (#452, #454, #456).

`marker_retrieve_rates(days)` is the deliverable:

```
SELECT m.kind, COUNT(*), SUM(r.hash IS NOT NULL)
  FROM fold_markers m LEFT JOIN retrieve_events r ON r.hash = m.handle
 WHERE m.ts >= strftime('%s','now') - days * 86400
 GROUP BY m.kind
```

A shape with a high retrieve rate is one that did not answer the question it interrupted.
That is the work queue #767, #768 and #769 are waiting on, ordered by evidence rather than
by which example someone remembers.

**Two things the break-tests found, and the second one is the point of doing them.**
Mislabelling a re-run as a plain run fails the test at the assertion that names it. And
blanking the handle column left the first draft of the test **green**, which means the
retrieve rate this whole ticket exists for was unasserted and would have shipped reading
zero forever. The test now records a real retrieval against the handle it reads out of the
marker; the same break is red at `mod.rs:1287`.

clippy also refused the five-tuple `substitute` had grown into, correctly, so that is a
named `Substitution` struct now.

Verification: `make ci` green, `smoke_test.sh` 70/70.

Closes #766






<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds per-marker ledger telemetry so marker wording and later retrieval behavior can be measured without changing existing fold aggregates.
- Marker rendering now returns a stable shape label alongside the rendered text.
- Emitted marker metadata is persisted in the new `fold_markers` table.
- Retrieve-rate reporting uses a per-marker `EXISTS` check and retains marker rows under the ledger retention policy.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/ledger/mod.rs | Couples each rendered marker with its static kind and records metadata only for markers in the accepted projected view. |
| src/store/sqlite.rs | Adds marker persistence, retention cleanup, and per-kind retrieval-rate aggregation while preserving one count per marker. |
| changelog.d/766.added.md | Documents the new per-marker telemetry and its retrieval-rate purpose. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant L as Ledger
    participant S as SQLite Store
    participant A as Agent
    L->>S: Archive folded content
    S-->>L: Content handle
    L->>A: Render marker with handle and kind
    L->>S: Record fold and marker metadata
    A->>S: Retrieve content by handle
    S->>S: Record retrieval event
    S->>S: Compute per-kind rate with EXISTS
```
</details>

<sub>Reviews (3): Last reviewed commit: ["docs(store): say why the retrieval windo..."](https://github.com/fajarhide/omni/commit/68b3efbe537550a213edcdddaa4da73129f0db41) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60287003)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Persistent data and retrieval](https://app.greptile.com/weekndlabs/-/custom-context/knowledge-base/fajarhide/omni/-/docs/persistent-data-and-retrieval.md)
- Knowledge Base — [SQLite transcripts and queries](https://app.greptile.com/weekndlabs/-/custom-context/knowledge-base/fajarhide/omni/-/docs/sqlite-transcripts-and-queries.md)
- Knowledge Base — [Graphs, ledger, and context analytics](https://app.greptile.com/weekndlabs/-/custom-context/knowledge-base/fajarhide/omni/-/docs/graphs-ledger-and-context-analytics.md)
</details>


<!-- /greptile_comment -->