### PR TITLE
fix(init): --hook installs hooks, and an absent MCP server is not a fault

### DIFF
--- a/changelog.d/757.fixed.md
+++ b/changelog.d/757.fixed.md
@@ -1,0 +1,8 @@
+- **`omni init --hook` registered an MCP server it said it would not (#757)**: the flag has
+  read "Only install hooks" since it shipped and installed both halves anyway, and then
+  `omni doctor` called the resulting state a broken install and `omni doctor --fix` undid
+  it. Three ways of overruling a choice the CLI offered in the first place. `--hook` and
+  `--mcp` now install the half they name, naming the host or both halves still gets both,
+  and an absent MCP registration on Claude Code is reported as what it is rather than as a
+  fault: the hooks are what shortens output there, and the server is a convenience whose
+  tool definitions sit in the prefix of every request.

--- a/docs/website/src-id/reference/agents.md
+++ b/docs/website/src-id/reference/agents.md
@@ -61,11 +61,17 @@ JSON di awal setiap request, dan host membuang seluruh cache ketika sebuah serve
 tersambung atau terputus sementara perkakasnya sudah dimuat, yang bisa terjadi sendiri
 saat proses server keluar lalu tersambung lagi di tengah sesi tanpa Anda melakukan apa
 pun. `omni init --claude` mendaftarkannya. Jalur plugin tidak menambah definisi perkakas
-sama sekali. Untuk tetap memakai hook tanpa pertukaran itu, hapus entri `omni` dari
-`mcpServers` di `~/.claude.json`, dan ketahui bahwa penghapusannya tidak bertahan:
-`omni doctor` melaporkan ketiadaannya sebagai peringatan, sedangkan `omni doctor --fix`
-dan `omni init` berikutnya akan mendaftarkannya lagi. Belum ada flag khusus hook saja
-([#757](https://github.com/fajarhide/omni/issues/757)).
+sama sekali. Untuk tetap memakai hook tanpa pertukaran itu, pasang
+separuhnya saja:
+
+```sh
+omni init --hook     # hook saja, tanpa pendaftaran MCP
+omni init --mcp      # server MCP saja, kalau Anda berubah pikiran
+```
+
+`omni doctor` kemudian melaporkan server MCP sebagai tidak terdaftar, bukan sebagai
+kesalahan, dan baik ia maupun `--fix` tidak akan memasangnya kembali (#757). Menyebut
+host-nya, `omni init --claude`, tetap memasang keduanya.
 
 **OpenClaw** Penuh di giliran berikutnya, bukan giliran saat ini. Hook
 `tool_result_persist`-nya menulis ulang hasil tool yang disimpan OpenClaw, jadi model

--- a/docs/website/src/reference/agents.md
+++ b/docs/website/src/reference/agents.md
@@ -57,10 +57,16 @@ in the prefix of every request, and the host discards the whole cache when an MC
 connects or disconnects with its tools loaded, which a server process can do by exiting
 and reconnecting mid-session without you touching anything. `omni init --claude`
 registers it. The plugin route adds no tool definitions at all. To keep the hooks and drop
-the trade, remove the `omni` entry from `mcpServers` in `~/.claude.json`, and know that
-the removal does not stick: `omni doctor` reports the absence as a warning, and both
-`omni doctor --fix` and the next `omni init` register it again. There is no hooks-only
-flag yet ([#757](https://github.com/fajarhide/omni/issues/757)).
+the trade, install that half on its own:
+
+```sh
+omni init --hook     # hooks, no MCP registration
+omni init --mcp      # the MCP server on its own, if you change your mind
+```
+
+`omni doctor` then reports the MCP server as not registered rather than as a fault, and
+neither it nor `--fix` puts it back (#757). Naming the host, `omni init --claude`, still
+installs both.
 
 **OpenClaw** is Full on a later turn, not the current one. Its `tool_result_persist`
 hook rewrites the tool result OpenClaw persists, so the model reads the distilled bytes

--- a/src/agents/claude.rs
+++ b/src/agents/claude.rs
@@ -28,25 +28,13 @@ impl AgentIntegration for ClaudeIntegration {
     }
 
     fn install(&self, exe_path: &str) -> anyhow::Result<()> {
-        let (path, mut val) = initialize_settings()?;
-        let _ = backup_settings(&path);
-
-        install_omni_hooks(&mut val, exe_path);
-        let new_content = serde_json::to_string_pretty(&val)?;
-        fs::write(&path, new_content)?;
-        crate::agent_report!(
-            "  {} {} installed in Claude settings",
-            "✓".green(),
-            "Hooks".bold()
-        );
-
+        install_hooks(exe_path)?;
         install_mcp_server(exe_path)?;
         crate::agent_report!(
             "  {} {} registered in .claude.json",
             "✓".green(),
             "MCP Server".bold()
         );
-
         Ok(())
     }
 
@@ -256,24 +244,24 @@ impl AgentIntegration for ClaudeIntegration {
             }
         }
         if !mcp_found {
-            if fix_mode {
-                if let Ok(exe_path) = std::env::current_exe() {
-                    crate::agents::report_fix(
-                        "MCP Server:",
-                        "registered",
-                        self.install(&exe_path.to_string_lossy()),
-                        warnings,
-                    );
-                }
-            } else {
-                crate::agent_report!(
-                    "   {:<15} {}",
-                    "MCP Server:".bright_black(),
-                    "[WARNING] no MCP server found".yellow().bold()
-                );
-                warnings.push("MCP Server is not configured. Run `omni init`.".to_string());
-                all_ok = false;
-            }
+            // #757. Absence is a state here, not a fault. The hooks are what
+            // shortens output on this host; the MCP server is a convenience whose
+            // two tool definitions sit in the prefix of every request, and the
+            // host discards the whole prompt cache when an MCP server connects or
+            // disconnects with its tools loaded. Someone who ran
+            // `omni init --hook`, or who removed the entry on purpose after
+            // reading that, was being told their install was broken and then
+            // having the decision undone by the next `doctor --fix`.
+            //
+            // So it reports, and says how to add it, and neither fails the check
+            // nor repairs what nobody broke.
+            let _ = fix_mode;
+            crate::agent_report!(
+                "   {:<15} {}  {}",
+                "MCP Server:".bright_black(),
+                "[not registered]".bright_black(),
+                "optional here, `omni init --mcp` adds it".bright_black()
+            );
         }
 
         all_ok
@@ -556,6 +544,28 @@ pub fn install_omni_hooks(val: &mut Value, exe_path: &str) {
         hooks.entry("FileChanged").or_insert_with(|| json!([])),
         &hook_cmd,
     );
+}
+
+/// The half of the install that does the work.
+///
+/// Separate from the MCP registration because `omni init --hook` has promised
+/// "Only install hooks" since it shipped and installed both anyway, which is the
+/// shape of #151: a flag the parser accepts and the code ignores. On this host
+/// the hooks are what shortens output and the MCP server is a convenience whose
+/// tool definitions sit in the prefix of every request, so wanting one without
+/// the other is an ordinary preference and not a broken install (#757).
+pub fn install_hooks(exe_path: &str) -> anyhow::Result<()> {
+    let (path, mut val) = initialize_settings()?;
+    let _ = backup_settings(&path);
+
+    install_omni_hooks(&mut val, exe_path);
+    fs::write(&path, serde_json::to_string_pretty(&val)?)?;
+    crate::agent_report!(
+        "  {} {} installed in Claude settings",
+        "✓".green(),
+        "Hooks".bold()
+    );
+    Ok(())
 }
 
 pub fn install_mcp_server(exe_path: &str) -> anyhow::Result<()> {

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -127,6 +127,22 @@ fn non_interactive_host() -> anyhow::Result<&'static str> {
     })
 }
 
+/// Which halves of the Claude Code install a flag set asks for, as (hooks, mcp).
+///
+/// #757. `--hook` has said "Only install hooks" since it shipped and installed
+/// the MCP server as well, which is the shape of #151: a flag the parser accepts
+/// and the code ignores. On this host the hooks are what shortens output and the
+/// MCP server is a convenience whose tool definitions sit in the prefix of every
+/// request, so one without the other is a preference somebody can hold.
+///
+/// Asking for both, by naming the host or by naming both halves, gets both.
+fn claude_halves(is_claude: bool, is_all: bool, is_hook: bool, is_mcp: bool) -> (bool, bool) {
+    if is_claude || is_all || (is_hook && is_mcp) || (!is_hook && !is_mcp) {
+        return (true, true);
+    }
+    (is_hook, is_mcp)
+}
+
 pub fn run_init(args: &[String]) -> anyhow::Result<()> {
     if super::wants_help(args) {
         print_help();
@@ -426,7 +442,21 @@ pub fn run_init(args: &[String]) -> anyhow::Result<()> {
         if target_ids.contains(&agent.id()) {
             println!("{}", format!("🤖 {} Setup", agent.name()).bold().cyan());
 
-            match agent.install(&exe_path) {
+            // #757. `--hook` and `--mcp` have promised "Only install hooks" and
+            // "Only register MCP server" since they shipped, and both installed
+            // the pair. On Claude Code the hooks are what shortens output and the
+            // MCP server is a convenience that puts two tool definitions in the
+            // prefix of every request, so one without the other is a preference
+            // somebody can hold, and the flag that says so has to mean it.
+            let outcome = match (
+                agent.id(),
+                claude_halves(is_claude, is_all, is_hook, is_mcp),
+            ) {
+                ("claude", (true, false)) => crate::agents::claude::install_hooks(&exe_path),
+                ("claude", (false, true)) => crate::agents::claude::install_mcp_server(&exe_path),
+                _ => agent.install(&exe_path),
+            };
+            match outcome {
                 Err(e) => eprintln!("  {} Failed: {}", "✗".red(), e),
                 // #684. The success line was the same shape on every host, so
                 // configuring an MCP-only one read as "OMNI is now shortening
@@ -462,6 +492,33 @@ pub fn run_init(args: &[String]) -> anyhow::Result<()> {
 
 #[cfg(test)]
 mod tests {
+
+    /// #757. Both flags have promised a half since they shipped and delivered
+    /// the pair, so `omni init --hook` registered an MCP server the user had
+    /// just said they did not want. The parser accepted the flag and the code
+    /// ignored it, which is #151 wearing a different name.
+    ///
+    /// The table is the point: naming the host, or naming both halves, or naming
+    /// neither, all still get both. Only a single half means a single half.
+    #[test]
+    fn a_half_flag_installs_that_half_and_nothing_else() {
+        // (is_claude, is_all, is_hook, is_mcp) -> (hooks, mcp)
+        for (args, want) in [
+            ((false, false, true, false), (true, false)),
+            ((false, false, false, true), (false, true)),
+            ((false, false, true, true), (true, true)),
+            ((true, false, true, false), (true, true)),
+            ((false, true, true, false), (true, true)),
+            ((false, false, false, false), (true, true)),
+        ] {
+            let (is_claude, is_all, is_hook, is_mcp) = args;
+            assert_eq!(
+                claude_halves(is_claude, is_all, is_hook, is_mcp),
+                want,
+                "claude_halves{args:?} has to be {want:?}"
+            );
+        }
+    }
     use super::*;
 
     /// Every host the no-tty path can pick has to be a real install target, or


### PR DESCRIPTION
`omni init --hook` has read "Only install hooks" since it shipped and registered the MCP
server as well. The parser accepted the flag and the code ignored it, which is #151 wearing
a different name. Then `omni doctor` called the state that flag produces a broken install
and pushed `MCP Server is not configured. Run omni init`, and `omni doctor --fix`
reinstalled it. Three ways of overruling a choice the CLI offered in the first place.

`--hook` and `--mcp` now install the half they name. Naming the host, naming both halves,
or naming neither still installs both, which is the table:

| flags | hooks | mcp |
| --- | --- | --- |
| `--hook` | yes | no |
| `--mcp` | no | yes |
| `--hook --mcp` | yes | yes |
| `--claude`, `--all`, or neither | yes | yes |

An absent MCP registration on Claude Code is now reported as what it is rather than as a
fault, and `--fix` does not repair what nobody broke. That is not leniency: on this host the
hooks are what shortens output, while the MCP server is a convenience whose two tool
definitions sit in the prefix of every request, and the host discards the whole prompt
cache when an MCP server connects or disconnects with its tools loaded (#740). Wanting one
without the other is an ordinary preference.

`docs/website` in both trees stops telling readers to delete a line from `~/.claude.json`
and warning them it will not stick, since there is a flag now.

**The first test I wrote was toothless and is not in this PR.** It asserted that the hooks
half leaves `mcpServers` out of `settings.json`, which was already true on `main` because
the MCP registration lives in a different file. The decision is a function now,
`claude_halves`, and the test is the table above. Break-tested: forcing it to answer
`(true, true)` fails at `claude_halves(false, false, true, false) has to be (true, false)`.

Verification: `make ci` green, `smoke_test.sh` 70/70, `check_translations.sh` green.

Closes #757


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR separates Claude hook and MCP installation so `--hook` and `--mcp` can install only their named half, and makes an absent Claude MCP registration informational rather than unhealthy.

- Adds table-driven selection for full, hooks-only, and MCP-only Claude setup.
- Extracts the Claude hook installer from the full integration installer.
- Stops doctor from warning about or directly repairing an absent optional MCP server.
- Updates English and Indonesian agent documentation and the changelog.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until Claude hook repair preserves a hooks-only installation instead of restoring the optional MCP server.

The primary init path correctly separates the two installation halves, but every Claude hook-repair path still calls the full installer and therefore reverses the new hooks-only choice.

**Files Needing Attention:** src/agents/claude.rs
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/cli/init.rs | Adds Claude half-selection and routes single-half requests to dedicated installers. |
| src/agents/claude.rs | Splits hook installation and makes MCP absence optional, but hook repair still invokes the full installer and restores MCP. |
| docs/website/src/reference/agents.md | Documents hooks-only and MCP-only Claude setup in English. |
| docs/website/src-id/reference/agents.md | Mirrors the updated Claude setup guidance in Indonesian. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[omni init flags] --> B{Claude halves}
  B -->|hook only| C[Install Claude hooks]
  B -->|MCP only| D[Register MCP server]
  B -->|both| E[Full Claude installer]
  F[omni doctor --fix] --> G{Hooks need repair?}
  G -->|yes| E
  E --> C
  E --> D
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/agents/claude.rs`, line 177 ([link](https://github.com/fajarhide/omni/blob/a541daf5ca78a0b9724173bbf5399c5766c78372/src/agents/claude.rs#L177)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Hook repair restores MCP**

   When a hooks-only installation has missing hooks and the user runs `omni doctor --fix`, this branch calls the full `install()` method, which also registers the MCP server, causing `.claude.json` to regain the entry that `--hook` was intended to omit. The other hook-repair branches have the same behavior.

   **Knowledge Base Used:**
   - [CLI command workflows](https://app.greptile.com/weekndlabs/-/custom-context/knowledge-base/fajarhide/omni/-/docs/cli-command-workflows.md)
   - [Agent integration layer](https://app.greptile.com/weekndlabs/-/custom-context/knowledge-base/fajarhide/omni/-/docs/agent-integration-layer.md)
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: src/agents/claude.rs
   Line: 177
   
   Comment:
   **Hook repair restores MCP**
   
   When a hooks-only installation has missing hooks and the user runs `omni doctor --fix`, this branch calls the full `install()` method, which also registers the MCP server, causing `.claude.json` to regain the entry that `--hook` was intended to omit. The other hook-repair branches have the same behavior.
   
   **Knowledge Base Used:**
   - [CLI command workflows](https://app.greptile.com/weekndlabs/-/custom-context/knowledge-base/fajarhide/omni/-/docs/cli-command-workflows.md)
   - [Agent integration layer](https://app.greptile.com/weekndlabs/-/custom-context/knowledge-base/fajarhide/omni/-/docs/agent-integration-layer.md)
   
   ---
   
   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>
   
   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fagents%2Fclaude.rs%0ALine%3A%20177%0A%0AComment%3A%0A**Hook%20repair%20restores%20MCP**%0A%0AWhen%20a%20hooks-only%20installation%20has%20missing%20hooks%20and%20the%20user%20runs%20%60omni%20doctor%20--fix%60%2C%20this%20branch%20calls%20the%20full%20%60install%28%29%60%20method%2C%20which%20also%20registers%20the%20MCP%20server%2C%20causing%20%60.claude.json%60%20to%20regain%20the%20entry%20that%20%60--hook%60%20was%20intended%20to%20omit.%20The%20other%20hook-repair%20branches%20have%20the%20same%20behavior.%0A%0A**Knowledge%20Base%20Used%3A**%0A-%20%5BCLI%20command%20workflows%5D%28https%3A%2F%2Fapp.greptile.com%2Fweekndlabs%2F-%2Fcustom-context%2Fknowledge-base%2Ffajarhide%2Fomni%2F-%2Fdocs%2Fcli-command-workflows.md%29%0A-%20%5BAgent%20integration%20layer%5D%28https%3A%2F%2Fapp.greptile.com%2Fweekndlabs%2F-%2Fcustom-context%2Fknowledge-base%2Ffajarhide%2Fomni%2F-%2Fdocs%2Fagent-integration-layer.md%29%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni&pr=772&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fajarhide%2Fomni%22%20on%20the%20existing%20branch%20%22feat%2F757-hooks-without-mcp%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F757-hooks-without-mcp%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fagents%2Fclaude.rs%0ALine%3A%20177%0A%0AComment%3A%0A**Hook%20repair%20restores%20MCP**%0A%0AWhen%20a%20hooks-only%20installation%20has%20missing%20hooks%20and%20the%20user%20runs%20%60omni%20doctor%20--fix%60%2C%20this%20branch%20calls%20the%20full%20%60install%28%29%60%20method%2C%20which%20also%20registers%20the%20MCP%20server%2C%20causing%20%60.claude.json%60%20to%20regain%20the%20entry%20that%20%60--hook%60%20was%20intended%20to%20omit.%20The%20other%20hook-repair%20branches%20have%20the%20same%20behavior.%0A%0A**Knowledge%20Base%20Used%3A**%0A-%20%5BCLI%20command%20workflows%5D%28https%3A%2F%2Fapp.greptile.com%2Fweekndlabs%2F-%2Fcustom-context%2Fknowledge-base%2Ffajarhide%2Fomni%2F-%2Fdocs%2Fcli-command-workflows.md%29%0A-%20%5BAgent%20integration%20layer%5D%28https%3A%2F%2Fapp.greptile.com%2Fweekndlabs%2F-%2Fcustom-context%2Fknowledge-base%2Ffajarhide%2Fomni%2F-%2Fdocs%2Fagent-integration-layer.md%29%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni&pr=772&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fagents%2Fclaude.rs%0ALine%3A%20177%0A%0AComment%3A%0A**Hook%20repair%20restores%20MCP**%0A%0AWhen%20a%20hooks-only%20installation%20has%20missing%20hooks%20and%20the%20user%20runs%20%60omni%20doctor%20--fix%60%2C%20this%20branch%20calls%20the%20full%20%60install%28%29%60%20method%2C%20which%20also%20registers%20the%20MCP%20server%2C%20causing%20%60.claude.json%60%20to%20regain%20the%20entry%20that%20%60--hook%60%20was%20intended%20to%20omit.%20The%20other%20hook-repair%20branches%20have%20the%20same%20behavior.%0A%0A**Knowledge%20Base%20Used%3A**%0A-%20%5BCLI%20command%20workflows%5D%28https%3A%2F%2Fapp.greptile.com%2Fweekndlabs%2F-%2Fcustom-context%2Fknowledge-base%2Ffajarhide%2Fomni%2F-%2Fdocs%2Fcli-command-workflows.md%29%0A-%20%5BAgent%20integration%20layer%5D%28https%3A%2F%2Fapp.greptile.com%2Fweekndlabs%2F-%2Fcustom-context%2Fknowledge-base%2Ffajarhide%2Fomni%2F-%2Fdocs%2Fagent-integration-layer.md%29%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=772&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fajarhide%2Fomni%22%20on%20the%20existing%20branch%20%22feat%2F757-hooks-without-mcp%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F757-hooks-without-mcp%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fagents%2Fclaude.rs%0ALine%3A%20177%0A%0AComment%3A%0A**Hook%20repair%20restores%20MCP**%0A%0AWhen%20a%20hooks-only%20installation%20has%20missing%20hooks%20and%20the%20user%20runs%20%60omni%20doctor%20--fix%60%2C%20this%20branch%20calls%20the%20full%20%60install%28%29%60%20method%2C%20which%20also%20registers%20the%20MCP%20server%2C%20causing%20%60.claude.json%60%20to%20regain%20the%20entry%20that%20%60--hook%60%20was%20intended%20to%20omit.%20The%20other%20hook-repair%20branches%20have%20the%20same%20behavior.%0A%0A**Knowledge%20Base%20Used%3A**%0A-%20%5BCLI%20command%20workflows%5D%28https%3A%2F%2Fapp.greptile.com%2Fweekndlabs%2F-%2Fcustom-context%2Fknowledge-base%2Ffajarhide%2Fomni%2F-%2Fdocs%2Fcli-command-workflows.md%29%0A-%20%5BAgent%20integration%20layer%5D%28https%3A%2F%2Fapp.greptile.com%2Fweekndlabs%2F-%2Fcustom-context%2Fknowledge-base%2Ffajarhide%2Fomni%2F-%2Fdocs%2Fagent-integration-layer.md%29%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductor.svg?v=6"><img alt="Fix in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductor.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20fajarhide%2Fomni%20PR%20%23772%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=fajarhide%2Fomni&pr=772&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fagents%2Fclaude.rs%3A177%0A**Hook%20repair%20restores%20MCP**%0A%0AWhen%20a%20hooks-only%20installation%20has%20missing%20hooks%20and%20the%20user%20runs%20%60omni%20doctor%20--fix%60%2C%20this%20branch%20calls%20the%20full%20%60install%28%29%60%20method%2C%20which%20also%20registers%20the%20MCP%20server%2C%20causing%20%60.claude.json%60%20to%20regain%20the%20entry%20that%20%60--hook%60%20was%20intended%20to%20omit.%20The%20other%20hook-repair%20branches%20have%20the%20same%20behavior.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni&pr=772&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fajarhide%2Fomni%22%20on%20the%20existing%20branch%20%22feat%2F757-hooks-without-mcp%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F757-hooks-without-mcp%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fagents%2Fclaude.rs%3A177%0A**Hook%20repair%20restores%20MCP**%0A%0AWhen%20a%20hooks-only%20installation%20has%20missing%20hooks%20and%20the%20user%20runs%20%60omni%20doctor%20--fix%60%2C%20this%20branch%20calls%20the%20full%20%60install%28%29%60%20method%2C%20which%20also%20registers%20the%20MCP%20server%2C%20causing%20%60.claude.json%60%20to%20regain%20the%20entry%20that%20%60--hook%60%20was%20intended%20to%20omit.%20The%20other%20hook-repair%20branches%20have%20the%20same%20behavior.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni&pr=772&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Asrc%2Fagents%2Fclaude.rs%3A177%0A**Hook%20repair%20restores%20MCP**%0A%0AWhen%20a%20hooks-only%20installation%20has%20missing%20hooks%20and%20the%20user%20runs%20%60omni%20doctor%20--fix%60%2C%20this%20branch%20calls%20the%20full%20%60install%28%29%60%20method%2C%20which%20also%20registers%20the%20MCP%20server%2C%20causing%20%60.claude.json%60%20to%20regain%20the%20entry%20that%20%60--hook%60%20was%20intended%20to%20omit.%20The%20other%20hook-repair%20branches%20have%20the%20same%20behavior.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=772&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fajarhide%2Fomni%22%20on%20the%20existing%20branch%20%22feat%2F757-hooks-without-mcp%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F757-hooks-without-mcp%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fagents%2Fclaude.rs%3A177%0A**Hook%20repair%20restores%20MCP**%0A%0AWhen%20a%20hooks-only%20installation%20has%20missing%20hooks%20and%20the%20user%20runs%20%60omni%20doctor%20--fix%60%2C%20this%20branch%20calls%20the%20full%20%60install%28%29%60%20method%2C%20which%20also%20registers%20the%20MCP%20server%2C%20causing%20%60.claude.json%60%20to%20regain%20the%20entry%20that%20%60--hook%60%20was%20intended%20to%20omit.%20The%20other%20hook-repair%20branches%20have%20the%20same%20behavior.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/agents/claude.rs:177
**Hook repair restores MCP**

When a hooks-only installation has missing hooks and the user runs `omni doctor --fix`, this branch calls the full `install()` method, which also registers the MCP server, causing `.claude.json` to regain the entry that `--hook` was intended to omit. The other hook-repair branches have the same behavior.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(manual): the hooks-only route is a ..."](https://github.com/fajarhide/omni/commit/a541daf5ca78a0b9724173bbf5399c5766c78372) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60326574)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [CLI command workflows](https://app.greptile.com/weekndlabs/-/custom-context/knowledge-base/fajarhide/omni/-/docs/cli-command-workflows.md)
- Knowledge Base — [Agent integration layer](https://app.greptile.com/weekndlabs/-/custom-context/knowledge-base/fajarhide/omni/-/docs/agent-integration-layer.md)
- Knowledge Base — [Agent adapters and output handling](https://app.greptile.com/weekndlabs/-/custom-context/knowledge-base/fajarhide/omni/-/docs/agent-adapters-and-output.md)
</details>


<!-- /greptile_comment -->