### PR TITLE
fix(hooks): a folded reply carries no second accounting of itself

### DIFF
--- a/changelog.d/775.fixed.md
+++ b/changelog.d/775.fixed.md
@@ -1,0 +1,8 @@
+- **A folded reply carried a second accounting of itself (#775)**: on a re-run of
+  `git log --oneline -40` the distiller cut a single byte, the ledger folded the reply to a
+  few lines, and a banner then announced `1 bytes omitted` on top of fold markers that
+  already accounted for all 40 lines. Every figure was true and the arithmetic a reader can
+  do was not. The banner is weighed against the distiller's own output now, since that is
+  the stage its numbers describe, and when it cannot pay for itself the reply keeps the
+  ledger's fold instead of being thrown away: the first cut of this fix turned a 3,257 byte
+  reply folded to 325 into a passthrough. Singulars too, so no more `1 bytes`.

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -192,9 +192,12 @@ fn rewind_marker(
         return (String::new(), String::new());
     }
     let lost = if omitted_lines > 0 {
-        format!("{omitted_lines} lines")
+        let unit = if omitted_lines == 1 { "line" } else { "lines" };
+        format!("{omitted_lines} {unit}")
     } else {
-        format!("{} bytes", content.len().saturating_sub(kept_bytes))
+        let bytes = content.len().saturating_sub(kept_bytes);
+        let unit = if bytes == 1 { "byte" } else { "bytes" };
+        format!("{bytes} {unit}")
     };
 
     if content.len() > crate::guard::limits::MAX_REWIND_BYTES {
@@ -838,6 +841,10 @@ pub fn process_payload(
     // (#519). Same defect as #301, one stage further up.
     let distilled_lines = final_out.lines().count();
     let distilled_len = final_out.len();
+    // Whether the stage after this one changed the reply, which the banner block
+    // below has to know: its `else` arm throws the reply away, and that is only
+    // correct when the distiller was the only stage that touched it (#775).
+    let mut ledger_folded = false;
 
     if let (Some(s), Some(session)) = (store.as_ref(), normalized.host_session_id.as_deref())
         && !crate::pipeline::format::refuses_the_ledger(&final_out)
@@ -856,6 +863,7 @@ pub fn process_payload(
             .project(&final_out)
     {
         final_out = view;
+        ledger_folded = true;
     }
 
     // The post-condition (#458). Every invariant above constrains what a stage
@@ -1004,11 +1012,32 @@ pub fn process_payload(
         // reply with fewer facts and more tokens, which is #268 and #269 on 102
         // and 90 byte payloads. Below that floor, hand back what the command
         // produced instead.
-        if final_out.len() + marker.len() < content.len() {
+        //
+        // Weighed against the distiller's own output, not the delivered one
+        // (#775). The numbers in this marker describe the distiller's cut, so
+        // the test that decides whether it is worth printing has to describe the
+        // same stage. Reading `final_out` let the ledger pay for it: on a
+        // re-run of `git log --oneline -40` the distiller cut a single byte, the
+        // ledger folded the reply to 4 lines, and the saving the ledger made
+        // bought a marker announcing `1 bytes omitted` on top of two fold
+        // markers that already accounted for all 40 lines. Every number was
+        // true and their sum was not.
+        if distilled_len + marker.len() < content.len() {
             final_out.push_str(&marker);
             if !rewind_hash.is_empty() {
                 route = Route::Rewind;
             }
+        } else if ledger_folded {
+            // The marker cannot pay for the distiller's cut, so it is not
+            // printed. The ledger's fold is a different saving with its own
+            // markers and its own handles, and throwing it away here cost the
+            // whole of it: on a re-run of `git log --oneline -40` this arm
+            // turned a 3,257 byte reply that had been folded to 325 into a
+            // passthrough, because the distiller had cut one byte.
+            //
+            // Nothing is left unreachable. The handle is cleared because no
+            // marker names it, and every folded run carries its own.
+            rewind_hash.clear();
         } else {
             final_out = content.to_string();
             route = Route::Passthrough;
@@ -1553,6 +1582,54 @@ mod tests {
         );
 
         assert_eq!(retrieval, None, "a retrieval must reach the agent verbatim");
+    }
+
+    /// #775. Two accountings of one payload landed in one blob and their sum
+    /// exceeded the input. The distiller cut a single byte from
+    /// `git log --oneline -40`, the ledger then folded the reply to a few lines,
+    /// and the banner announced `1 bytes omitted` on top of fold markers that
+    /// already accounted for all 40. Every number was true and the arithmetic a
+    /// reader can do was not.
+    ///
+    /// The banner is weighed against the distiller's own output now, since that
+    /// is the stage its numbers describe. The first version of this fix weighed
+    /// it correctly and then let the old `else` arm throw the ledger's fold away
+    /// with it, turning a 3,257 byte reply that had been folded to 325 into a
+    /// passthrough. Both halves are asserted here for that reason.
+    #[test]
+    fn a_folded_reply_carries_no_second_accounting_of_itself() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Arc::new(Store::open_path(&dir.path().join("omni.db")).expect("store"));
+        let body: String = (0..40)
+            .map(|i| {
+                format!(
+                    "{:07x} fix(scope): the {i}th change to something
+",
+                    i * 2_654_435
+                )
+            })
+            .collect();
+        let payload = serde_json::json!({
+            "session_id": "s-775",
+            "tool_name": "Bash",
+            "tool_input": {"command": "git log --oneline -40"},
+            "tool_response": {"stdout": body, "stderr": ""}
+        })
+        .to_string();
+
+        let _ = process_payload(&payload, Some(store.clone()), None);
+        let second = process_payload(&payload, Some(store.clone()), None)
+            .expect("a re-run of a recorded reply has to fold, not pass through");
+
+        assert!(
+            !second.contains("omitted"),
+            "a second accounting was printed over folds that already cover the \
+             payload: {second}"
+        );
+        assert!(
+            second.contains("identical to an earlier run") || second.contains("already shown"),
+            "the ledger's fold was thrown away with the banner: {second}"
+        );
     }
 
     /// #773. The column is only worth having if the hook writes it, and the

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -1022,12 +1022,29 @@ pub fn process_payload(
         // bought a marker announcing `1 bytes omitted` on top of two fold
         // markers that already accounted for all 40 lines. Every number was
         // true and their sum was not.
-        if distilled_len + marker.len() < content.len() {
+        // Two tests, and they ask different questions (#775).
+        //
+        // The first is whether the cut this marker describes can pay for it.
+        // Reading `final_out` alone let the *ledger's* saving buy a marker about
+        // the *distiller's* cut: on a re-run of `git log --oneline -40` the
+        // distiller cut one byte, the ledger folded the reply to a few lines, and
+        // the reply carried `1 bytes omitted` over fold markers that already
+        // accounted for every line. Both figures true, their sum impossible.
+        //
+        // The second is whether the reply that results is still smaller than what
+        // the command produced, which is #268 and #269 and is about every byte
+        // this function has appended, including a `[Partial signal]` added after
+        // the distiller's numbers were taken. Dropping it handed 104 bytes back
+        // for 99, caught by `never_hands_back_more_bytes_than_the_command_produced`
+        // rather than by review.
+        if distilled_len + marker.len() < content.len()
+            && final_out.len() + marker.len() < content.len()
+        {
             final_out.push_str(&marker);
             if !rewind_hash.is_empty() {
                 route = Route::Rewind;
             }
-        } else if ledger_folded {
+        } else if ledger_folded && final_out.len() < content.len() {
             // The marker cannot pay for the distiller's cut, so it is not
             // printed. The ledger's fold is a different saving with its own
             // markers and its own handles, and throwing it away here cost the
@@ -1037,6 +1054,12 @@ pub fn process_payload(
             //
             // Nothing is left unreachable. The handle is cleared because no
             // marker names it, and every folded run carries its own.
+            //
+            // The size test is not decoration. `never_hands_back_more_bytes_than_
+            // the_command_produced` caught the first version of this arm handing
+            // 104 bytes back for 99: a fold on a tiny payload can cost more than
+            // it saves, and the old passthrough was what capped that. Keeping the
+            // fold is only right when the fold is smaller.
             rewind_hash.clear();
         } else {
             final_out = content.to_string();


### PR DESCRIPTION
A folded reply carried a second accounting of itself, and the two did not add up to the
input. On a re-run of `git log --oneline -40`, through the installed 0.7.9 with an isolated
database:

```
[OMNI: 22 lines identical to an earlier run, omni retrieve 87538eab3c7f9929]
[OMNI: 17 lines identical to an earlier run, omni retrieve c7ca76c26123fa4d]
<one surviving line>
[OMNI: 1 bytes omitted, omni retrieve 91e7492e2c005907 for full output]
```

22 + 17 + 1 = 40, the whole input, and then a fourth line claims a byte more. That is the
false-claim class: nothing was missing and the output says otherwise.

**The mechanism is narrower than the issue's own diagnosis.** The banner's numbers come
from the distiller, correctly and by design (#519). What did not was the test deciding
whether to print it, which read `final_out`, and by then `final_out` is the **ledger's**
output. So the ledger's saving bought a marker describing the distiller's cut, and here
that cut was one byte, almost certainly a trailing newline.

**Three commits, because the first two were wrong in ways worth keeping in the history.**

1. Weigh the marker against `distilled_len`. Correct, and on its own it turned a 3,257 byte
   reply folded to 325 into a passthrough: the `else` arm throws the whole reply away, which
   was right when the distiller was the only stage to touch it and is not right now the
   ledger runs first.
2. Keep the fold when the marker cannot pay for itself, and pass through only when the
   ledger left the reply alone. Then `never_hands_back_more_bytes_than_the_command_produced`
   went red at 104 bytes back for 99 raw. That test drives `process_payload` with no store,
   so the ledger never runs and the new arm was not involved at all: the leak was
   `[Partial signal]`, appended after the distiller's numbers are taken, whose cost had
   silently left the affordability test.
3. Require both tests. The marker must be paid for by the cut it describes **and** the reply
   must still be smaller than the command's own bytes. Those are different questions and
   answering only one of them is what each earlier commit did.

After all three the same command delivers 252 bytes for 3,257, and the markers sum to
exactly 40 of 40.

Also `1 bytes` and `1 lines`. Singulars.

**The issue's second claim is not fixed and the issue stays open for it.**
`[Partial signal]` over a complete answer did not reproduce in three attempts on 0.7.9 with
isolated databases: the post-hook on the reported command, the same through `omni exec`, and
a constructed 130 line log payload aimed at the partial route. It needs `route == Soft`
together with a partial rather than whole-output fold, and every fixture I built folded
whole or never reached Soft. Not a verdict that it is unreal; the reporter saw it. The
detail is in the issue.

Verification: `make ci` green, `smoke_test.sh` 70/70, and the reported command re-run
against the release binary.

Refs #775


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adjusts post-tool rewind affordability so ledger savings cannot fund a marker describing a separate distiller cut, preserves useful ledger folds when that marker is rejected, and fixes singular marker units.

- Measures marker affordability against both the distiller output and the final delivered output.
- Tracks whether the ledger folded the reply and retains that fold when it remains smaller than the raw command output.
- Adds regression coverage for repeated `git log` output and documents the fix in the changelog.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until retained ledger folds preserve a retrieval path for any bytes removed earlier by the distiller.

The new fallback keeps a reduced host-visible result while clearing the only handle that archives the raw pre-distillation output, making the distiller's omitted bytes unreachable from the response.

**Files Needing Attention:** src/hooks/post_tool.rs
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/hooks/post_tool.rs | Corrects cross-stage marker accounting and adds regression coverage, but the new fold-preservation branch can strand bytes removed by the distiller without a visible retrieval handle. |
| changelog.d/775.fixed.md | Documents the false double-accounting fix, fold preservation, and singular marker wording. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Raw[Raw command output] --> Distiller[Distiller]
  Distiller --> Distilled[Distilled output]
  Distilled --> Ledger[Session ledger fold]
  Ledger --> Final[Final folded output]
  Raw --> Archive[Raw-output rewind archive]
  Archive --> Marker{Marker affordable?}
  Distilled --> Marker
  Final --> Marker
  Marker -->|Yes| DeliverMarker[Deliver fold plus rewind marker]
  Marker -->|No, ledger folded| DeliverFold[Deliver ledger fold]
  Marker -->|No fold| Passthrough[Keep raw host output]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20fajarhide%2Fomni%20PR%20%23777%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=fajarhide%2Fomni&pr=777&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fhooks%2Fpost_tool.rs%3A1047-1063%0A**Distiller%20cuts%20lose%20recovery**%0A%0AWhen%20the%20distiller%20removes%20less%20than%20its%20marker%20costs%20and%20the%20ledger%20also%20folds%20the%20reply%2C%20this%20branch%20keeps%20the%20folded%20output%20but%20clears%20the%20only%20handle%20covering%20the%20raw%20pre-distillation%20content.%20The%20ledger%20handles%20recover%20only%20runs%20from%20the%20already-distilled%20text%2C%20so%20the%20agent%20cannot%20recover%20bytes%20removed%20by%20the%20distiller.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni&pr=777&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fajarhide%2Fomni%22%20on%20the%20existing%20branch%20%22fix%2F775-banner-pays-for-its-own-cut%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F775-banner-pays-for-its-own-cut%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fhooks%2Fpost_tool.rs%3A1047-1063%0A**Distiller%20cuts%20lose%20recovery**%0A%0AWhen%20the%20distiller%20removes%20less%20than%20its%20marker%20costs%20and%20the%20ledger%20also%20folds%20the%20reply%2C%20this%20branch%20keeps%20the%20folded%20output%20but%20clears%20the%20only%20handle%20covering%20the%20raw%20pre-distillation%20content.%20The%20ledger%20handles%20recover%20only%20runs%20from%20the%20already-distilled%20text%2C%20so%20the%20agent%20cannot%20recover%20bytes%20removed%20by%20the%20distiller.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni&pr=777&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Asrc%2Fhooks%2Fpost_tool.rs%3A1047-1063%0A**Distiller%20cuts%20lose%20recovery**%0A%0AWhen%20the%20distiller%20removes%20less%20than%20its%20marker%20costs%20and%20the%20ledger%20also%20folds%20the%20reply%2C%20this%20branch%20keeps%20the%20folded%20output%20but%20clears%20the%20only%20handle%20covering%20the%20raw%20pre-distillation%20content.%20The%20ledger%20handles%20recover%20only%20runs%20from%20the%20already-distilled%20text%2C%20so%20the%20agent%20cannot%20recover%20bytes%20removed%20by%20the%20distiller.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=777&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fajarhide%2Fomni%22%20on%20the%20existing%20branch%20%22fix%2F775-banner-pays-for-its-own-cut%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F775-banner-pays-for-its-own-cut%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fhooks%2Fpost_tool.rs%3A1047-1063%0A**Distiller%20cuts%20lose%20recovery**%0A%0AWhen%20the%20distiller%20removes%20less%20than%20its%20marker%20costs%20and%20the%20ledger%20also%20folds%20the%20reply%2C%20this%20branch%20keeps%20the%20folded%20output%20but%20clears%20the%20only%20handle%20covering%20the%20raw%20pre-distillation%20content.%20The%20ledger%20handles%20recover%20only%20runs%20from%20the%20already-distilled%20text%2C%20so%20the%20agent%20cannot%20recover%20bytes%20removed%20by%20the%20distiller.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fajarhide%2Fomni"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/hooks/post_tool.rs:1047-1063
**Distiller cuts lose recovery**

When the distiller removes less than its marker costs and the ledger also folds the reply, this branch keeps the folded output but clears the only handle covering the raw pre-distillation content. The ledger handles recover only runs from the already-distilled text, so the agent cannot recover bytes removed by the distiller.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(hooks): the marker has to pass both ..."](https://github.com/fajarhide/omni/commit/7419ecdea7392a94ced0a1baa6b0e6d934a35b72) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60428749)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Tool hook integration](https://app.greptile.com/weekndlabs/-/custom-context/knowledge-base/fajarhide/omni/-/docs/tool-hook-integration.md)

<!-- /greptile_comment -->