### PR TITLE
fix(hooks): a fold does not make the signal partial

### DIFF
--- a/changelog.d/775b.fixed.md
+++ b/changelog.d/775b.fixed.md
@@ -1,0 +1,8 @@
+- **A folded reply was labelled a partial signal (#775)**: `[Partial signal]` says the
+  pipeline recognised some of the output and not all of it, which is a claim about the
+  distiller, and it was being read off a route computed after the ledger folds. So a
+  payload the distiller never touched could reach that route on the strength of a fold and
+  carry the banner over an answer nothing was lost from: 16 of 40 lines folded with a
+  handle, 24 verbatim, and the reply calling itself partial. The banner now reads the
+  distiller's own ratio. The pipe door was checked and never had this: its ledger runs
+  after the banner, so its ratio was already the distiller's.

--- a/src/hooks/post_tool.rs
+++ b/src/hooks/post_tool.rs
@@ -945,7 +945,26 @@ pub fn process_payload(
     // partial is a false claim about a complete answer (#335). `Soft` is decided
     // on the byte ratio alone, and folding a repeated prefix shrinks bytes
     // without losing a line.
-    if route == Route::Soft && distilled_lines <= content.lines().count() {
+    //
+    // Weighed on the distiller's own ratio, not the delivered one (#775). `route`
+    // above is computed from `final_out`, which the ledger has already folded, so
+    // a payload the distiller never touched can land in `Soft` on the strength of
+    // a fold and collect a banner announcing partial recognition of an output
+    // nothing was lost from. Reproduced with 16 of 40 lines already seen: the
+    // reply carried `16 lines already shown` with a handle, 24 lines verbatim,
+    // and `[Partial signal]` under an answer that was complete.
+    //
+    // The banner is the distiller's claim about its own reading, so it is the
+    // distiller's ratio that decides whether it is made.
+    let distiller_ratio = 1.0 - (distilled_len as f32 / content.len().max(1) as f32);
+    let distiller_route = if distiller_ratio >= keep_threshold {
+        Route::Keep
+    } else if distiller_ratio >= soft_threshold {
+        Route::Soft
+    } else {
+        Route::Passthrough
+    };
+    if distiller_route == Route::Soft && distilled_lines <= content.lines().count() {
         final_out.push_str("\n[Partial signal]\n");
     }
 
@@ -1605,6 +1624,58 @@ mod tests {
         );
 
         assert_eq!(retrieval, None, "a retrieval must reach the agent verbatim");
+    }
+
+    /// #775, second half. `[Partial signal]` says the pipeline recognised some of
+    /// the output and not all of it, which is a claim about the distiller. The
+    /// route it was read from is computed after the ledger folds, so a payload
+    /// the distiller never touched could land in `Soft` on the strength of a fold
+    /// and collect the banner over an answer nothing was lost from.
+    ///
+    /// Sixteen of forty lines seen earlier: the fold is announced with a handle,
+    /// the other twenty four are verbatim, and the reply used to end with a
+    /// banner calling that partial.
+    #[test]
+    fn a_fold_does_not_make_the_signal_partial() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Arc::new(Store::open_path(&dir.path().join("omni.db")).expect("store"));
+        let lines: Vec<String> = (0..40)
+            .map(|i| {
+                format!(
+                    "2026-09-04T10:{i:02}:00Z INFO  worker {i} finished batch {} in {}ms",
+                    i * 7,
+                    11 + i
+                )
+            })
+            .collect();
+        let seen = format!("{}\n", lines[..16].join("\n"));
+        let whole = format!("{}\n", lines.join("\n"));
+        let payload = |cmd: &str, body: &str| {
+            serde_json::json!({
+                "session_id": "s-775b",
+                "tool_name": "Bash",
+                "tool_input": {"command": cmd},
+                "tool_response": {"stdout": body, "stderr": ""}
+            })
+            .to_string()
+        };
+
+        let _ = process_payload(
+            &payload("tail -16 app.log", &seen),
+            Some(store.clone()),
+            None,
+        );
+        let out = process_payload(&payload("cat app.log", &whole), Some(store.clone()), None)
+            .expect("a partial repeat is foldable");
+
+        assert!(
+            out.contains("already shown"),
+            "the fixture has to fold part of the reply or it proves nothing: {out}"
+        );
+        assert!(
+            !out.contains("[Partial signal]"),
+            "a complete answer was labelled partial because the ledger folded it: {out}"
+        );
     }
 
     /// #775. Two accountings of one payload landed in one blob and their sum


### PR DESCRIPTION
The second half of #775. `[Partial signal]` says the pipeline recognised some of the output
and not all of it, which is a claim about the distiller, and it was being read off a route
computed from `final_out` after the ledger has folded it.

So a payload the distiller never touched could reach `Soft` on the strength of a fold and
collect a banner over an answer nothing was lost from.

**Reproduced, after three earlier attempts failed.** The failures were the useful part:
both my first fixtures folded the *whole* payload, which lands in `Keep`, so the banner
never fired. The condition needs a **partial** fold. Sixteen of forty lines seen earlier:

```
[OMNI: 16 lines already shown from tail -16 app.log, omni retrieve 5b3d90904b481957]
2026-09-04T10:16:00Z INFO  worker 16 finished batch 112 in 27ms
... 23 more lines, verbatim ...

[Partial signal]
```

The fold is announced and retrievable, the other 24 lines are present, and the reply calls
itself partial.

`route` is left exactly as it is: it describes the delivered reply, which is what the
accounting that reads it wants. Only the banner moves to the ratio it is a claim about.

**The other door was checked rather than assumed.** `hooks::pipe` runs its ledger at
`pipe.rs:364`, after the banner at `:328`, so its ratio is already the distiller's and it
never had this. That is written into the changelog so the next person does not go looking.

Verification: `make ci` green, `smoke_test.sh` 70/70, and the reproduction re-run against
the release binary, where the banner is gone and the fold survives. Break-tested: putting
the delivered route back fails the new test with the full reply printed.

Closes #775


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes the post-tool partial-signal banner depend on the distiller’s pre-ledger compression ratio rather than the delivered reply’s post-fold ratio.
- Separates banner classification from ledger-fold routing.
- Adds a regression test for a partially folded 40-line response.
- Documents the corrected behavior and why the pipe path is unaffected.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable correctness or security issues identified.

The banner now reflects the distiller’s own reduction rather than a later ledger fold, while the existing delivered-route, guardrail, recovery, and passthrough behavior remains intact.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/hooks/post_tool.rs | Correctly derives the partial-signal decision from the distiller output while preserving delivered-route accounting and adds focused regression coverage. |
| changelog.d/775b.fixed.md | Accurately documents the false partial-signal condition, the fix, and the unaffected pipe path. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): record the partial-sign..."](https://github.com/fajarhide/omni/commit/6c0eec640431babd9044d2b5354e829d99ed715e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60455108)</sub>

<!-- /greptile_comment -->