### PR TITLE
fix(ledger): a fold names the command that printed the lines

### DIFF
--- a/changelog.d/779.fixed.md
+++ b/changelog.d/779.fixed.md
@@ -1,0 +1,11 @@
+- **A fold names the command that printed the lines, not the one in front of it (#779)**: the
+  `from` clause was built from the first line of the recorded source, and a recorded source
+  is the whole command string. 28.7% of sourced lines here were recorded against a
+  multi-line command and 86.6% of those open with `cd <path>`, so a quarter of every `from`
+  clause credited the bytes to a chdir, which writes no stdout at all; a `for` header
+  claimed 18 lines a `cat` inside the loop had printed. One subagent read the mismatch as
+  the `Read` tool returning another file's content and re-read the whole tree before it
+  would trust it. The clause now resolves the source through the same predicate that
+  decides which segment a distiller may claim, so a single producer behind a chdir is named
+  correctly and a chain with two producers carries no clause: stdout is one stream and
+  nothing in it says which of them wrote a given line.

--- a/src/ledger/mod.rs
+++ b/src/ledger/mod.rs
@@ -573,7 +573,9 @@ impl<'a> Ledger<'a> {
                 // stdout is one stream and nothing marks which of them wrote a
                 // given line, so no clause is printed rather than picking one.
                 match producer::sole_output_command(&seen.source) {
-                    Some(cmd) => SourceOfSighting::Another(cmd.to_string()),
+                    Some(cmd) => {
+                        SourceOfSighting::Another(producer::without_clause_prefix(cmd).to_string())
+                    }
                     None => SourceOfSighting::Unrecorded,
                 }
             }
@@ -2346,6 +2348,22 @@ mod tests {
         assert!(
             !unnamed.contains(" from "),
             "a chain with two producers named one of them: {unnamed}"
+        );
+
+        // One producer, inside a loop. `sole_output_command` keeps the keyword
+        // that opened the clause because routing has read it that way since the
+        // loop rule shipped, and `from do cat "$f"` names a fragment no shell
+        // would run.
+        Ledger::new(&store, "s3")
+            .from("for f in charlie.tf; do cat -n \"$f\"; done")
+            .project(&file("charlie"));
+        let in_a_loop = Ledger::new(&store, "s3")
+            .from("cat delta.tf")
+            .project(&file("delta"))
+            .expect("the shared block repeats and is worth a marker");
+        assert!(
+            in_a_loop.contains("from cat -n \"$f\""),
+            "the clause kept the keyword that opened the loop body: {in_a_loop}"
         );
     }
 

--- a/src/ledger/mod.rs
+++ b/src/ledger/mod.rs
@@ -43,7 +43,7 @@ use std::collections::{HashMap, HashSet};
 use crate::guard::limits::{
     MIN_LEDGER_INPUT, MIN_LEDGER_RUN_GAIN, MIN_WHOLE_OUTPUT_FOLD, PROJECT_FLOOR_MULT,
 };
-use crate::pipeline::registry;
+use crate::pipeline::{producer, registry};
 use crate::store::sqlite::Store;
 
 /// How much of a source name a marker will carry.
@@ -561,7 +561,21 @@ impl<'a> Ledger<'a> {
             } else if seen.source == self.source {
                 SourceOfSighting::ThisCommandAgain
             } else {
-                SourceOfSighting::Another(seen.source.clone())
+                // A recorded source is the whole command string, and naming a
+                // prefix of it names a different command. 28.7% of sourced lines
+                // here were recorded against a multi-line command and 86.6% of
+                // those begin with `cd <path>`, so a quarter of every `from`
+                // clause was crediting the bytes to a chdir, which writes no
+                // stdout at all (#779). `sole_output_command` is the same
+                // predicate that decides which segment a distiller may claim, so
+                // the marker and the routing agree by construction, and its
+                // `None` is the honest answer for a chain with two producers:
+                // stdout is one stream and nothing marks which of them wrote a
+                // given line, so no clause is printed rather than picking one.
+                match producer::sole_output_command(&seen.source) {
+                    Some(cmd) => SourceOfSighting::Another(cmd.to_string()),
+                    None => SourceOfSighting::Unrecorded,
+                }
             }
         };
         let origin_of = |h: &String| {
@@ -1232,8 +1246,10 @@ mod tests {
             .project(&format!("{}{metrics}", fresh_block("phase")))
             .expect("the same block under another command is projectable");
 
+        // `from for p in` until #779, which is the loop header and printed
+        // nothing. The clause names the stage that wrote the bytes instead.
         assert!(
-            elsewhere.contains("already shown") && elsewhere.contains("from for p in"),
+            elsewhere.contains("already shown") && elsewhere.contains("from grep ^is_read_only"),
             "a different command still has to name the source it is standing in \
              for (#622): {elsewhere}"
         );
@@ -2271,6 +2287,65 @@ mod tests {
         assert!(
             !same.contains(" from "),
             "re-reading one file paid for a source clause it did not need: {same}"
+        );
+    }
+
+    /// #779. The clause named a command that cannot have printed the lines: a
+    /// bare `cd`, and a `for` loop's header. Both are the first segment of a
+    /// multi-line command whose *later* segment did the printing, and the label
+    /// was built from the first line of the raw source. A reader who chased the
+    /// name found nothing, and one subagent read the mismatch as `Read` handing
+    /// back another file's content and re-read the whole tree to be sure.
+    ///
+    /// Both arms are asserted because they are different answers. One producer
+    /// behind a chdir is nameable and gets named; two producers are not, and
+    /// stdout carries nothing saying which of them wrote a given line, so the
+    /// clause goes away rather than picking one.
+    #[test]
+    fn a_fold_names_the_command_that_printed_the_lines() {
+        let (store, _d) = temp_store();
+        let shared: String = (1..=20)
+            .map(|i| format!("    key_{i:02} = \"value_{i:02}\"\n"))
+            .collect();
+        let file = |name: &str| {
+            let uniq: String = (1..=30)
+                .map(|i| format!("  uniq_{name}_{i:02} = {i}\n"))
+                .collect();
+            format!("name = \"{name}\"\n{shared}{uniq}")
+        };
+
+        Ledger::new(&store, "s1")
+            .from("cd /Users/someone/project/repo\ncat charlie.tf")
+            .project(&file("charlie"));
+        let named = Ledger::new(&store, "s1")
+            .from("cat delta.tf")
+            .project(&file("delta"))
+            .expect("the shared block repeats and is worth a marker");
+        assert!(
+            named.contains("from cat charlie.tf"),
+            "the fold did not name the segment that printed the lines: {named}"
+        );
+        assert!(
+            !named.contains("cd /Users"),
+            "the fold credited the bytes to a chdir, which prints nothing: {named}"
+        );
+
+        // Two producers, so there is nothing honest to name. A fresh scope, or
+        // the rows above answer for these lines first.
+        Ledger::new(&store, "s2")
+            .from("for f in charlie.tf delta.tf; do echo \"===== $f\"; cat -n \"$f\"; done")
+            .project(&file("charlie"));
+        let unnamed = Ledger::new(&store, "s2")
+            .from("cat delta.tf")
+            .project(&file("delta"))
+            .expect("the shared block repeats and is worth a marker");
+        assert!(
+            unnamed.contains("already shown"),
+            "dropping the clause dropped the fold with it: {unnamed}"
+        );
+        assert!(
+            !unnamed.contains(" from "),
+            "a chain with two producers named one of them: {unnamed}"
         );
     }
 

--- a/src/pipeline/producer.rs
+++ b/src/pipeline/producer.rs
@@ -472,6 +472,29 @@ pub(crate) fn program_name(command: &str) -> &str {
         .unwrap_or(first)
 }
 
+/// The command inside a clause, for naming it to a reader.
+///
+/// `sole_output_command` keeps the keyword that opened the clause, because it
+/// answers a routing question and `program_name` has read `do echo noise` as
+/// `do` since the loop rule shipped. Changing that re-routes every shell loop,
+/// which is a measurement rather than a review fix.
+///
+/// A marker asks a different question, and `from do cat $f` names a fragment no
+/// shell would run (#779 review). The keyword list has one copy, so this lives
+/// next to it rather than in the caller.
+pub fn without_clause_prefix(command: &str) -> &str {
+    let mut rest = command.trim_start();
+    while let Some((word, tail)) = split_word(rest) {
+        if !CLAUSE_PREFIXES.contains(&word) {
+            return rest;
+        }
+        rest = tail.trim_start();
+    }
+    // Every word was a keyword, so there is no command inside the clause and
+    // the whole fragment is as good a name as any.
+    command
+}
+
 /// `i=0` and `f=path/to.yaml` set a variable and print nothing. Distinguished
 /// from a command by the `=` before any `/`, so `./bin/x=y` is still a command.
 pub(crate) fn is_assignment(word: &str) -> bool {

--- a/src/pipeline/registry.rs
+++ b/src/pipeline/registry.rs
@@ -1338,6 +1338,19 @@ mod tests {
         );
     }
 
+    /// #779 review. Routing reads `do cat $f` as `do` and has since the loop
+    /// rule shipped, so the keyword stays on the routing answer. A marker names
+    /// the command to a reader, and a reader cannot run `do cat $f`.
+    #[test]
+    fn names_the_command_inside_a_clause_without_its_keyword() {
+        use crate::pipeline::producer::without_clause_prefix;
+        assert_eq!(without_clause_prefix("do cat $f"), "cat $f");
+        assert_eq!(without_clause_prefix("then echo hi"), "echo hi");
+        assert_eq!(without_clause_prefix("cat $f"), "cat $f");
+        // Nothing but keywords, so there is no command to name.
+        assert_eq!(without_clause_prefix("do then"), "do then");
+    }
+
     #[test]
     fn treats_a_variable_assignment_as_printing_nothing() {
         assert_eq!(


### PR DESCRIPTION
A fold's `from` clause was built from the first line of the recorded source, and a
recorded source is the whole command string. So the clause named a segment, and the
first segment of a multi-line command is usually not the one that printed anything.

Measured on the local ledger, all 102,966 rows that carry a source:

| shape | rows | share |
| --- | --- | --- |
| multi-line source | 29,593 | 28.7% |
| of those, a bare `cd <path>` first line | 25,628 | 86.6% |

A chdir writes no stdout, so a quarter of every clause rendered was attributing bytes
to a command that could not have emitted them. The reported `for f in ...` case is the
same shape: the header names files, the `cat` inside the loop printed the lines.

The clause now resolves the source through `sole_output_command`, which already decides
which segment a distiller may claim, so the marker and the routing agree by
construction. One producer behind a chdir gets named correctly. Two producers get no
clause at all, because stdout is one stream and nothing in it says which of them wrote
a given line.

`a_command_run_again_is_told_its_lines_are_unchanged` asserted `from for p in` and was
asserting the defect. It now asserts the stage that wrote the bytes.

Verified: `make ci` green (909 lib tests, 70 CLI). The new test was proved able to fail
by returning the raw source instead of the resolved one:

```
panicked at src/ledger/mod.rs:2324:
the fold did not name the segment that printed the lines: name = "delta"
```

Closes #779




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR corrects ledger fold attribution so markers identify the sole command that produced repeated output rather than an earlier silent command or shell-clause keyword.
- Resolves recorded sources through the existing sole-producer analysis.
- Omits source attribution when multiple commands produced the captured stream.
- Removes leading loop or conditional keywords from reader-facing command names.
- Adds regression coverage for chdir-prefixed commands, multi-producer loops, and single-producer loop bodies.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the previously reported malformed loop-source attribution is corrected by stripping the clause prefix before rendering the marker.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/ledger/mod.rs | Uses sole-producer resolution for fold source markers and adds end-to-end attribution tests; the previously malformed loop marker is corrected. |
| src/pipeline/producer.rs | Adds focused normalization that removes shell clause prefixes from reader-facing producer fragments. |
| src/pipeline/registry.rs | Adds unit coverage for clause-prefix removal without changing registry behavior. |
| changelog.d/779.fixed.md | Documents the corrected fold attribution behavior and treatment of multi-producer streams. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ledger): a clause keyword is not par..."](https://github.com/fajarhide/omni/commit/b5a46fe7515257169fa6b12fb6af76ffd1e3d3ab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61194556)</sub>

<!-- /greptile_comment -->