### PR TITLE
fix(redact): a value that names a credential is not destroyed like one

### DIFF
--- a/src/distillers/system_ops.rs
+++ b/src/distillers/system_ops.rs
@@ -685,6 +685,56 @@ fn looks_like_shell_expansion(value: &str) -> bool {
     rest.starts_with(['(', '{']) || rest.starts_with(|c: char| c.is_ascii_alphabetic() || c == '_')
 }
 
+/// Source that names a value instead of holding one, so redacting it destroys
+/// the line and hides nothing.
+///
+/// `looks_like_shell_expansion` above already carries this idea for `$VAR`, and
+/// says why it applies to every pattern where the identifier rule does not: an
+/// expansion carries no credential material whatever the key is called. Code has
+/// two more shapes with that property, a call and a dotted reference, plus the
+/// null literals. This matters because `token`, `secret`, `password` and
+/// `api_key` are ordinary local names in auth code, which is the code most
+/// likely to be read carefully, and `token = token.strip()` was delivered as
+/// `token = [REDACTED]` (#783).
+///
+/// Three deliberate narrowings, because the direction of doubt in this file has
+/// not changed and a false negative here prints a secret:
+///
+/// - **Unquoted only.** A credential is written as a literal, so anything
+///   opening with a quote keeps the old reading.
+/// - **No quote anywhere in the value**, which is why `os.environ["TOK"]` from
+///   #783's repro stays redacted. Allowing them would wave through
+///   `token = decrypt("ghp_real")`, and telling a subscript key apart from a
+///   hardcoded argument needs a parser rather than a predicate.
+/// - **A bare identifier is not here.** `hunter2` has exactly that shape, and
+///   #559 already settled that `pass=hello` stays redacted. A call or a dot is
+///   required, so `token = other_var` is still cut.
+fn references_instead_of_holding(value: &str) -> bool {
+    let v = value.trim().trim_end_matches([',', ';']).trim();
+    if v.is_empty() {
+        return false;
+    }
+    // A keyword is the whole value or it is not one, so this runs before the
+    // shape rules rather than as another charset exception.
+    const NULLISH: &[&str] = &["none", "null", "nil", "undefined", "true", "false"];
+    if NULLISH.iter().any(|k| v.eq_ignore_ascii_case(k)) {
+        return true;
+    }
+    if !v.starts_with(|c: char| c.is_ascii_alphabetic() || c == '_') {
+        return false;
+    }
+    // Whitespace would let a second token hide behind the first, so the whole
+    // value has to be one reference expression.
+    if v.chars().any(|c| c.is_whitespace() || matches!(c, '"' | '\'')) {
+        return false;
+    }
+    if !v.contains(['(', '.']) {
+        return false;
+    }
+    v.chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '.' | '(' | ')' | '[' | ']'))
+}
+
 /// One line's redaction decision and its replacement, so the two callers cannot
 /// disagree about either.
 ///
@@ -707,6 +757,7 @@ fn redact_assignment(key: &str, value: &str) -> Option<String> {
     if !is_sensitive_key(key)
         || (literal.trim().is_empty() && is_only_punctuation(tail))
         || looks_like_shell_expansion(value)
+        || references_instead_of_holding(value)
     {
         return None;
     }
@@ -1256,6 +1307,56 @@ mod tests {
                 redact_assignment(key, value),
                 Some(expected.to_string()),
                 "{key}={value} kept a literal the reader should not see"
+            );
+        }
+    }
+
+    /// #783. `redact_sensitive_assignments` checked the key and never the value,
+    /// so reading source code with a local named `token` delivered
+    /// `token = token.strip()` as `token = [REDACTED]`. An agent then reasons
+    /// about the function from a line that was never there, and can write the
+    /// corrupted line back out in an edit.
+    ///
+    /// The second table is the point, and it is larger than the first on
+    /// purpose: a rule that only proves the code shapes survive is
+    /// indistinguishable from deleting the `TOKEN` pattern. Two rows in it are
+    /// cases #783 asked for and this fix deliberately does not give, so a later
+    /// reader can see they were decided rather than missed.
+    #[test]
+    fn a_reference_names_a_credential_and_a_literal_holds_one() {
+        for (key, value) in [
+            ("token", " token.strip()"),
+            ("token", " get_token()"),
+            ("token", " None"),
+            ("token", " null"),
+            ("api_key", " cfg.api_key"),
+            ("PASSWORD", " os.getenv()"),
+            ("secret", " self.secret"),
+        ] {
+            assert_eq!(
+                redact_assignment(key, value),
+                None,
+                "{key}={value} names a value rather than holding one, and was destroyed"
+            );
+        }
+
+        for (key, value) in [
+            // A bare identifier is the shape `hunter2` has, so #559's call
+            // stands and this stays cut even though #783 listed it.
+            ("token", " other_var"),
+            // A quote anywhere means a literal could be hiding in an argument,
+            // so `os.environ["TOK"]` from the repro is cut with it.
+            ("token", " os.environ[\"TOK\"]"),
+            ("token", " decrypt(\"ghp_realLookingValue1234\")"),
+            // The credential the repro was actually there to protect.
+            ("token", " \"ghp_realLookingValueHere1234\""),
+            // Whitespace would let a second token hide behind a reference.
+            ("token", " cfg.token \"sk-ant-real\""),
+            ("PASSWORD", " hunter2"),
+        ] {
+            assert!(
+                redact_assignment(key, value).is_some(),
+                "{key}={value} could carry a credential and was delivered"
             );
         }
     }

--- a/src/distillers/system_ops.rs
+++ b/src/distillers/system_ops.rs
@@ -1366,7 +1366,10 @@ mod tests {
             ("secret", " self.secret"),
             // The shape that makes the rule non-negotiable: a JWT is
             // alphanumeric runs joined by dots.
-            ("token", " eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjMifQ.dBjftJeZ4CVP"),
+            (
+                "token",
+                " eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjMifQ.dBjftJeZ4CVP",
+            ),
         ] {
             assert!(
                 redact_assignment(key, value).is_some(),

--- a/src/distillers/system_ops.rs
+++ b/src/distillers/system_ops.rs
@@ -723,14 +723,16 @@ fn references_instead_of_holding(value: &str) -> bool {
     if !v.starts_with(|c: char| c.is_ascii_alphabetic() || c == '_') {
         return false;
     }
-    // Whitespace would let a second token hide behind the first, so the whole
-    // value has to be one reference expression.
-    if v.chars().any(|c| c.is_whitespace() || matches!(c, '"' | '\'')) {
-        return false;
-    }
     if !v.contains(['(', '.']) {
         return false;
     }
+    // This charset is the whole of the second and third narrowings above, so do
+    // not add a quote or a space to it. Excluding the quote is what keeps
+    // `decrypt("ghp_real")` redacted, and excluding whitespace is what stops a
+    // second token hiding behind a reference in `cfg.token "sk-ant-real"`. An
+    // earlier version repeated both as their own guard clause; the break test
+    // stayed green with that clause deleted, which is how it was found to be
+    // dead rather than defensive.
     v.chars()
         .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '.' | '(' | ')' | '[' | ']'))
 }

--- a/src/distillers/system_ops.rs
+++ b/src/distillers/system_ops.rs
@@ -690,25 +690,29 @@ fn looks_like_shell_expansion(value: &str) -> bool {
 ///
 /// `looks_like_shell_expansion` above already carries this idea for `$VAR`, and
 /// says why it applies to every pattern where the identifier rule does not: an
-/// expansion carries no credential material whatever the key is called. Code has
-/// two more shapes with that property, a call and a dotted reference, plus the
-/// null literals. This matters because `token`, `secret`, `password` and
-/// `api_key` are ordinary local names in auth code, which is the code most
-/// likely to be read carefully, and `token = token.strip()` was delivered as
-/// `token = [REDACTED]` (#783).
+/// expansion carries no credential material whatever the key is called. A call
+/// has that property, and so do the null literals. This matters because `token`,
+/// `secret`, `password` and `api_key` are ordinary local names in auth code,
+/// which is the code most likely to be read carefully, and
+/// `token = token.strip()` was delivered as `token = [REDACTED]` (#783).
 ///
-/// Three deliberate narrowings, because the direction of doubt in this file has
-/// not changed and a false negative here prints a secret:
+/// **A call, not a reference.** The first version of this also accepted a dotted
+/// reference, so `api_key = cfg.api_key` survived. Review killed it: a dotted
+/// reference and a dotted credential are the same string. `TOKEN=v1.secret.form`
+/// was the case raised, and a JWT is worse, because `eyJhbGci….eyJzdWIi….sig` is
+/// alphanumeric runs joined by dots and nothing lexical separates it from
+/// `cfg.api_key`. Requiring a call is what makes that impossible: a credential
+/// never ends in `)`. Attribute references went back to being redacted with it,
+/// which is the trade this file's direction of doubt already prices.
 ///
-/// - **Unquoted only.** A credential is written as a literal, so anything
-///   opening with a quote keeps the old reading.
-/// - **No quote anywhere in the value**, which is why `os.environ["TOK"]` from
-///   #783's repro stays redacted. Allowing them would wave through
-///   `token = decrypt("ghp_real")`, and telling a subscript key apart from a
-///   hardcoded argument needs a parser rather than a predicate.
+/// The other two narrowings, for the same reason:
+///
+/// - **Unquoted only**, and **no quote anywhere in the value**, which is why
+///   `os.environ["TOK"]` from #783's repro stays redacted. Allowing them would
+///   wave through `token = decrypt("ghp_real")`, and telling a subscript key
+///   apart from a hardcoded argument needs a parser rather than a predicate.
 /// - **A bare identifier is not here.** `hunter2` has exactly that shape, and
-///   #559 already settled that `pass=hello` stays redacted. A call or a dot is
-///   required, so `token = other_var` is still cut.
+///   #559 already settled that `pass=hello` stays redacted.
 fn references_instead_of_holding(value: &str) -> bool {
     let v = value.trim().trim_end_matches([',', ';']).trim();
     if v.is_empty() {
@@ -723,16 +727,17 @@ fn references_instead_of_holding(value: &str) -> bool {
     if !v.starts_with(|c: char| c.is_ascii_alphabetic() || c == '_') {
         return false;
     }
-    if !v.contains(['(', '.']) {
+    // The call is the whole guard against a dotted credential, so do not relax
+    // this to "contains a dot". A secret can hold dots; it does not end in `)`.
+    if !(v.ends_with(')') && v.contains('(')) {
         return false;
     }
-    // This charset is the whole of the second and third narrowings above, so do
-    // not add a quote or a space to it. Excluding the quote is what keeps
-    // `decrypt("ghp_real")` redacted, and excluding whitespace is what stops a
-    // second token hiding behind a reference in `cfg.token "sk-ant-real"`. An
-    // earlier version repeated both as their own guard clause; the break test
-    // stayed green with that clause deleted, which is how it was found to be
-    // dead rather than defensive.
+    // This charset carries the quote and whitespace narrowings above, so do not
+    // add either to it. Excluding the quote is what keeps `decrypt("ghp_real")`
+    // redacted, and excluding whitespace is what stops a second token hiding
+    // behind a call in `strip() "sk-ant-real"`. An earlier version repeated both
+    // as their own guard clause; the break test stayed green with that clause
+    // deleted, which is how it was found to be dead rather than defensive.
     v.chars()
         .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '.' | '(' | ')' | '[' | ']'))
 }
@@ -1329,11 +1334,10 @@ mod tests {
         for (key, value) in [
             ("token", " token.strip()"),
             ("token", " get_token()"),
+            ("token", " self.session.refresh()"),
             ("token", " None"),
             ("token", " null"),
-            ("api_key", " cfg.api_key"),
             ("PASSWORD", " os.getenv()"),
-            ("secret", " self.secret"),
         ] {
             assert_eq!(
                 redact_assignment(key, value),
@@ -1352,9 +1356,17 @@ mod tests {
             ("token", " decrypt(\"ghp_realLookingValue1234\")"),
             // The credential the repro was actually there to protect.
             ("token", " \"ghp_realLookingValueHere1234\""),
-            // Whitespace would let a second token hide behind a reference.
-            ("token", " cfg.token \"sk-ant-real\""),
+            // Whitespace would let a second token hide behind a call.
+            ("token", " token.strip() \"sk-ant-real\""),
             ("PASSWORD", " hunter2"),
+            // Review's case (PR #784). A dotted reference and a dotted
+            // credential are the same string, so neither survives.
+            ("TOKEN", " v1.secret.form"),
+            ("api_key", " cfg.api_key"),
+            ("secret", " self.secret"),
+            // The shape that makes the rule non-negotiable: a JWT is
+            // alphanumeric runs joined by dots.
+            ("token", " eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjMifQ.dBjftJeZ4CVP"),
         ] {
             assert!(
                 redact_assignment(key, value).is_some(),


### PR DESCRIPTION
Closes #783

`redact_sensitive_assignments` judged the key and never the value, so a local named
`token`, `secret`, `password` or `api_key` lost its right-hand side even when that side
was plainly code. This lands on source, not command output, and the marker claimed six
sensitive values where the repro had one.

The machinery was already here, gated to the weak `KEY` pattern on purpose: letting
`looks_like_plain_identifier` speak for `TOKEN` would wave through `sk-ant-abc123`. But
`looks_like_shell_expansion` already applies to every pattern, and its own comment says
why: an expansion carries no credential material whatever the key is called. A call and
the null literals have that property too, so they join it at that site instead of
widening the identifier rule. One `redact_assignment` serves both
`redact_sensitive_assignments` and `distill_env_output`, so the guard lands once.

## Before and after

Same payload through `--post-hook`, which is the path the report used. `omni exec` is not:
a seven-line payload never clears the distiller's size gate and both binaries return zero
redactions. `=` is shown as `:` because the author's own installed hook redacts the
terminal otherwise.

```
0.7.9                      this branch
[OMNI: 6 redacted]         [OMNI: 3 redacted]
token : [REDACTED]         token : token.strip()
token : [REDACTED]         token : get_token()
token : [REDACTED]         token : None
token : ""                 token : ""
token : [REDACTED]         token : [REDACTED]
token : [REDACTED]         token : [REDACTED]
token : "[REDACTED]"       token : "[REDACTED]"
```

## Two cases from the repro are deliberately still redacted

Narrower than the issue's suggested fix, and the test names both so a later reader can see
they were decided rather than missed.

- `token = other_var`. `hunter2` has exactly that shape, and #559 already settled that
  `pass=hello` stays redacted.
- `token = os.environ["TOK"]`. Excluding the quote is what keeps
  `decrypt("ghp_real")` redacted; telling a subscript key from a hardcoded argument needs
  a parser, not a predicate.

So six false positives become two, not zero.

## The second commit is a break test finding

Breaking the guard out went red as expected. Breaking it the other way, loosening it,
stayed green with the break proven landed by `diff`. The quote and whitespace clause was
dead: the charset check below it already rejects both. It is deleted, the reasoning moved
onto the charset with a note not to widen it, and the re-run break goes red on
`os.environ["TOK"]`.

`make ci` green, smoke test 70/70.


## Review

Greptile's P1 was valid and is fixed in `fca83d7`. The first version accepted any dotted
value, so `TOKEN=v1.secret.form` read as a reference and was delivered. A JWT is the shape
that settles it: `eyJhbGci….eyJzdWIi….sig` is alphanumeric runs joined by dots, and nothing
lexical separates it from `cfg.api_key`. The shape rule is now a call, since a credential
never ends in `)`.

Attribute references went back to being redacted with it. `cfg.api_key` and `self.secret`
moved to the cut table alongside `v1.secret.form` and a JWT, so the refusal is recorded
rather than left to be rediscovered. The reported repro is unchanged at 3 redactions.

Break test on the new rule: reverting it to "contains a dot" goes red on
`TOKEN=v1.secret.form`, `rc=101`.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR refines sensitive-assignment redaction so code expressions and null literals remain readable while dotted values continue to be redacted.
- Adds a shared classifier for call-shaped expressions and null literals.
- Applies the classifier through the existing shared assignment-redaction path.
- Adds regression coverage for preserved expressions and redacted dotted credential shapes.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/distillers/system_ops.rs | Adds narrowly constrained reference classification and regression tests; the previously reported dotted-credential bypass is fixed. |

</details>

<sub>Reviews (2): Last reviewed commit: ["style: cargo fmt after the review fix"](https://github.com/fajarhide/omni/commit/0503de93d707e25e0a62151db283b043b5d46a8e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61257832)</sub>

**Context used:**

- Knowledge Base — [Repository intelligence](https://app.greptile.com/weekndlabs/-/custom-context/knowledge-base/fajarhide/omni/-/docs/repository-intelligence.md)
- Knowledge Base — [Evidence distillation](https://app.greptile.com/weekndlabs/-/custom-context/knowledge-base/fajarhide/omni/-/docs/evidence-distillation.md)

<!-- /greptile_comment -->