### PR TITLE
docs(changelog): add the missing 783 fragment

### DIFF
--- a/changelog.d/783.fixed.md
+++ b/changelog.d/783.fixed.md
@@ -1,0 +1,13 @@
+- **A value that names a credential is no longer destroyed like one.**
+  `redact_sensitive_assignments` checked the key and never looked at the value, so any
+  line assigning to a variable called `token`, `secret`, `password` or `api_key` arrived
+  with its right-hand side replaced, even when that side was plainly code. Reading a
+  Python file with a loop variable named `token`, the line `token = token.strip()` was
+  delivered as `token = [REDACTED]`, and the marker gave no hint the cut was a false
+  positive: six of seven lines in the reported repro lost their value and only one was a
+  credential. An unquoted call and the null literals now pass through for every pattern,
+  the way a `$VAR` expansion already did, because neither holds credential material
+  whatever the key is named. Everything else stays redacted, including a bare identifier
+  (`hunter2` has that shape), anything carrying a quote (`decrypt("ghp_real")`), and any
+  dotted value, since a JWT is alphanumeric runs joined by dots and nothing separates it
+  from `cfg.api_key`.

--- a/changelog.d/783.fixed.md
+++ b/changelog.d/783.fixed.md
@@ -7,7 +7,8 @@
   positive: six of seven lines in the reported repro lost their value and only one was a
   credential. An unquoted call and the null literals now pass through for every pattern,
   the way a `$VAR` expansion already did, because neither holds credential material
-  whatever the key is named. Everything else stays redacted, including a bare identifier
-  (`hunter2` has that shape), anything carrying a quote (`decrypt("ghp_real")`), and any
-  dotted value, since a JWT is alphanumeric runs joined by dots and nothing separates it
-  from `cfg.api_key`.
+  whatever the key is named. Under those strong patterns nothing else changed, so a bare
+  identifier (`hunter2` has that shape), anything carrying a quote
+  (`decrypt("ghp_real")`) and any dotted value are still cut, the last because a JWT is
+  alphanumeric runs joined by dots and nothing separates it from `cfg.api_key`. The weak
+  `KEY` pattern keeps the wider exceptions it already had from #486 and #530.


### PR DESCRIPTION
PR #784 merged without its `changelog.d/` fragment. The file was written in the same shell call that the git-identity guard blocked, so it never existed and the `git add -A` after it staged nothing. `omni doctor` therefore counts 7 unreleased entries for 8 shipped fixes.

Content only, no code. Text follows #784's own account of what changed and what deliberately still redacts.



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR restores the missing changelog fragment for the redaction fix described in #783.
- Documents that unquoted calls and null literals now pass through strong redaction patterns.
- Clarifies that the weak `KEY` pattern retains its broader existing exceptions.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| changelog.d/783.fixed.md | Adds the missing changelog entry and now explicitly scopes the previously overstated redaction behavior by noting the weak-key exceptions. |

</details>

<sub>Reviews (2): Last reviewed commit: ["docs(changelog): scope the exceptions to..."](https://github.com/fajarhide/omni/commit/f54a322393cc7e390229b09dcfc93af354c8b3aa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61284747)</sub>

<!-- /greptile_comment -->